### PR TITLE
Possibility to add an auth0-forwarded-for header to ROPC token requests

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -372,7 +372,14 @@ namespace Auth0.AuthenticationApi
                 parameters.Add("realm", request.Realm);
             }
 
-            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, null, null);
+            var headers = new Dictionary<string, object>();
+
+            if (!string.IsNullOrEmpty(request.ForwardedForIp))
+            {
+                headers.Add("auth0-forwarded-for", request.ForwardedForIp);
+            }
+
+            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, headers, null);
         }
 
         /// <inheritdoc />

--- a/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
@@ -39,5 +39,10 @@
         /// Gets or sets the username.
         /// </summary>
         public string Username { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ip of the end user this token is requested for
+        /// </summary>
+        public string ForwardedForIp { get; set; }
     }
 }


### PR DESCRIPTION
The current option to add a auth0-forwarded-for header to ROPC token requests, is to implement a custom Http​Message​Handler and overriding SendAsync. However, this removes the possibility to provide a reusable HttpClient. Since this header is an official feature of ROPC token requests, I think it is ok to add the option of using it to the ResourceOwnerTokenRequest.

I looked for any tests that should be adapted for this change, but could not find any. Please point me in the right direction if any more work needs to be done.