### PR TITLE
Inject HttpClient into AuthenticationApiClient 

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -25,12 +25,6 @@ namespace Auth0.AuthenticationApi
         {
             _baseUri = baseUri;
 
-            // If no diagnostics header structure was specified, then revert to the default one
-            if (diagnostics == null)
-            {
-                diagnostics = DiagnosticsHeader.Default;
-            }
-
             Connection = connection ?? throw new ArgumentNullException(nameof(ApiConnection));
         }
 
@@ -41,7 +35,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
-            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics, handler))
+            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, handler))
         {
         }
 
@@ -52,7 +46,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="diagnostics"></param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpClient httpClient)
-            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics, httpClient))
+            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, httpClient))
         {
         }
 

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -21,13 +21,7 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         private readonly Uri _baseUri;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
-        /// </summary>
-        /// <param name="baseUri">The base URI.</param>
-        /// <param name="diagnostics">The diagnostics.</param>
-        /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
-        public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
+        private AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, ApiConnection connection)
         {
             _baseUri = baseUri;
 
@@ -37,7 +31,18 @@ namespace Auth0.AuthenticationApi
                 diagnostics = DiagnosticsHeader.Default;
             }
 
-            Connection = new ApiConnection(null, baseUri.AbsoluteUri, diagnostics, handler);
+            Connection = connection ?? throw new ArgumentNullException(nameof(ApiConnection));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
+        /// </summary>
+        /// <param name="baseUri">The base URI.</param>
+        /// <param name="diagnostics">The diagnostics.</param>
+        /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
+        public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
+            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics, handler))
+        {
         }
 
         /// <summary>
@@ -47,16 +52,8 @@ namespace Auth0.AuthenticationApi
         /// <param name="diagnostics"></param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpClient httpClient)
+            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics, httpClient))
         {
-            _baseUri = baseUri;
-
-            // If no diagnostics header structure was specified, then revert to the default one
-            if (diagnostics == null)
-            {
-                diagnostics = DiagnosticsHeader.Default;
-            }
-
-            Connection = new ApiConnection(null, baseUri.AbsoluteUri, diagnostics, httpClient);
         }
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -43,10 +43,40 @@ namespace Auth0.AuthenticationApi
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
         /// </summary>
+        /// <param name="baseUri"></param>
+        /// <param name="diagnostics"></param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpClient httpClient)
+        {
+            _baseUri = baseUri;
+
+            // If no diagnostics header structure was specified, then revert to the default one
+            if (diagnostics == null)
+            {
+                diagnostics = DiagnosticsHeader.Default;
+            }
+
+            Connection = new ApiConnection(null, baseUri.AbsoluteUri, diagnostics, httpClient);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
+        /// </summary>
         /// <param name="baseUri">The base URI.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(Uri baseUri, HttpMessageHandler handler)
             : this(baseUri, null, handler)
+        {
+        }
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
+        /// </summary>
+        /// <param name="baseUri"></param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public AuthenticationApiClient(Uri baseUri, HttpClient httpClient)
+            : this(baseUri, null, httpClient)
         {
         }
 
@@ -56,7 +86,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics)
-            : this(baseUri, diagnostics, null)
+            : this(baseUri, diagnostics, (HttpMessageHandler) null)
         {
         }
 
@@ -65,7 +95,7 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="baseUri">The base URI.</param>
         public AuthenticationApiClient(Uri baseUri)
-            : this(baseUri, null, null)
+            : this(baseUri, null, (HttpMessageHandler) null)
         {
         }
 
@@ -83,6 +113,17 @@ namespace Auth0.AuthenticationApi
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
         /// </summary>
+        /// <param name="domain"></param>
+        /// <param name="diagnostics"></param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public AuthenticationApiClient(string domain, DiagnosticsHeader diagnostics, HttpClient httpClient)
+            : this(new Uri($"https://{domain}"), diagnostics, httpClient)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
+        /// </summary>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(string domain, HttpMessageHandler handler)
@@ -93,10 +134,20 @@ namespace Auth0.AuthenticationApi
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
         /// </summary>
+        /// <param name="domain"></param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public AuthenticationApiClient(string domain, HttpClient httpClient)
+            : this(new Uri($"https://{domain}"), null, httpClient)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
+        /// </summary>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         public AuthenticationApiClient(string domain, DiagnosticsHeader diagnostics)
-            : this(new Uri($"https://{domain}"), diagnostics, null)
+            : this(new Uri($"https://{domain}"), diagnostics, (HttpMessageHandler) null)
         {
         }
 
@@ -105,7 +156,7 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         public AuthenticationApiClient(string domain)
-            : this(new Uri($"https://{domain}"), null, null)
+            : this(new Uri($"https://{domain}"), null, (HttpMessageHandler) null)
         {
         }
 

--- a/src/Auth0.Core/Http/ApiConnection.cs
+++ b/src/Auth0.Core/Http/ApiConnection.cs
@@ -43,6 +43,16 @@ namespace Auth0.Core.Http
             _httpClient = new HttpClient(handler ?? new HttpClientHandler());
         }
 
