### PR TITLE
Implement paging phase 2

### DIFF
--- a/.idea/.idea.Auth0.Net/.idea/contentModel.xml
+++ b/.idea/.idea.Auth0.Net/.idea/contentModel.xml
@@ -191,6 +191,8 @@
             <e p="EmailTemplateUpdateRequest.cs" t="Include" />
             <e p="EmailVerificationTicketRequest.cs" t="Include" />
             <e p="EncryptionKey.cs" t="Include" />
+            <e p="GetClientGrantsRequest.cs" t="Include" />
+            <e p="GetRulesRequest.cs" t="Include" />
             <e p="GuardianEnrollment.cs" t="Include" />
             <e p="GuardianEnrollmentStatus.cs" t="Include" />
             <e p="GuardianFactor.cs" t="Include" />
@@ -207,6 +209,7 @@
             <e p="JwtConfiguration.cs" t="Include" />
             <e p="LogEntry.cs" t="Include" />
             <e p="Mobile.cs" t="Include" />
+            <e p="PaginationInfo.cs" t="Include" />
             <e p="PasswordChangeTicketRequest.cs" t="Include" />
             <e p="ResourceServer.cs" t="Include" />
             <e p="ResourceServerBase.cs" t="Include" />

--- a/.idea/.idea.Auth0.Net/.idea/contentModel.xml
+++ b/.idea/.idea.Auth0.Net/.idea/contentModel.xml
@@ -192,7 +192,11 @@
             <e p="EmailVerificationTicketRequest.cs" t="Include" />
             <e p="EncryptionKey.cs" t="Include" />
             <e p="GetClientGrantsRequest.cs" t="Include" />
+            <e p="GetClientsRequest.cs" t="Include" />
+            <e p="GetConnectionsRequest.cs" t="Include" />
+            <e p="GetLogsRequest.cs" t="Include" />
             <e p="GetRulesRequest.cs" t="Include" />
+            <e p="GetUsersRequest.cs" t="Include" />
             <e p="GuardianEnrollment.cs" t="Include" />
             <e p="GuardianEnrollmentStatus.cs" t="Include" />
             <e p="GuardianFactor.cs" t="Include" />

--- a/.idea/.idea.Auth0.Net/.idea/contentModel.xml
+++ b/.idea/.idea.Auth0.Net/.idea/contentModel.xml
@@ -196,6 +196,7 @@
             <e p="GetConnectionsRequest.cs" t="Include" />
             <e p="GetLogsRequest.cs" t="Include" />
             <e p="GetRulesRequest.cs" t="Include" />
+            <e p="GetUserLogsRequest.cs" t="Include" />
             <e p="GetUsersRequest.cs" t="Include" />
             <e p="GuardianEnrollment.cs" t="Include" />
             <e p="GuardianEnrollmentStatus.cs" t="Include" />

--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
@@ -6,21 +6,16 @@
     <AssemblyName>Auth0.ManagementApi</AssemblyName>
     <PackageId>Auth0.ManagementApi</PackageId>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.1\Auth0.ManagementApi.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>
-  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-
 </Project>

--- a/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Auth0.Core.Collections;
 using Auth0.Core.Http;
 using Auth0.ManagementApi.Models;
+using Auth0.ManagementApi.Serialization;
 
 namespace Auth0.ManagementApi.Clients
 {
@@ -43,18 +45,29 @@ namespace Auth0.ManagementApi.Clients
             }, null);
         }
 
-        /// <summary>
-        /// Gets a list of all the client grants.
-        /// </summary>
-        /// <param name="audience">The audience according to which you want to filter the returned client grants.</param>
-        /// <returns>A list of client grants</returns>
-        public Task<IList<ClientGrant>> GetAllAsync(string audience = null)
+        /// <inheritdoc />
+        public Task<IList<ClientGrant>> GetAllAsync(string audience = null, string clientId = null)
         {
             return Connection.GetAsync<IList<ClientGrant>>("client-grants", null,
                 new Dictionary<string, string>
                 {
-                    {"audience", audience}
+                    {"audience", audience},
+                    {"client_id", clientId}
                 }, null, null);
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<ClientGrant>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string audience = null, string clientId = null)
+        {
+            return Connection.GetAsync<IPagedList<ClientGrant>>("client-grants", null,
+                new Dictionary<string, string>
+                {
+                    {"page", page?.ToString()},
+                    {"per_page", perPage?.ToString()},
+                    {"include_totals", includeTotals?.ToString().ToLower()},
+                    {"audience", audience},
+                    {"client_id", clientId}
+                }, null, new PagedListConverter<ClientGrant>("client_grants"));
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Auth0.Core.Collections;
@@ -46,27 +47,46 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <inheritdoc />
-        public Task<IList<ClientGrant>> GetAllAsync(string audience = null, string clientId = null)
+        [Obsolete("Use GetAllAsync(GetClientGrantsRequest) or GetAllAsync(GetClientGrantsRequest, PaginationInfo) instead")]
+        public Task<IList<ClientGrant>> GetAllAsync(string audience = null)
         {
             return Connection.GetAsync<IList<ClientGrant>>("client-grants", null,
                 new Dictionary<string, string>
                 {
-                    {"audience", audience},
-                    {"client_id", clientId}
+                    {"audience", audience}
                 }, null, null);
         }
 
         /// <inheritdoc />
-        public Task<IPagedList<ClientGrant>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string audience = null, string clientId = null)
+        public Task<IPagedList<ClientGrant>> GetAllAsync(GetClientGrantsRequest request)
         {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
             return Connection.GetAsync<IPagedList<ClientGrant>>("client-grants", null,
                 new Dictionary<string, string>
                 {
-                    {"page", page?.ToString()},
-                    {"per_page", perPage?.ToString()},
-                    {"include_totals", includeTotals?.ToString().ToLower()},
-                    {"audience", audience},
-                    {"client_id", clientId}
+                    {"audience", request.Audience},
+                    {"client_id", request.ClientId}
+                }, null, new PagedListConverter<ClientGrant>("client_grants"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<ClientGrant>> GetAllAsync(GetClientGrantsRequest request, PaginationInfo pagination)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
+
+            return Connection.GetAsync<IPagedList<ClientGrant>>("client-grants", null,
+                new Dictionary<string, string>
+                {
+                    {"audience", request.Audience},
+                    {"client_id", request.ClientId},
+                    {"page", pagination.PageNo.ToString()},
+                    {"per_page", pagination.PerPage.ToString()},
+                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
                 }, null, new PagedListConverter<ClientGrant>("client_grants"));
         }
 

--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -49,6 +49,8 @@ namespace Auth0.ManagementApi.Clients
             }, null);
         }
 
