### PR TITLE
Support username/password validation

### DIFF
--- a/Auth0.Net/Auth0.Net.csproj
+++ b/Auth0.Net/Auth0.Net.csproj
@@ -67,6 +67,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UserIdentifier.cs" />
     <Compile Include="UserProfile.cs" />
+    <Compile Include="UserValidationResult.cs" />
     <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Auth0.Net/Client.cs
+++ b/Auth0.Net/Client.cs
@@ -1059,6 +1059,13 @@ namespace Auth0
             request.AddParameter("client_id", clientID);
 
             var result = this.client.Execute(request);
+            if (result.StatusCode != HttpStatusCode.OK && result.StatusCode != HttpStatusCode.NotFound)
+            {
+                var detail = GetErrorDetails(result.Content);
+                throw new InvalidOperationException(
+                    string.Format("{0} - {1}", result.StatusDescription, detail));
+            }
+
             return new UserValidationResult
             {
                 IsValid = result.StatusCode == HttpStatusCode.OK,
@@ -1071,6 +1078,9 @@ namespace Auth0
             try
             {
                 return JsonConvert.DeserializeObject(resultContent).ToString();
+            }
+            catch (NullReferenceException)
+            {
             }
             catch (JsonReaderException)
             {

--- a/Auth0.Net/Client.cs
+++ b/Auth0.Net/Client.cs
@@ -1028,6 +1028,44 @@ namespace Auth0
             return result.Data["ticket"];
         }
 
+        /// <summary>
+        /// Validate the username and password for a specific connection.
+        /// </summary>
+        /// <param name="username">The username.</param>
+        /// <param name="password">The password.</param>
+        /// <param name="connection">The connection name.</param>
+        public UserValidationResult ValidateUser(string username, string password, string connection)
+        {
+            if (string.IsNullOrEmpty(username))
+            {
+                throw new ArgumentNullException("username");
+            }
+
+            if (string.IsNullOrEmpty(password))
+            {
+                throw new ArgumentNullException("password");
+            }
+
+            if (string.IsNullOrEmpty(connection))
+            {
+                throw new ArgumentNullException("connection");
+            }
+
+            var request = new RestRequest("/public/api/users/validate_userpassword", Method.POST);
+            request.AddHeader("Content-Type", "application/x-www-form-urlencoded");
+            request.AddParameter("connection", connection);
+            request.AddParameter("username", username);
+            request.AddParameter("password", password);
+            request.AddParameter("client_id", clientID);
+
+            var result = this.client.Execute(request);
+            return new UserValidationResult
+            {
+                IsValid = result.StatusCode == HttpStatusCode.OK,
+                Message = result.Content
+            };
+        }
+
         private static string GetErrorDetails(string resultContent)
         {
             try

--- a/Auth0.Net/UserValidationResult.cs
+++ b/Auth0.Net/UserValidationResult.cs
@@ -1,0 +1,9 @@
+namespace Auth0
+{
+    public class UserValidationResult
+    {
+        public bool IsValid { get; internal set; }
+
+        public string Message { get; internal set; }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -101,6 +101,22 @@ var verificationUrl = client.GenerateVerificationTicket("auth0|54c6322f6936d1531
    "http://myapp.com/activated");
 ~~~
 
+### client.ValidateUser(username, password, connection)
+
+Verify if the username and password are correct for a given connection.
+
+~~~csharp
+var validationResult = client.ValidateUser("some@user.com", "Passw0rd!", "Username-Password-Authentication");
+if (validationResult.IsValid)
+{
+    return "User is valid.";
+}
+else
+{
+    return "Invalid user. Details: " + validationResult.Message;
+}
+~~~
+
 ## Authentication
 
 This library is useful to consume the http api of Auth0, in order to authenticate users you can use our platform specific SDKs:


### PR DESCRIPTION
This endpoint is required if you're building a secure password reset form which doesn't use email verification. You could present the user with 4 input fields:

 - Username
 - Current password
 - New password
 - Confirm new password

The username and current password would then be validated, and if both are correct the user's password can be changed to the new password.