+        public ApiConnection(string token, string baseUrl, DiagnosticsHeader diagnostics,
+            HttpClient httpClient)
+        {
+            _token = token;
+            _diagnostics = diagnostics;
+            _baseUrl = baseUrl;
+
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        }
+
         private void ApplyHeaders(HttpRequestMessage message, IDictionary<string, object> headers)
         {
             // Add the diagnostics header, unless user explicitly opted out of it

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -115,13 +115,6 @@ namespace Auth0.ManagementApi
         private ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics,
             ApiConnection apiConnection)
         {
-            // If no diagnostics header structure was specified, then revert to the default one
-            if (diagnostics == null)
-            {
-                diagnostics = DiagnosticsHeader.Default;
-            }
-
-
             _apiConnection = apiConnection;
 
             BlacklistedTokens = new BlacklistedTokensClient(_apiConnection);
@@ -150,7 +143,7 @@ namespace Auth0.ManagementApi
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
-        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics, handler))
+        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, handler))
         {
         }
 
@@ -162,7 +155,7 @@ namespace Auth0.ManagementApi
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
         public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics, HttpClient httpClient)
-        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics, httpClient))
+        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, httpClient))
         {
 
         }

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -112,14 +112,8 @@ namespace Auth0.ManagementApi
             return _apiConnection.ApiInfo;
         }
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ManagementApiClient"/> class.
-        /// </summary>
-        /// <param name="token">The token.</param>
-        /// <param name="baseUri">The base URI.</param>
-        /// <param name="diagnostics">The diagnostics.</param>
-        /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
-        public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
+        private ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics,
+            ApiConnection apiConnection)
         {
             // If no diagnostics header structure was specified, then revert to the default one
             if (diagnostics == null)
@@ -127,7 +121,8 @@ namespace Auth0.ManagementApi
                 diagnostics = DiagnosticsHeader.Default;
             }
 
-            _apiConnection = new ApiConnection(token, baseUri.AbsoluteUri, diagnostics, handler);
+
+            _apiConnection = apiConnection;
 
             BlacklistedTokens = new BlacklistedTokensClient(_apiConnection);
             ClientGrants = new ClientGrantsClient(_apiConnection);
@@ -145,6 +140,30 @@ namespace Auth0.ManagementApi
             Tickets = new TicketsClient(_apiConnection);
             UserBlocks = new UserBlocksClient(_apiConnection);
             Users = new UsersClient(_apiConnection);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagementApiClient"/> class.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="baseUri">The base URI.</param>
+        /// <param name="diagnostics">The diagnostics.</param>
+        /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
+        public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
+        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics, handler))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagementApiClient"/> class.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="baseUri">The base URI.</param>
+        /// <param name="diagnostics">The diagnostics.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics, HttpClient httpClient)
+        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics, httpClient))
+        {
 
         }
 
@@ -155,7 +174,7 @@ namespace Auth0.ManagementApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics)
-            : this(token, baseUri, diagnostics, null)
+            : this(token, baseUri, diagnostics, (HttpMessageHandler) null)
         {
         }
 
@@ -170,13 +189,26 @@ namespace Auth0.ManagementApi
         {
         }
 
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagementApiClient"/> class.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="baseUri">The base URI.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public ManagementApiClient(string token, Uri baseUri, HttpClient httpClient)
+            : this(token, baseUri, null, httpClient)
+        {
+
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ManagementApiClient"/> class.
         /// </summary>
         /// <param name="token">The token.</param>
         /// <param name="baseUri">The base URI.</param>
         public ManagementApiClient(string token, Uri baseUri)
-            : this(token, baseUri, null, null)
+            : this(token, baseUri, null, (HttpMessageHandler) null)
         {
         }
 
@@ -198,8 +230,20 @@ namespace Auth0.ManagementApi
         /// <param name="token">The token.</param>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="diagnostics">The diagnostics.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public ManagementApiClient(string token, string domain, DiagnosticsHeader diagnostics, HttpClient httpClient)
+            : this(token, new Uri($"https://{domain}/api/v2"), diagnostics, httpClient)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagementApiClient"/> class.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
+        /// <param name="diagnostics">The diagnostics.</param>
         public ManagementApiClient(string token, string domain, DiagnosticsHeader diagnostics)
-            : this(token, new Uri($"https://{domain}/api/v2"), diagnostics, null)
+            : this(token, new Uri($"https://{domain}/api/v2"), diagnostics, (HttpMessageHandler) null)
         {
         }
 
@@ -219,8 +263,19 @@ namespace Auth0.ManagementApi
         /// </summary>
         /// <param name="token">The token.</param>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
+        /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        public ManagementApiClient(string token, string domain, HttpClient httpClient)
+            : this(token, new Uri($"https://{domain}/api/v2"), null, httpClient)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ManagementApiClient"/> class.
+        /// </summary>
+        /// <param name="token">The token.</param>
+        /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         public ManagementApiClient(string token, string domain)
-            : this(token, new Uri($"https://{domain}/api/v2"), null, null)
+            : this(token, new Uri($"https://{domain}/api/v2"), null, (HttpMessageHandler) null)
         {
         }
 


### PR DESCRIPTION
In reference to #165 I've spiked out opening up the AuthenticationApiClient to allow consumers to inject their own HttpClient that they can manage the lifetime of per their application requirements.

This is to help comply with what is given on MSDN regarding HttpClient socket exhaustion: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=netframework-4.7 `HttpClient is intended to be instantiated once and re-used throughout the life of an application. Instantiating an HttpClient class for every request will exhaust the number of sockets available under heavy loads. This will result in SocketException errors.`

Let me know if you'd like for me to extend this into the ManagementApiClient before acceptance or if you'd like specific test cases written.