+        /// <inheritdoc />
+        [Obsolete("Use GetAllAsync(GetClientsRequest) or GetAllAsync(GetClientsRequest, PaginationInfo) instead")]
         public Task<IPagedList<Client>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string fields = null, bool? includeFields = null, 
             bool? isGlobal = null, bool? isFirstParty = null, ClientApplicationType[] appType = null)
         {
@@ -66,6 +68,55 @@ namespace Auth0.ManagementApi.Clients
             if (appType != null)
             {
                 queryStrings.Add("app_type", string.Join(",", appType.Select(ToEnumString)));
+            }
+            
+            return Connection.GetAsync<IPagedList<Client>>("clients", null, queryStrings, null, new PagedListConverter<Client>("clients"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<Client>> GetAllAsync(GetClientsRequest request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"fields", request.Fields},
+                {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                {"is_global", request.IsGlobal?.ToString().ToLower()},
+                { "is_first_party", request.IsFirstParty?.ToString().ToLower()}
+            };
+
+            if (request.AppType != null)
+            {
+                queryStrings.Add("app_type", string.Join(",", request.AppType.Select(ToEnumString)));
+            }
+            
+            return Connection.GetAsync<IPagedList<Client>>("clients", null, queryStrings, null, new PagedListConverter<Client>("clients"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<Client>> GetAllAsync(GetClientsRequest request, PaginationInfo pagination)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
+
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"fields", request.Fields},
+                {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                {"is_global", request.IsGlobal?.ToString().ToLower()},
+                {"is_first_party", request.IsFirstParty?.ToString().ToLower()},
+                {"page", pagination.PageNo.ToString()},
+                {"per_page", pagination.PerPage.ToString()},
+                {"include_totals", pagination.IncludeTotals.ToString().ToLower()},
+            };
+
+            if (request.AppType != null)
+            {
+                queryStrings.Add("app_type", string.Join(",", request.AppType.Select(ToEnumString)));
             }
             
             return Connection.GetAsync<IPagedList<Client>>("clients", null, queryStrings, null, new PagedListConverter<Client>("clients"));

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -88,6 +88,7 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <inheritdoc />
+        [Obsolete("Use GetAllAsync(GetConnectionsRequest) or GetAllAsync(GetConnectionsRequest, PaginationInfo) instead")]
         public Task<IPagedList<Connection>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, 
             string fields = null, bool? includeFields = null, string name = null, string[] strategy = null)
         {
@@ -105,6 +106,61 @@ namespace Auth0.ManagementApi.Clients
             if (strategy != null)
             {
                 foreach (var s in strategy)
+                {
+                    queryStrings.Add("strategy", s);
+                }
+            }
+            
+            return Connection.GetAsync<IPagedList<Connection>>("connections", null, queryStrings, null, new PagedListConverter<Connection>("connections"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"fields", request.Fields},
+                {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                {"name", request.Name}
+            };
+            
+            // Add each strategy as a separate querystring
+            if (request.Strategy != null)
+            {
+                foreach (var s in request.Strategy)
+                {
+                    queryStrings.Add("strategy", s);
+                }
+            }
+            
+            return Connection.GetAsync<IPagedList<Connection>>("connections", null, queryStrings, null, new PagedListConverter<Connection>("connections"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, PaginationInfo pagination)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
+
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"fields", request.Fields},
+                {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                {"name", request.Name},
+                {"page", pagination.PageNo.ToString()},
+                {"per_page", pagination.PerPage.ToString()},
+                {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
+            };
+            
+            // Add each strategy as a separate querystring
+            if (request.Strategy != null)
+            {
+                foreach (var s in request.Strategy)
                 {
                     queryStrings.Add("strategy", s);
                 }

--- a/src/Auth0.ManagementApi/Clients/IClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IClientGrantsClient.cs
@@ -1,6 +1,7 @@
 ﻿using Auth0.ManagementApi.Models;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Auth0.Core.Collections;
 
 namespace Auth0.ManagementApi.Clients
 {
@@ -27,8 +28,20 @@ namespace Auth0.ManagementApi.Clients
         /// Gets a list of all the client grants.
         /// </summary>
         /// <param name="audience">The audience according to which you want to filter the returned client grants.</param>
+        /// <param name="clientId">The Id of a client to filter</param>
         /// <returns>A list of client grants</returns>
-        Task<IList<ClientGrant>> GetAllAsync(string audience = null);
+        Task<IList<ClientGrant>> GetAllAsync(string audience = null, string clientId = null);
+
+        /// <summary>
+        /// Gets a list of all the client grants.
+        /// </summary>
+        /// <param name="page">The page number. Zero based.</param>
+        /// <param name="perPage">The amount of entries per page.</param>
+        /// <param name="includeTotals">True if a query summary must be included in the result.</param>
+        /// <param name="audience">The audience according to which you want to filter the returned client grants.</param>
+        /// <param name="clientId">The Id of a client to filter</param>
+        /// <returns>A list of client grants</returns>
+        Task<IPagedList<ClientGrant>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string audience = null, string clientId = null);
 
         /// <summary>
         /// Updates a client grant

--- a/src/Auth0.ManagementApi/Clients/IClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IClientGrantsClient.cs
@@ -1,4 +1,5 @@
-﻿using Auth0.ManagementApi.Models;
+﻿using System;
+using Auth0.ManagementApi.Models;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using Auth0.Core.Collections;
@@ -28,20 +29,24 @@ namespace Auth0.ManagementApi.Clients
         /// Gets a list of all the client grants.
         /// </summary>
         /// <param name="audience">The audience according to which you want to filter the returned client grants.</param>
-        /// <param name="clientId">The Id of a client to filter</param>
         /// <returns>A list of client grants</returns>
-        Task<IList<ClientGrant>> GetAllAsync(string audience = null, string clientId = null);
+        [Obsolete("Use GetAllAsync(GetClientGrantsRequest) or GetAllAsync(GetClientGrantsRequest, PaginationInfo) instead")]
+        Task<IList<ClientGrant>> GetAllAsync(string audience = null);
 
         /// <summary>
         /// Gets a list of all the client grants.
         /// </summary>
-        /// <param name="page">The page number. Zero based.</param>
-        /// <param name="perPage">The amount of entries per page.</param>
-        /// <param name="includeTotals">True if a query summary must be included in the result.</param>
-        /// <param name="audience">The audience according to which you want to filter the returned client grants.</param>
-        /// <param name="clientId">The Id of a client to filter</param>
-        /// <returns>A list of client grants</returns>
-        Task<IPagedList<ClientGrant>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string audience = null, string clientId = null);
+        /// <param name="request">Specifies criteria to use when querying client grants</param>
+        /// <returns>A paged list of client grants</returns>
+        Task<IPagedList<ClientGrant>> GetAllAsync(GetClientGrantsRequest request);
+
+        /// <summary>
+        /// Gets a list of all the client grants.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying client grants.</param>
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>A paged list of client grants</returns>
+        Task<IPagedList<ClientGrant>> GetAllAsync(GetClientGrantsRequest request, PaginationInfo pagination);
 
         /// <summary>
         /// Updates a client grant

--- a/src/Auth0.ManagementApi/Clients/IClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IClientsClient.cs
@@ -37,8 +37,24 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="isFirstParty">Filter on whether or not a client is a first party client.</param>
         /// <param name="appType">List of application types used to filter the returned clients</param>
         /// <returns></returns>
+        [Obsolete("Use GetAllAsync(GetClientsRequest) or GetAllAsync(GetClientsRequest, PaginationInfo) instead")]
         Task<IPagedList<Client>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, 
             string fields = null, bool? includeFields = null, bool? isGlobal = null, bool? isFirstParty = null, ClientApplicationType[] appType = null);
+
+        /// <summary>
+        /// Retrieves a list of all client applications.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying clients.</param>
+        /// <returns>An <see cref="IPagedList{Client}"/> containing the clients.</returns>
+        Task<IPagedList<Client>> GetAllAsync(GetClientsRequest request);
+
+        /// <summary>
+        /// Retrieves a list of all client applications.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying clients.</param>
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{Client}"/> containing the clients.</returns>
+        Task<IPagedList<Client>> GetAllAsync(GetClientsRequest request, PaginationInfo pagination);
 
         /// <summary>
         ///     Retrieves a list of all client applications. Accepts a list of fields to include or exclude.

--- a/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
@@ -46,8 +46,24 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="name">The name of the connection to retrieve</param>
         /// <param name="strategy">Only retrieve connections with these strategies.</param>
         /// <returns></returns>
+        [Obsolete("Use GetAllAsync(GetConnectionsRequest) or GetAllAsync(GetConnectionsRequest, PaginationInfo) instead")]
         Task<IPagedList<Connection>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, 
             string fields = null, bool? includeFields = null, string name = null, string[] strategy = null);
+
+        /// <summary>
+        /// Retrieves every connection matching the specified strategy. All connections are retrieved if no strategy is being specified. Accepts a list of fields to include or exclude in the resulting list of connection objects.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying connections.</param>
+        /// <returns>An <see cref="IPagedList{Connection}"/> containing the list of connections.</returns>
+        Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request);
+
+        /// <summary>
+        /// Retrieves every connection matching the specified strategy. All connections are retrieved if no strategy is being specified. Accepts a list of fields to include or exclude in the resulting list of connection objects.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying connections.</param>
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{Connection}"/> containing the list of connections.</returns>
+        Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, PaginationInfo pagination); 
 
         /// <summary>
         /// Retrieves every connection matching the specified strategy. All connections are retrieved if no strategy is being specified. Accepts a list of fields to include or exclude in the resulting list of connection objects.

--- a/src/Auth0.ManagementApi/Clients/ILogsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ILogsClient.cs
@@ -1,4 +1,5 @@
-﻿using Auth0.Core.Collections;
+﻿using System;
+using Auth0.Core.Collections;
 using System.Threading.Tasks;
 using Auth0.ManagementApi.Models;
 
@@ -25,8 +26,24 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="take">The total amount of entries to retrieve when using the from parameter. Default: 50. Max value: 100</param>
         /// <param name="q">Query in Lucene query string syntax.</param>
         /// <returns></returns>
+        [Obsolete("Use GetAllAsync(GetLogsRequest) or GetAllAsync(GetLogsRequest,PaginationInfo) instead")]
         Task<IPagedList<LogEntry>> GetAllAsync(int? page = null, int? perPage = null, string sort = null, string fields = null, bool? includeFields = null, 
             bool? includeTotals = null, string from = null, int? take = null, string q = null);
+
+        /// <summary>
+        /// Retrieves log entries that match the specified search criteria
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying logs.</param>
+        /// <returns>An <see cref="IPagedList{LogEntry}"/> containing the list of log entries.</returns>
+        Task<IPagedList<LogEntry>> GetAllAsync(GetLogsRequest request);
+
+        /// <summary>
+        /// Retrieves log entries that match the specified search criteria
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying logs.</param>
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{LogEntry}"/> containing the list of log entries.</returns>
+        Task<IPagedList<LogEntry>> GetAllAsync(GetLogsRequest request, PaginationInfo pagination);
 
         /// <summary>
         /// Retrieves the data related to the log entry identified by id. This returns a single log entry representation as specified in the schema.

--- a/src/Auth0.ManagementApi/Clients/IResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IResourceServersClient.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
 using Auth0.Core.Collections;
 using Auth0.ManagementApi.Models;
 
@@ -9,6 +11,9 @@ namespace Auth0.ManagementApi.Clients
     /// </summary>
     public interface IResourceServersClient
     {
+        [Obsolete("Use GetAllAsync(PaginationInfo) instead")]
+        Task<System.Collections.Generic.IList<ResourceServer>> GetAllAsync();
+
         /// <summary>
         /// Creates a new resource server
         /// </summary>
@@ -24,13 +29,11 @@ namespace Auth0.ManagementApi.Clients
         Task DeleteAsync(string id);
 
         /// <summary>
-        /// Gets a list of all the client grants.
+        /// Gets a list of all the resource servers.
         /// </summary>
-        /// <param name="page">The page number. Zero based.</param>
-        /// <param name="perPage">The amount of entries per page.</param>
-        /// <param name="includeTotals">True if a query summary must be included in the result.</param>
-        /// <returns>A list of client grants</returns>
-        Task<IPagedList<ResourceServer>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null);
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>A <see cref="IPagedList{ResourceServer}"/> containing the list of resource servers.</returns>
+        Task<IPagedList<ResourceServer>> GetAllAsync(PaginationInfo pagination);
 
         /// <summary>
         /// Get a resource server by its id

--- a/src/Auth0.ManagementApi/Clients/IResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IResourceServersClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Auth0.Core.Collections;
 using Auth0.ManagementApi.Models;
 
 namespace Auth0.ManagementApi.Clients
@@ -8,8 +9,6 @@ namespace Auth0.ManagementApi.Clients
     /// </summary>
     public interface IResourceServersClient
     {
-        Task<System.Collections.Generic.IList<ResourceServer>> GetAllAsync();
-
         /// <summary>
         /// Creates a new resource server
         /// </summary>
@@ -23,6 +22,15 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="id">The id of the resource server to delete</param>
         /// <returns></returns>
         Task DeleteAsync(string id);
+
+        /// <summary>
+        /// Gets a list of all the client grants.
+        /// </summary>
+        /// <param name="page">The page number. Zero based.</param>
+        /// <param name="perPage">The amount of entries per page.</param>
+        /// <param name="includeTotals">True if a query summary must be included in the result.</param>
+        /// <returns>A list of client grants</returns>
+        Task<IPagedList<ResourceServer>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null);
 
         /// <summary>
         /// Get a resource server by its id

--- a/src/Auth0.ManagementApi/Clients/IRulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IRulesClient.cs
@@ -52,9 +52,9 @@ namespace Auth0.ManagementApi.Clients
         /// Retrieves a list of all rules.
         /// </summary>
         /// <param name="request">Specifies criteria to use when querying rules.</param>
-        /// <param name="paginationInfo">Specifies pagination info to use when requesting paged results.</param>
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <returns>An <see cref="IPagedList{Rule}"/> containing the rules</returns>
-        Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo paginationInfo);
+        Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo pagination);
 
         /// <summary>
         ///     Retrieves a rule by its ID.

