### PR TITLE
Add implmenetation for username password login endpoint

### DIFF
--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -68,6 +68,8 @@
     <Compile Include="Builders\WsFedUrlBuilder.cs" />
     <Compile Include="IAuthenticationApiClient.cs" />
     <Compile Include="Models\AccessToken.cs" />
+    <Compile Include="Models\UsernamePasswordLoginResponse.cs" />
+    <Compile Include="Models\UsernamePasswordLoginRequest.cs" />
     <Compile Include="Models\AuthenticationRequest.cs" />
     <Compile Include="Models\AuthenticationResponse.cs" />
     <Compile Include="Models\ChangePasswordRequest.cs" />

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -294,5 +294,28 @@ namespace Auth0.AuthenticationApi
         {
             await Connection.PostAsync<object>("unlink", request, null, null, null, null, null);
         }
+        
+        /// <summary>
+        /// Given an <see cref="UsernamePasswordLoginRequest"/>, it will do the authentication on the provider and return a <see cref="UsernamePasswordLoginResponse"/>
+        /// </summary>
+        /// <param name="request">The authentication request details containing information regarding the connection, username, password etc.</param>
+        /// <returns>A <see cref="UsernamePasswordLoginResponse"/> containing the WS-Federation Login Form, which can be posted by the user to trigger a server-side login.</returns>
+        public async Task<UsernamePasswordLoginResponse> UsernamePasswordLogin(UsernamePasswordLoginRequest request)
+        {
+            if (request != null && string.IsNullOrEmpty(request.Tenant) && baseUri.Host.Contains("."))
+            {
+                request.Tenant = baseUri.Host.Split('.')[0];
+            }
+
+            if (request != null && string.IsNullOrEmpty(request.ResponseType))
+            {
+                request.ResponseType = "code";
+            }
+
+            return new UsernamePasswordLoginResponse()
+            {
+                HtmlForm = await Connection.PostAsync<string>("usernamepassword/login", request, null, null, null, null, null).ConfigureAwait(false)
+            };
+        }
     }
 }

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -139,5 +139,12 @@ namespace Auth0.AuthenticationApi
         /// <param name="request">The <see cref="UnlinkUserRequest"/> containing the information of the accounts to unlink.</param>
         /// <returns>Nothing</returns>
         Task UnlinkUser(UnlinkUserRequest request);
