### PR TITLE
Support for profileData on linked identities

### DIFF
--- a/src/Auth0.Core/Identity.cs
+++ b/src/Auth0.Core/Identity.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Auth0.Core
 {
@@ -45,6 +46,11 @@ namespace Auth0.Core
         /// </summary>
         [JsonProperty("user_id")]
         public string UserId { get; set; }
-        
+
+        /// <summary>
+        /// Contains additional profile information for linked identities.
+        /// </summary>
+        [JsonProperty("profileData")]
+        public IDictionary<string, object> ProfileData { get; set; }
     }
 }


### PR DESCRIPTION
Adds support for reading the 'profileData' property of a secondary identity thas has been linked to a primary identity. 
E.g. raw user JSON:

```
  {
    "email": "027d4dee653d4dfbba9deb64d6ad6bbb@nonexistingdomain.aaa",
    "email_verified": true,
    "user_id": "auth0|58658a88ef793e559a05bafb",
    "picture": "https://s.gravatar.com/avatar/7476381b06763751bed7fef7fac1ae90?s=480&r=pg&d=https%3A%2F%2Fcdn.auth0.com%2Favatars%2F02.png",
    "identities": [
        {
            "connection": "ec1e7da1629c4ad49fa7910a5181feee",
            "user_id": "58658a88ef793e559a05bafb",
            "provider": "auth0",
            "isSocial": false
        },
        {
            "profileData": {
                "email": "f1b31ca358f24e5b8b0a6f9b06aef650@nonexistingdomain.aaa",
                "email_verified": true
            },
            "connection": "ec1e7da1629c4ad49fa7910a5181feee",
            "user_id": "58658a89ef793e559a05bafc",
            "provider": "auth0",
            "isSocial": false
        }
    ],
    "updated_at": "2016-12-29T22:13:29.886Z",
    "created_at": "2016-12-29T22:13:28.810Z",
    "blocked_for": [],
    "guardian_enrollments": []
}
```