--- a/src/Auth0.ManagementApi/Clients/IRulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IRulesClient.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Auth0.Core.Collections;
 using Auth0.ManagementApi.Models;
 
 namespace Auth0.ManagementApi.Clients
@@ -37,6 +38,25 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="stage">Retrieves rules that match the execution stage (defaults to login_success).</param>
         /// <returns>A list of <see cref="Rule" /> objects.</returns>
         Task<IList<Rule>> GetAllAsync(bool? enabled = null, string fields = null, bool includeFields = true, string stage = null);
+
+        /// <summary>
+        ///     Retrieves a list of all rules.
+        /// </summary>
+        /// <param name="page">The page number. Zero based.</param>
+        /// <param name="perPage">The amount of entries per page.</param>
+        /// <param name="includeTotals">True if a query summary must be included in the result.</param>
+        /// <param name="enabled">If provided retrieves rules that match the value, otherwise all rules are retrieved.</param>
+        /// <param name="fields">
+        ///     A comma separated list of fields to include or exclude (depending on
+        ///     <paramref name="includeFields" />) from the result, empty to retrieve all fields.
+        /// </param>
+        /// <param name="includeFields">
+        ///     True if the fields specified are to be included in the result, false otherwise (defaults to
+        ///     true).
+        /// </param>
+        /// <param name="stage">Retrieves rules that match the execution stage (defaults to login_success).</param>
+        /// <returns>A list of <see cref="Rule" /> objects.</returns>
+        Task<IPagedList<Rule>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, bool? enabled = null, string fields = null, bool includeFields = true, string stage = null);
 
         /// <summary>
         ///     Retrieves a rule by its ID.

--- a/src/Auth0.ManagementApi/Clients/IRulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IRulesClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Auth0.Core.Collections;
 using Auth0.ManagementApi.Models;
@@ -37,26 +38,23 @@ namespace Auth0.ManagementApi.Clients
         /// </param>
         /// <param name="stage">Retrieves rules that match the execution stage (defaults to login_success).</param>
         /// <returns>A list of <see cref="Rule" /> objects.</returns>
+        [Obsolete("Use GetAllAsync(GetRulesRequest) or GetAllAsync(GetRulesRequest, PaginationInfo) instead")]
         Task<IList<Rule>> GetAllAsync(bool? enabled = null, string fields = null, bool includeFields = true, string stage = null);
 
         /// <summary>
-        ///     Retrieves a list of all rules.
+        /// Retrieves a list of all rules.
         /// </summary>
-        /// <param name="page">The page number. Zero based.</param>
-        /// <param name="perPage">The amount of entries per page.</param>
-        /// <param name="includeTotals">True if a query summary must be included in the result.</param>
-        /// <param name="enabled">If provided retrieves rules that match the value, otherwise all rules are retrieved.</param>
-        /// <param name="fields">
-        ///     A comma separated list of fields to include or exclude (depending on
-        ///     <paramref name="includeFields" />) from the result, empty to retrieve all fields.
-        /// </param>
-        /// <param name="includeFields">
-        ///     True if the fields specified are to be included in the result, false otherwise (defaults to
-        ///     true).
-        /// </param>
-        /// <param name="stage">Retrieves rules that match the execution stage (defaults to login_success).</param>
-        /// <returns>A list of <see cref="Rule" /> objects.</returns>
-        Task<IPagedList<Rule>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, bool? enabled = null, string fields = null, bool includeFields = true, string stage = null);
+        /// <param name="request">Specifies criteria to use when querying rules.</param>
+        /// <returns>An <see cref="IPagedList{Rule}"/> containing the rules</returns>
+        Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request);
+        
+        /// <summary>
+        /// Retrieves a list of all rules.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying rules.</param>
+        /// <param name="paginationInfo">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{Rule}"/> containing the rules</returns>
+        Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo paginationInfo);
 
         /// <summary>
         ///     Retrieves a rule by its ID.

--- a/src/Auth0.ManagementApi/Clients/IUsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IUsersClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Auth0.Core.Collections;
 using Auth0.ManagementApi.Models;
@@ -54,13 +55,28 @@ namespace Auth0.ManagementApi.Clients
         ///     true.
         /// </param>
         /// <param name="q">
-        ///     Query in Lucene query string syntax. Only fields in app_metadata, user_metadata or the normalized user
-        ///     profile are searchable.
+        ///     Query in Lucene query string syntax.
         /// </param>
-        /// <param name="searchEngine">Use 'v2' if you want to try the new search engine, or 'v1' for the old search engine.</param>
+        /// <param name="searchEngine">he version of the search engine to use.</param>
         /// <returns></returns>
+        [Obsolete("Use GetAllAsync(GetUsersRequest) or GetAllAsync(GetUsersRequest, PaginationInfo) instead")]
         Task<IPagedList<User>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string sort = null, string connection = null, string fields = null,
             bool? includeFields = null, string q = null, string searchEngine = null);