+
+        /// <summary>
+        /// Given an <see cref="UsernamePasswordLoginRequest"/>, it will do the authentication on the provider and return a <see cref="UsernamePasswordLoginResponse"/>
+        /// </summary>
+        /// <param name="request">The authentication request details containing information regarding the connection, username, password etc.</param>
+        /// <returns>A <see cref="UsernamePasswordLoginResponse"/> containing the WS-Federation Login Form, which can be posted by the user to trigger a server-side login.</returns>
+        Task<UsernamePasswordLoginResponse> UsernamePasswordLogin(UsernamePasswordLoginRequest request);
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/UsernamePasswordLoginRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/UsernamePasswordLoginRequest.cs
@@ -1,0 +1,64 @@
+using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    /// <summary>
+    /// Represents an active authentication request with SSO support.
+    /// </summary>
+    public class UsernamePasswordLoginRequest
+    {
+        /// <summary>
+        /// Gets or sets the client (app) identifier.
+        /// </summary>
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the connection.
+        /// </summary>
+        [JsonProperty("connection")]
+        public string Connection { get; set; }
+
+        /// <summary>
+        /// Gets or sets redirect uri.
+        /// </summary>
+        [JsonProperty("redirect_uri")]
+        public string RedirectUri { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response type.
+        /// </summary>
+        [JsonProperty("response_type")]
+        public string ResponseType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier token.
+        /// </summary>
+        [JsonProperty("id_token")]
+        public string IdToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the password.
+        /// </summary>
+        [JsonProperty("password")]
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the requested scope.
+        /// </summary>
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username.
+        /// </summary>
+        [JsonProperty("username")]
+        public string Username { get; set; }
+
+        /// <summary>
+        /// Gets or sets the tenant.
+        /// </summary>
+        [JsonProperty("tenant")]
+        public string Tenant { get; set; }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/UsernamePasswordLoginResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/UsernamePasswordLoginResponse.cs
@@ -1,0 +1,15 @@
+using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    /// <summary>
+    /// Represents an active authentication response with SSO support (a WS-Federation Login Form).
+    /// </summary>
+    public class UsernamePasswordLoginResponse
+    {
+        /// <summary>
+        /// The HTML form.
+        /// </summary>
+        public string HtmlForm { get; set; }
+    }
+}

--- a/src/Auth0.Core/ApiErrorContractResolver.cs
+++ b/src/Auth0.Core/ApiErrorContractResolver.cs
@@ -1,0 +1,36 @@
+﻿using Newtonsoft.Json.Serialization;
+using System.Collections.Generic;
+
+namespace Auth0.Core
+{
+    /// <summary>
+    /// A contract resolver to unify different error messages to a single class.
+    /// </summary>
+    public class ApiErrorContractResolver : DefaultContractResolver
+    {
+        private Dictionary<string, string> PropertyMappings { get; set; }
+
+        public ApiErrorContractResolver()
+        {
+            PropertyMappings = new Dictionary<string, string>
+            {
+                {"errorCode", "code"},
+                {"error", "name"},
+                {"message", "description"}
+            };
+        }
+
+        /// <summary>
+        /// Resolve a mapped attribute to an expected attribute.
+        /// </summary>
+        /// <param name="propertyName"></param>
+        /// <returns></returns>
+        protected override string ResolvePropertyName(string propertyName)
+        {
+            string resolvedName = null;
+            var resolved = this.PropertyMappings.TryGetValue(propertyName, out resolvedName);
+            return (resolved) ? resolvedName : base.ResolvePropertyName(propertyName);
+        }
+    }
+
+}

--- a/src/Auth0.Core/Auth0.Core.csproj
+++ b/src/Auth0.Core/Auth0.Core.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Base\PagingInformation.cs" />
     <Compile Include="Collections\IPagedList.cs" />
     <Compile Include="Collections\PagedList.cs" />
+    <Compile Include="ApiErrorContractResolver.cs" />
     <Compile Include="Exceptions\ApiException.cs" />
     <Compile Include="Http\DiagnosticsComponent.cs" />
     <Compile Include="Http\Utils.cs" />

--- a/src/Auth0.ManagementApi/Core/Http/ApiConnection.cs
+++ b/src/Auth0.ManagementApi/Core/Http/ApiConnection.cs
@@ -271,9 +271,6 @@ namespace Auth0.Core.Http
         {
             if (!response.IsSuccessStatusCode)
             {
-                //if (response.Exception != null)
-                //    throw new ApiException(response.Exception.Message, response.Exception);;
-
                 ApiError apiError = null;
 
                 // Grab the content
@@ -283,11 +280,20 @@ namespace Auth0.Core.Http
 
                     if (!string.IsNullOrEmpty(responseContent))
                     {
-                        apiError = JsonConvert.DeserializeObject<ApiError>(responseContent, new JsonSerializerSettings
+                        try
                         {
-                            // Suppress any parsing errors of payload
-                            Error = (sender, args) => { args.ErrorContext.Handled = true; }
-                        });
+                            apiError = JsonConvert.DeserializeObject<ApiError>(responseContent, new JsonSerializerSettings()
+                            {
+                                ContractResolver = new ApiErrorContractResolver()
+                            });
+                        }
+                        catch (Exception ex)
+                        {
+                            apiError = new ApiError();
+                            apiError.Error = responseContent;
+                            apiError.Message = responseContent;
+                            apiError.StatusCode = (int)response.StatusCode;
+                        }
                     }
                 }
 


### PR DESCRIPTION
This adds support for the usernamepassword/login endpoint. This endpoint will return a WS-Fed form instead of a JWT. Advantages:

 - This will be posted to Auth0 to the end user, which means SSO can be leveraged (Auth0 will set an SSO cookie)
 - You can use a code flow with this, allowing you to build custom login pages in combination with the Auth0 OWIN middleware for MVC.

Usage:

            var response = await auth.UsernamePasswordLogin(new Auth0.AuthenticationApi.Models.UsernamePasswordLoginRequest()
            {
                ClientId = "111",
                Username = "user@something.com",
                Password = "mypass",
                Connection = "Username-Password-Authentication",
                RedirectUri = "http://localhost:3001/login",
                Scope = "openid name"
            });

Response:

```
<form method="post" name="hiddenform" action="https://me.auth0.com/login/callback">
    <input type="hidden" name="wa" value="wsignin1.0">
    <input type="hidden" 
           name="wresult" 
           value="eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ...">
    <input type="hidden" name="wctx" value="{&quot;strategy&quot;:&quot;auth0...&quot;}">
    <noscript>
        <p>
            Script is disabled. Click Submit to continue.
        </p>
    </noscript>
<input type="submit" value="Submit">
</form>
```

Usage:

Return this form in an HTML view and the user's browser will automatically post this to Auth0 which will in turn post a valid token or authorization code back to your application