### PR TITLE
Fix issue 354

### DIFF
--- a/examples/webapi/Api/App_Start/WebApiConfig.cs
+++ b/examples/webapi/Api/App_Start/WebApiConfig.cs
@@ -14,8 +14,8 @@ namespace Api
             // Web API configuration and services
             config.EnableCors();
 
-            var clientID = WebConfigurationManager.AppSettings["Auth0ClientID"];
-            var clientSecret = WebConfigurationManager.AppSettings["Auth0ClientSecret"];
+            var clientID = WebConfigurationManager.AppSettings["auth0:ClientId"];
+            var clientSecret = WebConfigurationManager.AppSettings["auth0:ClientSecret"];
             
             config.MessageHandlers.Add(new JsonWebTokenValidationHandler()
             {

--- a/examples/webapi/Api/Web.config
+++ b/examples/webapi/Api/Web.config
@@ -9,8 +9,8 @@
     <add key="webpages:Enabled" value="false" />
     <add key="ClientValidationEnabled" value="true" />
     <add key="UnobtrusiveJavaScriptEnabled" value="true" />
-    <add key="Auth0ClientID" value="{CLIENT_ID}"/>
-    <add key="Auth0ClientSecret" value="{CLIENT_SECRET}"/>
+    <add key="auth0:ClientId" value="{CLIENT_ID}"/>
+    <add key="auth0:ClientSecret" value="{CLIENT_SECRET}"/>
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5" />


### PR DESCRIPTION
For the ASP.NET WebAPI seed, updates the names of the keys set in
web.config and used in WebApiConfig.cs, so that they are the same used
by the Auth0-ASPNET nuget package.