+
+        /// <summary>
+        /// Lists or search for users based on criteria.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying users.</param>
+        /// <returns>An <see cref="IPagedList{GetUsersRequest}"/> containing the list of users.</returns>
+        Task<IPagedList<User>> GetAllAsync(GetUsersRequest request);
+
+        /// <summary>
+        /// Lists or search for users based on criteria.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying users.</param>
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{GetUsersRequest}"/> containing the list of users.</returns>
+        Task<IPagedList<User>> GetAllAsync(GetUsersRequest request, PaginationInfo pagination);
 
         /// <summary>
         ///     Gets a user.
@@ -86,8 +102,24 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="sort">The field to use for sorting. Use field:order where order is 1 for ascending and -1 for descending. For example date:-1</param>
         /// <param name="includeTotals">True if a query summary must be included in the result, false otherwise. Default false.</param>
         /// <returns></returns>
+        [Obsolete("Use GetLogsAsync(GetUserLogsRequest) or GetLogsAsync(GetUserLogsRequest, PaginationInfo) instead")]
         Task<IPagedList<LogEntry>> GetLogsAsync(string userId, int? page = null, int? perPage = null, string sort = null,
             bool? includeTotals = null);
+
+        /// <summary>
+        /// Retrieve every log event for a specific user.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying logs for a user.</param>
+        /// <returns>An <see cref="IPagedList{LogEntry}"/> containing the log entries for the user.</returns>
+        Task<IPagedList<LogEntry>> GetLogsAsync(GetUserLogsRequest request); 
+
+        /// <summary>
+        /// Retrieve every log event for a specific user.
+        /// </summary>
+        /// <param name="request">Specifies criteria to use when querying logs for a user.</param>
+        /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{LogEntry}"/> containing the log entries for the user.</returns>
+        Task<IPagedList<LogEntry>> GetLogsAsync(GetUserLogsRequest request, PaginationInfo pagination); 
 
         /// <summary>
         /// Gets all users by email address.

--- a/src/Auth0.ManagementApi/Clients/IUsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IUsersClient.cs
@@ -57,7 +57,11 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="q">
         ///     Query in Lucene query string syntax.
         /// </param>
-        /// <param name="searchEngine">he version of the search engine to use.</param>
+        /// <param name="searchEngine">
+        /// The version of the search engine to use.
+        /// Will default to v2 if no value is passed. Default will change to v3 on 2018/11/13.
+        /// For more info <a href="https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3">see the online documentation</a>.
+        /// </param>
         /// <returns></returns>
         [Obsolete("Use GetAllAsync(GetUsersRequest) or GetAllAsync(GetUsersRequest, PaginationInfo) instead")]
         Task<IPagedList<User>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string sort = null, string connection = null, string fields = null,

--- a/src/Auth0.ManagementApi/Clients/LogsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogsClient.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Auth0.Core.Collections;
@@ -37,6 +38,7 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="take">The total amount of entries to retrieve when using the from parameter. Default: 50. Max value: 100</param>
         /// <param name="q">Query in Lucene query string syntax.</param>
         /// <returns></returns>
+        [Obsolete("Use GetAllAsync(GetLogsRequest) or GetAllAsync(GetLogsRequest,PaginationInfo) instead")]
         public Task<IPagedList<LogEntry>> GetAllAsync(int? page = null, int? perPage = null, string sort = null,
             string fields = null, bool? includeFields = null, bool? includeTotals = null,
             string from = null, int? take = null, string q = null)
@@ -53,6 +55,47 @@ namespace Auth0.ManagementApi.Clients
                     {"from", from},
                     {"take", take?.ToString().ToLower()},
                     {"q", q}
+                }, null, new PagedListConverter<LogEntry>("logs"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<LogEntry>> GetAllAsync(GetLogsRequest request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            return Connection.GetAsync<IPagedList<LogEntry>>("logs", null,
+                new Dictionary<string, string>
+                {
+                    {"sort", request.Sort},
+                    {"fields", request.Fields},
+                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                    {"from", request.From},
+                    {"take", request.Take?.ToString().ToLower()},
+                    {"q", request.Query}
+                }, null, new PagedListConverter<LogEntry>("logs"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<LogEntry>> GetAllAsync(GetLogsRequest request, PaginationInfo pagination)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
+
+            return Connection.GetAsync<IPagedList<LogEntry>>("logs", null,
+                new Dictionary<string, string>
+                {
+                    {"sort", request.Sort},
+                    {"fields", request.Fields},
+                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                    {"from", request.From},
+                    {"take", request.Take?.ToString().ToLower()},
+                    {"q", request.Query},
+                    {"page", pagination.PageNo.ToString()},
+                    {"per_page", pagination.PerPage.ToString()},
+                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
                 }, null, new PagedListConverter<LogEntry>("logs"));
         }
 

--- a/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Auth0.Core.Collections;
 using Auth0.Core.Http;
@@ -58,15 +59,26 @@ namespace Auth0.ManagementApi.Clients
                 null, null, null);
         }
 
+        /// <summary>
+        /// Get all resource servers
+        /// </summary>
+        /// <returns>A list of <see cref="ResourceServer"/></returns>
+        [Obsolete("Use GetAllAsync(PaginationInfo) instead")]
+        public Task<IList<ResourceServer>> GetAllAsync()
+        {
+            return Connection.GetAsync<IList<ResourceServer>>("resource-servers",
+                null, null, null, null);
+        }
+
         /// <inheritdoc />
-        public Task<IPagedList<ResourceServer>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null)
+        public Task<IPagedList<ResourceServer>> GetAllAsync(PaginationInfo pagination)
         {
             return Connection.GetAsync<IPagedList<ResourceServer>>("resource-servers", null,
                 new Dictionary<string, string>
                 {
-                    {"page", page?.ToString()},
-                    {"per_page", perPage?.ToString()},
-                    {"include_totals", includeTotals?.ToString().ToLower()}
+                    {"page", pagination.PageNo.ToString()},
+                    {"per_page", pagination.PerPage.ToString()},
+                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
                 }, null, new PagedListConverter<ResourceServer>("resource_servers"));
         }
 

--- a/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Auth0.Core.Collections;
 using Auth0.Core.Http;
 using Auth0.ManagementApi.Models;
+using Auth0.ManagementApi.Serialization;
 
 namespace Auth0.ManagementApi.Clients
 {
@@ -56,14 +58,16 @@ namespace Auth0.ManagementApi.Clients
                 null, null, null);
         }
 
-        /// <summary>
-        /// Get all resource servers
-        /// </summary>
-        /// <returns>A list of <see cref="ResourceServer"/></returns>
-        public Task<IList<ResourceServer>> GetAllAsync()
+        /// <inheritdoc />
+        public Task<IPagedList<ResourceServer>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null)
         {
-            return Connection.GetAsync<IList<ResourceServer>>("resource-servers",
-                null, null, null, null);
+            return Connection.GetAsync<IPagedList<ResourceServer>>("resource-servers", null,
+                new Dictionary<string, string>
+                {
+                    {"page", page?.ToString()},
+                    {"per_page", perPage?.ToString()},
+                    {"include_totals", includeTotals?.ToString().ToLower()}
+                }, null, new PagedListConverter<ResourceServer>("resource_servers"));
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/RulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RulesClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Auth0.Core.Collections;
 using Auth0.Core.Http;
@@ -45,6 +46,7 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <inheritdoc />
+        [Obsolete("Use GetAllAsync(GetRulesRequest) or GetAllAsync(GetRulesRequest, PaginationInfo) instead")]
         public Task<IList<Rule>> GetAllAsync(bool? enabled = null, string fields = null, bool includeFields = true, string stage = null)
         {
             return Connection.GetAsync<IList<Rule>>("rules", null,
@@ -58,18 +60,39 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <inheritdoc />
-        public Task<IPagedList<Rule>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, bool? enabled = null, string fields = null, bool includeFields = true, string stage = null)
+        public Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request)
         {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
             return Connection.GetAsync<IPagedList<Rule>>("rules", null,
                 new Dictionary<string, string>
                 {
-                    {"page", page?.ToString()},
-                    {"per_page", perPage?.ToString()},
-                    {"include_totals", includeTotals?.ToString().ToLower()},
-                    {"enabled", enabled?.ToString().ToLower()},
-                    {"fields", fields},
-                    {"include_fields", includeFields.ToString().ToLower()},
-                    {"stage", stage}
+                    {"enabled", request.Enabled?.ToString().ToLower()},
+                    {"fields", request.Fields},
+                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                    {"stage", request.Stage}
+                }, null, new PagedListConverter<Rule>("rules"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo paginationInfo)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (paginationInfo == null)
+                throw new ArgumentNullException(nameof(paginationInfo));
+
+            return Connection.GetAsync<IPagedList<Rule>>("rules", null,
+                new Dictionary<string, string>
+                {
+                    {"enabled", request.Enabled?.ToString().ToLower()},
+                    {"fields", request.Fields},
+                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                    {"stage", request.Stage},
+                    {"page", paginationInfo.PageNo.ToString()},
+                    {"per_page", paginationInfo.PerPage.ToString()},
+                    {"include_totals", paginationInfo.IncludeTotals.ToString().ToLower()}
                 }, null, new PagedListConverter<Rule>("rules"));
         }
 

--- a/src/Auth0.ManagementApi/Clients/RulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RulesClient.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Auth0.Core.Collections;
 using Auth0.Core.Http;
 using Auth0.ManagementApi.Models;
+using Auth0.ManagementApi.Serialization;
 
 namespace Auth0.ManagementApi.Clients
 {
@@ -42,16 +44,7 @@ namespace Auth0.ManagementApi.Clients
             }, null);
         }
 
