### PR TITLE
Add RefreshTokenRequest Audience to actual request

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -335,9 +335,13 @@ namespace Auth0.AuthenticationApi
                 { "grant_type", "refresh_token" },
                 { "refresh_token", request.RefreshToken },
                 { "client_id", request.ClientId },
-                { "client_secret", request.ClientSecret },
-                { "audience", request.Audience }
+                { "client_secret", request.ClientSecret }
             };
+
+            if (!string.IsNullOrEmpty(request.Audience))
+            {
+                parameters.Add("audience", request.Audience);
+            }
 
             if (!string.IsNullOrEmpty(request.Scope))
             {

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -335,7 +335,8 @@ namespace Auth0.AuthenticationApi
                 { "grant_type", "refresh_token" },
                 { "refresh_token", request.RefreshToken },
                 { "client_id", request.ClientId },
-                { "client_secret", request.ClientSecret }
+                { "client_secret", request.ClientSecret },
+                { "audience", request.Audience }
             };
 
             if (!string.IsNullOrEmpty(request.Scope))


### PR DESCRIPTION
I have a rule that need that info for scope attribution.
And the fact that the attribute exist in the model and is not used is kind of confusing.