### PR TITLE
Handle non-200 codes for paged results

### DIFF
--- a/Auth0.Net/Client.cs
+++ b/Auth0.Net/Client.cs
@@ -776,6 +776,12 @@ namespace Auth0
 
         private Page<T> BuildPage<T>(IRestResponse response)
         {
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                throw new InvalidOperationException(
+                    string.Format("A non-success status code of '{0}' was returned, with response '{1}'", response.StatusCode, response.Content));
+            }
+
             var results = JsonConvert.DeserializeObject<List<T>>(response.Content);
             var links = ParseLinks(response.Headers.FirstOrDefault(h => h.Name == "Link"));
 


### PR DESCRIPTION
When a paged result returns a non-200 result the JSON deserialisation fails and gives no useful error information. This pull request rectifies that by throwing an exception with status code and response body.