-        /// <summary>
-        /// Retrieves a list of all rules.
-        /// </summary>
-        /// <param name="enabled">If provided retrieves rules that match the value, otherwise all rules are retrieved.</param>
-        /// <param name="fields">A comma separated list of fields to include or exclude (depending on
-        /// <paramref name="includeFields" />) from the result, empty to retrieve all fields.</param>
-        /// <param name="includeFields">True if the fields specified are to be included in the result, false otherwise (defaults to
-        /// true).</param>
-        /// <param name="stage">Retrieves rules that match the execution stage (defaults to login_success).</param>
-        /// <returns>A list of <see cref="Rule" /> objects.</returns>
+        /// <inheritdoc />
         public Task<IList<Rule>> GetAllAsync(bool? enabled = null, string fields = null, bool includeFields = true, string stage = null)
         {
             return Connection.GetAsync<IList<Rule>>("rules", null,
@@ -62,6 +55,22 @@ namespace Auth0.ManagementApi.Clients
                     {"include_fields", includeFields.ToString().ToLower()},
                     {"stage", stage}
                 }, null, null);
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<Rule>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, bool? enabled = null, string fields = null, bool includeFields = true, string stage = null)
+        {
+            return Connection.GetAsync<IPagedList<Rule>>("rules", null,
+                new Dictionary<string, string>
+                {
+                    {"page", page?.ToString()},
+                    {"per_page", perPage?.ToString()},
+                    {"include_totals", includeTotals?.ToString().ToLower()},
+                    {"enabled", enabled?.ToString().ToLower()},
+                    {"fields", fields},
+                    {"include_fields", includeFields.ToString().ToLower()},
+                    {"stage", stage}
+                }, null, new PagedListConverter<Rule>("rules"));
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/RulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RulesClient.cs
@@ -76,12 +76,12 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <inheritdoc />
-        public Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo paginationInfo)
+        public Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo pagination)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (paginationInfo == null)
-                throw new ArgumentNullException(nameof(paginationInfo));
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
 
             return Connection.GetAsync<IPagedList<Rule>>("rules", null,
                 new Dictionary<string, string>
@@ -90,9 +90,9 @@ namespace Auth0.ManagementApi.Clients
                     {"fields", request.Fields},
                     {"include_fields", request.IncludeFields?.ToString().ToLower()},
                     {"stage", request.Stage},
-                    {"page", paginationInfo.PageNo.ToString()},
-                    {"per_page", paginationInfo.PerPage.ToString()},
-                    {"include_totals", paginationInfo.IncludeTotals.ToString().ToLower()}
+                    {"page", pagination.PageNo.ToString()},
+                    {"per_page", pagination.PerPage.ToString()},
+                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
                 }, null, new PagedListConverter<Rule>("rules"));
         }
 

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -90,6 +90,7 @@ namespace Auth0.ManagementApi.Clients
         /// profile are searchable.</param>
         /// <param name="searchEngine">Use 'v2' if you want to try the new search engine, or 'v1' for the old search engine.</param>
         /// <returns>A <see cref="IPagedList{User}"/> with the paged list of users.</returns>
+        [Obsolete("Use GetAllAsync(GetUsersRequest) or GetAllAsync(GetUsersRequest, PaginationInfo) instead")]
         public Task<IPagedList<User>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string sort = null, string connection = null, string fields = null,
             bool? includeFields = null,
             string q = null, string searchEngine = null)
@@ -109,6 +110,46 @@ namespace Auth0.ManagementApi.Clients
                 }, null, new PagedListConverter<User>("users"));
         }
 
+        /// <inheritdoc />
+        public Task<IPagedList<User>> GetAllAsync(GetUsersRequest request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            return Connection.GetAsync<IPagedList<User>>("users", null,
+                new Dictionary<string, string>
+                {
+                    {"sort", request.Sort},
+                    {"connection", request.Connection},
+                    {"fields", request.Fields},
+                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                    {"q", request.Query},
+                    {"search_engine", request.SearchEngine}
+                }, null, new PagedListConverter<User>("users"));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<User>> GetAllAsync(GetUsersRequest request, PaginationInfo pagination)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
+
+            return Connection.GetAsync<IPagedList<User>>("users", null,
+                new Dictionary<string, string>
+                {
+                    {"sort", request.Sort},
+                    {"connection", request.Connection},
+                    {"fields", request.Fields},
+                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                    {"q", request.Query},
+                    {"search_engine", request.SearchEngine},
+                    {"page", pagination.PageNo.ToString()},
+                    {"per_page", pagination.PerPage.ToString()},
+                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()},
+                }, null, new PagedListConverter<User>("users"));
+        }
 
         /// <summary>
         /// Gets a user.
@@ -142,6 +183,7 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="sort">The field to use for sorting. Use field:order where order is 1 for ascending and -1 for descending. For example date:-1</param>
         /// <param name="includeTotals">True if a query summary must be included in the result, false otherwise. Default false.</param>
         /// <returns></returns>
+        [Obsolete("Use GetLogsAsync(GetUserLogsRequest) or GetLogsAsync(GetUserLogsRequest, PaginationInfo) instead")]
         public Task<IPagedList<LogEntry>> GetLogsAsync(string userId, int? page = null, int? perPage = null, string sort = null, bool? includeTotals = null)
         {
             return Connection.GetAsync<IPagedList<LogEntry>>("users/{id}/logs",
@@ -155,6 +197,45 @@ namespace Auth0.ManagementApi.Clients
                     {"per_page", perPage?.ToString()},
                     {"sort", sort},
                     {"include_totals", includeTotals?.ToString().ToLower()}
+                }, null, new PagedListConverter<LogEntry>("logs", true));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<LogEntry>> GetLogsAsync(GetUserLogsRequest request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            return Connection.GetAsync<IPagedList<LogEntry>>("users/{id}/logs",
+                new Dictionary<string, string>
+                {
+                    {"id", request.UserId}
+                },
+                new Dictionary<string, string>
+                {
+                    {"sort", request.Sort}
+                }, null, new PagedListConverter<LogEntry>("logs", true));
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<LogEntry>> GetLogsAsync(GetUserLogsRequest request, PaginationInfo pagination)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
+
+            return Connection.GetAsync<IPagedList<LogEntry>>("users/{id}/logs",
+                new Dictionary<string, string>
+                {
+                    {"id", request.UserId}
+                },
+                new Dictionary<string, string>
+                {
+                    {"sort", request.Sort},
+                    {"page", pagination.PageNo.ToString()},
+                    {"per_page", pagination.PerPage.ToString()},
+                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
                 }, null, new PagedListConverter<LogEntry>("logs", true));
         }
 

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -74,22 +74,7 @@ namespace Auth0.ManagementApi.Clients
                 }, null);
         }
 
