### PR TITLE
Improve error handling in ExchangeAuthorizationCodePerAccessToken

### DIFF
--- a/Auth0.Net/Client.cs
+++ b/Auth0.Net/Client.cs
@@ -332,9 +332,9 @@
             var body = response.Data;
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                var errorDescription = body.ContainsKey("error_description") ? body["error_description"] : "(no description)";
+                var errorDescription = (body != null && body.ContainsKey("error_description")) ? body["error_description"] : "(no description)";
                 errorDescription += "; StatusCode=" + (int)response.StatusCode;
-                var errorCode = body.ContainsKey("error") ? body["error"] : string.Empty;
+                var errorCode = (body != null && body.ContainsKey("error")) ? body["error"] : string.Empty;
 
                 throw new OAuthException(errorDescription, errorCode);
             }

--- a/Auth0.Net/Client.cs
+++ b/Auth0.Net/Client.cs
@@ -321,7 +321,6 @@
             request.AddParameter("redirect_uri", redirectUri, ParameterType.GetOrPost);
 
             var response = this.client.Execute<Dictionary<string, string>>(request);
-            var body = response.Data;
 
             if (response.ResponseStatus != ResponseStatus.Completed)
             {
@@ -330,6 +329,7 @@
                     string.Empty);
             }
 
+            var body = response.Data;
             if (response.StatusCode != HttpStatusCode.OK)
             {
                 var errorDescription = body.ContainsKey("error_description") ? body["error_description"] : "(no description)";

--- a/Auth0.Net/Client.cs
+++ b/Auth0.Net/Client.cs
@@ -320,17 +320,29 @@
             request.AddParameter("grant_type", "authorization_code", ParameterType.GetOrPost);
             request.AddParameter("redirect_uri", redirectUri, ParameterType.GetOrPost);
 
-            var response = this.client.Execute<Dictionary<string, string>>(request).Data;
+            var response = this.client.Execute<Dictionary<string, string>>(request);
+            var body = response.Data;
 
-            if (response.ContainsKey("error") || response.ContainsKey("error_description"))
+            if (response.ResponseStatus != ResponseStatus.Completed)
             {
-                throw new OAuthException(response["error_description"], response["error"]);
+                throw new OAuthException(
+                    "The Auth0 API did not return a complete response; ResponseStatus=" + response.ResponseStatus + "; ErrorMessage=" + response.ErrorMessage ?? string.Empty, 
+                    string.Empty);
+            }
+
+            if (response.StatusCode != HttpStatusCode.OK)
+            {
+                var errorDescription = body.ContainsKey("error_description") ? body["error_description"] : "(no description)";
+                errorDescription += "; StatusCode=" + (int)response.StatusCode;
+                var errorCode = body.ContainsKey("error") ? body["error"] : string.Empty;
+
+                throw new OAuthException(errorDescription, errorCode);
             }
 
             return new TokenResult
             {
-                AccessToken = response["access_token"],
-                IdToken = response.ContainsKey("id_token") ? response["id_token"] : string.Empty
+                AccessToken = body["access_token"],
+                IdToken = body.ContainsKey("id_token") ? body["id_token"] : string.Empty
             };
         }
 


### PR DESCRIPTION
Under certain circumstances, the RestSharp response has no body and is
causing a `NullReferenceException`.  This change prevents that as well as reports back more meaningful errors for other scenarios.