### PR TITLE
Support email verification ticket

### DIFF
--- a/Auth0.Net-tests/ConnectionsTests.cs
+++ b/Auth0.Net-tests/ConnectionsTests.cs
@@ -175,6 +175,7 @@ namespace Auth0.Net_tests
                                         () => lowPrivilegeClient.CreateUser("email", "password", "connection", true),
                                         () => lowPrivilegeClient.ExchangeAuthorizationCodePerAccessToken("code", "redirect"),
                                         () => lowPrivilegeClient.GenerateChangePasswordTicket("user", "password", null),
+                                        () => lowPrivilegeClient.GenerateVerificationTicket("user", null),
                                         () => lowPrivilegeClient.GetConnections(0),
                                         () => lowPrivilegeClient.GetDelegationToken("token", "targetClientId", "passthrough"),
                                         () => lowPrivilegeClient.GetEnterpriseConnections(0),

--- a/Auth0.Net/Client.cs
+++ b/Auth0.Net/Client.cs
@@ -974,6 +974,40 @@ namespace Auth0
             }
 
             var result = this.client.Execute<Dictionary<string, string>>(request);
+            if (result.StatusCode != HttpStatusCode.OK)
+            {
+                var detail = GetErrorDetails(result.Content);
+                throw new InvalidOperationException(
+                    string.Format("{0} - {1}", result.StatusDescription, detail));
+            }
+
+            return result.Data["ticket"];
+        }
+
+        /// <summary>
+        /// Generates verification ticket.
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <param name="resultUrl">Post verification url</param>
+        /// <returns></returns>
+        public string GenerateVerificationTicket(string userId, string resultUrl = null)
+        {
+            if (string.IsNullOrEmpty(userId))
+            {
+                throw new ArgumentNullException("userId");
+            }
+
+            var accessToken = this.GetAccessToken();
+
+            var request = new RestRequest("/api/users/" + userId + "/verification_ticket?access_token=" + accessToken, Method.POST);
+            request.JsonSerializer = new RestSharp.Serializers.JsonSerializer();
+            
+            if (!string.IsNullOrEmpty(resultUrl))
+            {
+                request.AddParameter("resultUrl", resultUrl, ParameterType.GetOrPost);
+            }
+
+            var result = this.client.Execute<Dictionary<string, string>>(request);
 
             if (result.StatusCode != HttpStatusCode.OK)
             {

--- a/README.md
+++ b/README.md
@@ -90,6 +90,17 @@ var users = client.GetEnterpriseUsers("jdoe@contoso.com");
 var users = client.GetEnterpriseUsers();
 ~~~
 
+### client.GenerateVerificationTicket(userId, resultUrl = "")
+
+Generate an email verification link which can be added to custom emails an be used for email verification. Clicking this link will set ```email_verified``` to true for the user and optionally redirect to a page in the application.
+
+~~~csharp
+var verificationUrl = client.GenerateVerificationTicket("auth0|54c6322f6936d15310dca942");
+// or
+var verificationUrl = client.GenerateVerificationTicket("auth0|54c6322f6936d15310dca942",
+   "http://myapp.com/activated");
+~~~
+
 ## Authentication
 
 This library is useful to consume the http api of Auth0, in order to authenticate users you can use our platform specific SDKs:


### PR DESCRIPTION
Added GenerateVerificationTicket method to the client to allow generation of the email verification url. This is useful when people send out custom emails in which they want to include an email verification link.