-        /// <summary>
-        /// Lists or search for users based on criteria.
-        /// </summary>
-        /// <param name="page">The page number. Zero based.</param>
-        /// <param name="perPage">The amount of entries per page.</param>
-        /// <param name="includeTotals">True if a query summary must be included in the result.</param>
-        /// <param name="sort">The field to use for sorting. 1 == ascending and -1 == descending</param>
-        /// <param name="connection">Connection filter.</param>
-        /// <param name="fields">A comma separated list of fields to include or exclude (depending on
-        /// <paramref name="includeFields" />) from the result, empty to retrieve all fields.</param>
-        /// <param name="includeFields">True if the fields specified are to be included in the result, false otherwise. Defaults to
-        /// true.</param>
-        /// <param name="q">Query in Lucene query string syntax. Only fields in app_metadata, user_metadata or the normalized user
-        /// profile are searchable.</param>
-        /// <param name="searchEngine">Use 'v2' if you want to try the new search engine, or 'v1' for the old search engine.</param>
-        /// <returns>A <see cref="IPagedList{User}"/> with the paged list of users.</returns>
+        /// <inheritdoc />
         [Obsolete("Use GetAllAsync(GetUsersRequest) or GetAllAsync(GetUsersRequest, PaginationInfo) instead")]
         public Task<IPagedList<User>> GetAllAsync(int? page = null, int? perPage = null, bool? includeTotals = null, string sort = null, string connection = null, string fields = null,
             bool? includeFields = null,

--- a/src/Auth0.ManagementApi/Models/GetClientGrantsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetClientGrantsRequest.cs
@@ -1,0 +1,18 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying all client grants.
+    /// </summary>
+    public class GetClientGrantsRequest
+    {
+        /// <summary>
+        ///  URL Encoded audience of a client grant to filter.
+        /// </summary>
+        public string Audience { get; set; }
+
+        /// <summary>
+        ///  The Id of a client to filter by. 
+        /// </summary>
+        public string ClientId { get; set; }    
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetClientsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetClientsRequest.cs
@@ -1,0 +1,33 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying all clients.
+    /// </summary>
+    public class GetClientsRequest
+    {
+        /// <summary>
+        /// List of application types used to filter the returned clients.
+        /// </summary>
+        public ClientApplicationType[] AppType { get; set; } = null;
+
+        /// <summary>
+        /// A comma separated list of fields to include or exclude (depending on <see cref="IncludeFields"/>) from the result, empty to retrieve all fields.
+        /// </summary>
+        public string Fields { get; set; } = null;
+
+        /// <summary>
+        /// Specifies whether the fields specified in <see cref="Fields"/> should be included or excluded in the result.
+        /// </summary>
+        public bool? IncludeFields { get; set; } = null;
+
+        /// <summary>
+        /// Filter on the global client parameter.
+        /// </summary>
+        public bool? IsGlobal { get; set; } = null;
+
+        /// <summary>
+        /// Filter on whether or not a client is a first party client.
+        /// </summary>
+        public bool? IsFirstParty { get; set; } = null;
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetConnectionsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetConnectionsRequest.cs
@@ -1,0 +1,28 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying all connections.
+    /// </summary>
+    public class GetConnectionsRequest
+    {
+        /// <summary>
+        /// A comma separated list of fields to include or exclude (depending on <see cref="IncludeFields"/>) from the result, empty to retrieve all fields.
+        /// </summary>
+        public string Fields { get; set; } = null;
+
+        /// <summary>
+        /// Specifies whether the fields specified in <see cref="Fields"/> should be included or excluded in the result.
+        /// </summary>
+        public bool? IncludeFields { get; set; } = null;
+
+        /// <summary>
+        /// The name of the connection to retrieve.
+        /// </summary>
+        public string Name { get; set; } = null;
+
+        /// <summary>
+        /// Only retrieve connections with these strategies.
+        /// </summary>
+        public string[] Strategy { get; set; } = null;
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetLogsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetLogsRequest.cs
@@ -1,0 +1,39 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying all logs.
+    /// </summary>
+    public class GetLogsRequest
+    {
+        /// <summary>
+        /// A comma separated list of fields to include or exclude (depending on <see cref="IncludeFields"/>) from the result.
+        /// </summary>
+        public string Fields { get; set; } = null;
+
+        /// <summary>
+        /// Log Event Id to start retrieving logs. You can limit the amount of logs using the <see cref="Take"/> parameter.
+        /// </summary>
+        public string From { get; set; } = null;
+
+        /// <summary>
+        /// Specifies whether the fields specified in <see cref="Fields"/> should be included or excluded in the result.
+        /// </summary>
+        public bool? IncludeFields { get; set; } = null;
+
+        /// <summary>
+        /// Query in Lucene query string syntax.
+        /// </summary>
+        public string Query { get; set; } = null;
+
+        /// <summary>
+        /// The field to use for sorting. Use field:order where order is 1 for ascending and -1 for descending.
+        /// </summary>
+        /// <remarks>e.g. date:-1</remarks>
+        public string Sort { get; set; } = null;
+
+        /// <summary>
+        /// The total amount of entries to retrieve when using the <see cref="From"/> parameter. Default: 50. Max value: 100
+        /// </summary>
+        public int? Take { get; set; } = null;
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetRulesRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetRulesRequest.cs
@@ -1,0 +1,34 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying all rules.
+    /// </summary>
+    public class GetRulesRequest
+    {
+        /// <summary>
+        /// If provided retrieves rules that match the value, otherwise all rules are retrieved.
+        /// </summary>
+        public bool? Enabled { get; set; }
+
+        /// <summary>
+        /// A comma separated list of fields to include or exclude (depending on <see cref="IncludeFields"/>) from the result, empty to retrieve all fields.
+        /// </summary>
+        public string Fields { get; set; }
+
+        /// <summary>
+        /// True if the fields specified are to be included in the result, false otherwise.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to true.
+        /// </remarks>
+        public bool? IncludeFields { get; set; }
+
+        /// <summary>
+        /// Retrieves rules that match the execution stage.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to login_success.
+        /// </remarks>
+        public string Stage { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetUserLogsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetUserLogsRequest.cs
@@ -1,0 +1,21 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying logs for a user.
+    /// </summary>
+    public class GetUserLogsRequest
+    {
+        /// <summary>
+        /// The field to use for sorting.
+        /// </summary>
+        /// <remarks>
+        /// Use field:order where order is 1 for ascending and -1 for descending. For example date:-1
+        /// </remarks>
+        public string Sort { get; set; } = null;
+
+        /// <summary>
+        /// The user id of the user whose logs should be retrieved.
+        /// </summary>
+        public string UserId { get; set; } = null;
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetUsersRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetUsersRequest.cs
@@ -1,0 +1,41 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying all users.
+    /// </summary>
+    public class GetUsersRequest
+    {
+        /// <summary>
+        /// The connection to filter on.
+        /// </summary>
+        public string Connection { get; set; } = null;
+
+        /// <summary>
+        /// A comma separated list of fields to include or exclude (depending on <see cref="IncludeFields"/>) from the result, empty to retrieve all fields.
+        /// </summary>
+        public string Fields { get; set; } = null;
+
+        /// <summary>
+        /// Specifies whether the fields specified in <see cref="Fields"/> should be included or excluded in the result.
+        /// </summary>
+        public bool? IncludeFields { get; set; } = null;
+
+        /// <summary>
+        /// Query in Lucene query string syntax.
+        /// </summary>
+        /// <remarks>
+        /// Not all metadata fields are searchable when using search engine v2. When using search engine v3, some query types cannot be used on metadata fields.
+        /// </remarks>
+        public string Query { get; set; } = null;
+
+        /// <summary>
+        /// The version of the search engine to use.
+        /// </summary>
+        public string SearchEngine { get; set; } = null;
+
+        /// <summary>
+        /// The field to use for sorting. 1 == ascending and -1 == descending.
+        /// </summary>
+        public string Sort { get; set; } = null;
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetUsersRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetUsersRequest.cs
@@ -31,6 +31,10 @@
         /// <summary>
         /// The version of the search engine to use.
         /// </summary>
+        /// <remarks>
+        /// Will default to v2 if no value is passed. Default will change to v3 on 2018/11/13.
+        /// For more info <a href="https://auth0.com/docs/users/search/v3#migrate-from-search-engine-v2-to-v3">see the online documentation</a>.
+        /// </remarks>
         public string SearchEngine { get; set; } = null;
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Models/PaginationInfo.cs
+++ b/src/Auth0.ManagementApi/Models/PaginationInfo.cs
@@ -1,0 +1,39 @@
+﻿using System;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies pagination info to use when requesting paged results.
+    /// </summary>
+    public class PaginationInfo
+    {
+        public PaginationInfo()
+        {
+            PageNo = 0;
+            PerPage = 50;
+            IncludeTotals = false;
+        }
+
+        public PaginationInfo(int pageNo, int perPage, bool includeTotals)
+        {
+            IncludeTotals = includeTotals;
+            PerPage = perPage;
+            PageNo = pageNo;
+        }
+
+        /// <summary>
+        /// True if a query summary must be included in the result, False otherwise.
+        /// </summary>
+        public bool IncludeTotals { get; }
+        
+        /// <summary>
+        /// The amount of entries per page. 
+        /// </summary>
+        public int PerPage { get; }
+
+        /// <summary>
+        /// The page number to request. Zero based. 
+        /// </summary>
+        public int PageNo { get; }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
@@ -68,7 +68,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_client_credentials_crud_sequence()
         {
             // Get all the current client grants
-            var clientGrantsBefore = await _apiClient.ClientGrants.GetAllAsync();
+            var clientGrantsBefore = await _apiClient.ClientGrants.GetAllAsync(null, null);
 
             // Add a new client grant
             var newClientGrantRequest = new ClientGrantCreateRequest
@@ -87,7 +87,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 options => options.Excluding(cg => cg.Id));
 
             // Get all the client grants again, and verify we have one more
-            var clientGrantsAfter = await _apiClient.ClientGrants.GetAllAsync();
+            var clientGrantsAfter = await _apiClient.ClientGrants.GetAllAsync(null, null);
             clientGrantsAfter.Count.Should().Be(clientGrantsBefore.Count + 1);
 
             // Update the client grant
@@ -106,6 +106,26 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Delete the client grant
             await _apiClient.ClientGrants.DeleteAsync(newClientGrantResponse.Id);
+        }
+
+        [Fact]
+        public async Task Test_paging_does_not_include_totals()
+        {
+            // Act
+            var grants = await _apiClient.ClientGrants.GetAllAsync(page: 0, perPage: 50, includeTotals: false);
+            
+            // Assert
+            Assert.Null(grants.Paging);
+        }
+
+        [Fact]
+        public async Task Test_paging_includes_totals()
+        {
+            // Act
+            var grants = await _apiClient.ClientGrants.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
+            
+            // Assert
+            Assert.NotNull(grants.Paging);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
@@ -68,7 +68,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_client_credentials_crud_sequence()
         {
             // Get all the current client grants
-            var clientGrantsBefore = await _apiClient.ClientGrants.GetAllAsync(null, null);
+            var clientGrantsBefore = await _apiClient.ClientGrants.GetAllAsync(new GetClientGrantsRequest());
 
             // Add a new client grant
             var newClientGrantRequest = new ClientGrantCreateRequest
@@ -87,7 +87,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 options => options.Excluding(cg => cg.Id));
 
             // Get all the client grants again, and verify we have one more
-            var clientGrantsAfter = await _apiClient.ClientGrants.GetAllAsync(null, null);
+            var clientGrantsAfter = await _apiClient.ClientGrants.GetAllAsync(new GetClientGrantsRequest());
             clientGrantsAfter.Count.Should().Be(clientGrantsBefore.Count + 1);
 
             // Update the client grant
@@ -109,10 +109,20 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
+        public async Task Test_when_paging_not_specified_does_not_include_totals()
+        {
+            // Act
+            var grants = await _apiClient.ClientGrants.GetAllAsync(new GetClientGrantsRequest());
+            
+            // Assert
+            Assert.Null(grants.Paging);
+        }
+
+        [Fact]
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var grants = await _apiClient.ClientGrants.GetAllAsync(page: 0, perPage: 50, includeTotals: false);
+            var grants = await _apiClient.ClientGrants.GetAllAsync(new GetClientGrantsRequest(), new PaginationInfo(0, 50, false));
             
             // Assert
             Assert.Null(grants.Paging);
@@ -122,7 +132,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var grants = await _apiClient.ClientGrants.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
+            var grants = await _apiClient.ClientGrants.GetAllAsync(new GetClientGrantsRequest(), new PaginationInfo(0, 50, true));
             
             // Assert
             Assert.NotNull(grants.Paging);

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -108,12 +108,33 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
-        public async Task Test_pagination_totals_deserialize_correctly()
+        public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
-            var connections = await _apiClient.Clients.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
+            // Act
+            var clients = await _apiClient.Clients.GetAllAsync(new GetClientsRequest());
+            
+            // Assert
+            Assert.Null(clients.Paging);
+        }
 
-            connections.Should().NotBeNull();
-            connections.Paging.Should().NotBeNull();
+        [Fact]
+        public async Task Test_paging_does_not_include_totals()
+        {
+            // Act
+            var clients = await _apiClient.Clients.GetAllAsync(new GetClientsRequest(), new PaginationInfo(0, 50, false));
+            
+            // Assert
+            Assert.Null(clients.Paging);
+        }
+
+        [Fact]
+        public async Task Test_paging_includes_totals()
+        {
+            // Act
+            var clients = await _apiClient.Clients.GetAllAsync(new GetClientsRequest(), new PaginationInfo(0, 50, true));
+            
+            // Assert
+            Assert.NotNull(clients.Paging);
         }
 
         [Fact]
@@ -135,7 +156,10 @@ namespace Auth0.ManagementApi.IntegrationTests
             var newClientResponse = await _apiClient.Clients.CreateAsync(newClientRequest);
           
             // Rotate the secret
-            var connections = await _apiClient.Clients.GetAllAsync(appType: new ClientApplicationType[] { ClientApplicationType.Native });
+            var connections = await _apiClient.Clients.GetAllAsync(new GetClientsRequest
+            {
+                AppType = new[] {ClientApplicationType.Native}
+            });
 
             // Assert
             connections.Count.Should().BeGreaterThan(0);

--- a/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
@@ -28,7 +28,10 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_connection_crud_sequence()
         {
             // Get all connections before
-            var connectionsBefore = await _apiClient.Connections.GetAllAsync(strategy: new[] {"github"});
+            var connectionsBefore = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            {
+                Strategy = new[] {"github"}
+            });
 
             // Create a new connection
             var newConnectionRequest = new ConnectionCreateRequest
@@ -42,7 +45,10 @@ namespace Auth0.ManagementApi.IntegrationTests
             newConnectionResponse.Strategy.Should().Be(newConnectionRequest.Strategy);
 
             // Get all connections again
-            var connectionsAfter = await _apiClient.Connections.GetAllAsync(strategy: new[] {"github"});
+            var connectionsAfter = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            {
+                Strategy = new[] {"github"}
+            });
             connectionsAfter.Count.Should().Be(connectionsBefore.Count + 1);
 
             // Update a connection
@@ -74,13 +80,33 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
         
         [Fact]
-        public async Task Test_pagination_totals_deserialize_correctly()
+        public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
-            var connections = await _apiClient.Connections.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
-
-            connections.Should().NotBeNull();
-            connections.Paging.Should().NotBeNull();
+            // Act
+            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest());
+            
+            // Assert
+            Assert.Null(connections.Paging);
         }
 
+        [Fact]
+        public async Task Test_paging_does_not_include_totals()
+        {
+            // Act
+            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, false));
+            
+            // Assert
+            Assert.Null(connections.Paging);
+        }
+
+        [Fact]
+        public async Task Test_paging_includes_totals()
+        {
+            // Act
+            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, true));
+            
+            // Assert
+            Assert.NotNull(connections.Paging);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using Xunit;
 using FluentAssertions;
@@ -25,7 +26,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Can_fetch_single_entry()
         {
             // Get all log entries
-            var logEntries = await _apiClient.Logs.GetAllAsync();
+            var logEntries = await _apiClient.Logs.GetAllAsync(new GetLogsRequest());
 
             // Grab the first one
             var firstLogEntry = logEntries[0];
@@ -37,25 +38,34 @@ namespace Auth0.ManagementApi.IntegrationTests
             singleLogEntry.ShouldBeEquivalentTo(firstLogEntry);
         }
 
-
         [Fact]
-        public async Task Test_deserialization_without_totals()
+        public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
-            //var logEntries = await _apiClient.Users.GetLogsAsync("auth0|920042612b924ddba6ede57663fedce7");
-            var logEntries = await _apiClient.Logs.GetAllAsync();
+            // Act
+            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest());
             
-            logEntries.Should().NotBeNull();
-            logEntries.Paging.Should().BeNull();
+            // Assert
+            Assert.Null(logs.Paging);
         }
 
         [Fact]
-        public async Task Test_deserialization_with_totals()
+        public async Task Test_paging_does_not_include_totals()
         {
-            //var logEntries = await _apiClient.Users.GetLogsAsync("auth0|920042612b924ddba6ede57663fedce7", includeTotals: true);
-            var logEntries = await _apiClient.Logs.GetAllAsync(includeTotals: true);
+            // Act
+            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, false));
+            
+            // Assert
+            Assert.Null(logs.Paging);
+        }
 
