### PR TITLE
Issue 40: Client.ExchangeAuthorizationCodePerAccessToken throws OAuthException in .NET 3.5

### DIFF
--- a/Auth0.Net/Auth0.Net.csproj
+++ b/Auth0.Net/Auth0.Net.csproj
@@ -40,9 +40,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp, Version=105.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\RestSharp.105.0.1\lib\net35\RestSharp.dll</HintPath>
+    <Reference Include="RestSharp">
+      <HintPath>..\packages\RestSharp.105.1.0\lib\net35\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/Auth0.Net/Auth0.Net.csproj
+++ b/Auth0.Net/Auth0.Net.csproj
@@ -40,7 +40,7 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="RestSharp">
+    <Reference Include="RestSharp, Version=105.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\RestSharp.105.1.0\lib\net35\RestSharp.dll</HintPath>
     </Reference>
     <Reference Include="System" />

--- a/Auth0.Net/packages.config
+++ b/Auth0.Net/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net35" />
-  <package id="RestSharp" version="105.0.1" targetFramework="net35" />
+  <package id="RestSharp" version="105.1.0" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Fixes #40 