### PR TITLE
Missing properties for refreshtokens

### DIFF
--- a/src/Auth0.AuthenticationApi/Models/AccessToken.cs
+++ b/src/Auth0.AuthenticationApi/Models/AccessToken.cs
@@ -12,5 +12,11 @@ namespace Auth0.AuthenticationApi.Models
         /// </summary>
         [JsonProperty("id_token")]
         public string IdToken { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiry time in seconds.
+        /// </summary>
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/AuthenticationResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthenticationResponse.cs
@@ -1,4 +1,5 @@
-﻿namespace Auth0.AuthenticationApi.Models
+﻿using Newtonsoft.Json;
+namespace Auth0.AuthenticationApi.Models
 {
     /// <summary>
     /// Contains the response from an authentication request.
@@ -8,16 +9,25 @@
         /// <summary>
         /// Gets or sets the identifier token.
         /// </summary>
+        [JsonProperty("id_token")]
         public string IdToken { get; set; }
 
         /// <summary>
         /// Gets or sets the access token.
         /// </summary>
+        [JsonProperty("access_token")]
         public string AccessToken { get; set; }
 
         /// <summary>
         /// Gets or sets the type of the token.
         /// </summary>
+        [JsonProperty("token_type")]
         public string TokenType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the refresh token
+        /// </summary>
+        [JsonProperty("refresh_token")]
+        public string RefreshToken { get; set; }
     }
 }


### PR DESCRIPTION
Please also allow the following properties to be implemented for the use of refreshtokens:

AuthenticationResponse:
- refresh_token

AccessToken
- expires_in