-            logEntries.Should().NotBeNull();
-            logEntries.Paging.Should().NotBeNull();
+        [Fact]
+        public async Task Test_paging_includes_totals()
+        {
+            // Act
+            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, true));
+            
+            // Assert
+            Assert.NotNull(logs.Paging);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
@@ -88,20 +88,20 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var grants = await _apiClient.ResourceServers.GetAllAsync(page: 0, perPage: 50, includeTotals: false);
+            var resourceServers = await _apiClient.ResourceServers.GetAllAsync(new PaginationInfo(0, 50, false));
             
             // Assert
-            Assert.Null(grants.Paging);
+            Assert.Null(resourceServers.Paging);
         }
 
         [Fact]
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var grants = await _apiClient.ResourceServers.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
+            var resourceServers = await _apiClient.ResourceServers.GetAllAsync(new PaginationInfo(0, 50, true));
             
             // Assert
-            Assert.NotNull(grants.Paging);
+            Assert.NotNull(resourceServers.Paging);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
@@ -9,14 +9,25 @@ using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class ResourceServerTests : TestBase
+    public class ResourceServerTests : TestBase, IAsyncLifetime
     {
-        [Fact]
-        public async Task Test_resource_server_crud_sequence()
+        private ManagementApiClient _apiClient;
+
+        public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            var apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
+            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task Test_resource_server_crud_sequence()
+        {
 
             // Add a new resource server
             var identifier = Guid.NewGuid();
@@ -36,7 +47,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 }
             };
