### PR TITLE
Fix Authentication Response NULL

### DIFF
--- a/src/Auth0.AuthenticationApi/Models/AuthenticationResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthenticationResponse.cs
@@ -1,4 +1,5 @@
-﻿namespace Auth0.AuthenticationApi.Models
+using Newtonsoft.Json;
+namespace Auth0.AuthenticationApi.Models
 {
     /// <summary>
     /// Contains the response from an authentication request.
@@ -8,16 +9,19 @@
         /// <summary>
         /// Gets or sets the identifier token.
         /// </summary>
+        [JsonProperty("id_token")]
         public string IdToken { get; set; }
 
         /// <summary>
         /// Gets or sets the access token.
         /// </summary>
+        [JsonProperty("access_token")]
         public string AccessToken { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the token.
         /// </summary>
+        [JsonProperty("token_type")]
         public string TokenType { get; set; }
     }
 }


### PR DESCRIPTION
Could not convert JSON to object (properties were all null). This solved it for me as the returned json was different from the object format.

Let me know if this commit is correct, so I can use the nuget version.