-            var newResourceServerResponse = await apiClient.ResourceServers.CreateAsync(newResourceServerRequest);
+            var newResourceServerResponse = await _apiClient.ResourceServers.CreateAsync(newResourceServerRequest);
             newResourceServerResponse.ShouldBeEquivalentTo(newResourceServerRequest, options => options.Excluding(rs => rs.Id));
 
             // Update the resource server
@@ -60,17 +71,37 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 }
             };
-            var updateResourceServerResponse = await apiClient.ResourceServers.UpdateAsync(newResourceServerResponse.Id, resourceServerRequest);
+            var updateResourceServerResponse = await _apiClient.ResourceServers.UpdateAsync(newResourceServerResponse.Id, resourceServerRequest);
             updateResourceServerResponse.ShouldBeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
 
             // Get a single resource server
-            var resourceServer = await apiClient.ResourceServers.GetAsync(newResourceServerResponse.Id);
+            var resourceServer = await _apiClient.ResourceServers.GetAsync(newResourceServerResponse.Id);
             resourceServer.ShouldBeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
 
             // Delete the client, and ensure we get exception when trying to fetch client again
-            await apiClient.ResourceServers.DeleteAsync(resourceServer.Id);
-            Func<Task> getFunc = async () => await apiClient.ResourceServers.GetAsync(resourceServer.Id);
+            await _apiClient.ResourceServers.DeleteAsync(resourceServer.Id);
+            Func<Task> getFunc = async () => await _apiClient.ResourceServers.GetAsync(resourceServer.Id);
             getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_resource_server");
+        }
+        
+        [Fact]
+        public async Task Test_paging_does_not_include_totals()
+        {
+            // Act
+            var grants = await _apiClient.ResourceServers.GetAllAsync(page: 0, perPage: 50, includeTotals: false);
+            
+            // Assert
+            Assert.Null(grants.Paging);
+        }
+
+        [Fact]
+        public async Task Test_paging_includes_totals()
+        {
+            // Act
+            var grants = await _apiClient.ResourceServers.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
+            
+            // Assert
+            Assert.NotNull(grants.Paging);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
@@ -8,17 +8,27 @@ using Auth0.Tests.Shared;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class RulesTests : TestBase
+    public class RulesTests : TestBase, IAsyncLifetime
     {
-        [Fact]
-        public async Task Test_rules_crud_sequence()
+        private ManagementApiClient _apiClient;
+
+        public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            var apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
+            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
+        }
 
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task Test_rules_crud_sequence()
+        {
             // Get all rules
-            var rulesBefore = await apiClient.Rules.GetAllAsync();
+            var rulesBefore = await _apiClient.Rules.GetAllAsync(null, null, null, null);
 
             // Add a new rule
             var newRuleRequest = new RuleCreateRequest
@@ -29,12 +39,12 @@ namespace Auth0.ManagementApi.IntegrationTests
                               callback(null, user, context);
                             }"
             };
-            var newRuleResponse = await apiClient.Rules.CreateAsync(newRuleRequest);
+            var newRuleResponse = await _apiClient.Rules.CreateAsync(newRuleRequest);
             newRuleResponse.Should().NotBeNull();
             newRuleResponse.Name.Should().Be(newRuleRequest.Name);
 
             // Get all the rules again, and check that we now have one more
-            var rulesAfter = await apiClient.Rules.GetAllAsync();
+            var rulesAfter = await _apiClient.Rules.GetAllAsync(null, null, null, null);
             rulesAfter.Count.Should().Be(rulesBefore.Count + 1);
 
             // Update the Rule
@@ -42,19 +52,39 @@ namespace Auth0.ManagementApi.IntegrationTests
             {
                 Name = $"integration-test-rule-{Guid.NewGuid():N}"
             };
-            var updateRuleResponse = await apiClient.Rules.UpdateAsync(newRuleResponse.Id, updateRuleRequest);
+            var updateRuleResponse = await _apiClient.Rules.UpdateAsync(newRuleResponse.Id, updateRuleRequest);
             updateRuleResponse.Should().NotBeNull();
             updateRuleResponse.Name.Should().Be(updateRuleRequest.Name);
 
             // Get a single rule
-            var rule = await apiClient.Rules.GetAsync(newRuleResponse.Id);
+            var rule = await _apiClient.Rules.GetAsync(newRuleResponse.Id);
             rule.Should().NotBeNull();
             rule.Name.Should().Be(updateRuleRequest.Name);
 
             // Delete the rule, and ensure we get exception when trying to fetch it again
-            await apiClient.Rules.DeleteAsync(rule.Id);
-            Func<Task> getFunc = async () => await apiClient.Rules.GetAsync(rule.Id);
+            await _apiClient.Rules.DeleteAsync(rule.Id);
+            Func<Task> getFunc = async () => await _apiClient.Rules.GetAsync(rule.Id);
             getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_rule");
+        }
+        
+        [Fact]
+        public async Task Test_paging_does_not_include_totals()
+        {
+            // Act
+            var grants = await _apiClient.Rules.GetAllAsync(page: 0, perPage: 50, includeTotals: false);
+            
+            // Assert
+            Assert.Null(grants.Paging);
+        }
+
+        [Fact]
+        public async Task Test_paging_includes_totals()
+        {
+            // Act
+            var grants = await _apiClient.Rules.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
+            
+            // Assert
+            Assert.NotNull(grants.Paging);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
@@ -28,7 +28,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_rules_crud_sequence()
         {
             // Get all rules
-            var rulesBefore = await _apiClient.Rules.GetAllAsync(null, null, null, null);
+            var rulesBefore = await _apiClient.Rules.GetAllAsync(new GetRulesRequest());
 
             // Add a new rule
             var newRuleRequest = new RuleCreateRequest
@@ -44,7 +44,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             newRuleResponse.Name.Should().Be(newRuleRequest.Name);
 
             // Get all the rules again, and check that we now have one more
-            var rulesAfter = await _apiClient.Rules.GetAllAsync(null, null, null, null);
+            var rulesAfter = await _apiClient.Rules.GetAllAsync(new GetRulesRequest());
             rulesAfter.Count.Should().Be(rulesBefore.Count + 1);
 
             // Update the Rule
@@ -68,23 +68,33 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
         
         [Fact]
+        public async Task Test_when_paging_not_specified_does_not_include_totals()
+        {
+            // Act
+            var rules = await _apiClient.Rules.GetAllAsync(new GetRulesRequest());
+            
+            // Assert
+            Assert.Null(rules.Paging);
+        }
+
+        [Fact]
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var grants = await _apiClient.Rules.GetAllAsync(page: 0, perPage: 50, includeTotals: false);
+            var rules = await _apiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo(0, 50, false));
             
             // Assert
-            Assert.Null(grants.Paging);
+            Assert.Null(rules.Paging);
         }
 
         [Fact]
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var grants = await _apiClient.Rules.GetAllAsync(page: 0, perPage: 50, includeTotals: true);
+            var rules = await _apiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo(0, 50, true));
             
             // Assert
-            Assert.NotNull(grants.Paging);
+            Assert.NotNull(rules.Paging);
         }
     }
 }


### PR DESCRIPTION
This PR implements Phase 2 of adding pagination to Management API endpoints. Done in this PR are:

[x] Client Grants
[ ] User Grants
[x] Resource Servers
[x] Rules

`IClientGrantsClient` and `IRulesClient` has introduced breaking changes because previously all parameters were also optional. So not passing any parameters will throw

```
[CS0121] The call is ambiguous between the following methods or properties: 'IClientGrantsClient.GetAllAsync(string, string)' and 'IClientGrantsClient.GetAllAsync(int?, int?, bool?, string, string)'
```

Need to discuss how to handle this. One way is to simply append paging parameters to previous `GetAllAsync` method and change the return type of that method to `Task<IPagedList<T>>`. Since `IPagedList<T>` inherits from `IList<T>` this should not break any code. The only problem with this is that we will be inconsistent with other paged methods where the paging parameters occur as the first set of parameters

**Edit**: Also see extra comments below for additional thoughts