### PR TITLE
ID Token validation

### DIFF
--- a/.idea/.idea.Auth0.Net/.idea/contentModel.xml
+++ b/.idea/.idea.Auth0.Net/.idea/contentModel.xml
@@ -24,7 +24,11 @@
             <e p="UrlBuilderBase.cs" t="Include" />
             <e p="WsFedUrlBuilder.cs" t="Include" />
           </e>
+          <e p="Exceptions" t="Include">
+            <e p="IdentityTokenValidationException.cs" t="Include" />
+          </e>
           <e p="IAuthenticationApiClient.cs" t="Include" />
+          <e p="IdentityTokenValidator.cs" t="Include" />
           <e p="Models" t="Include">
             <e p="AccessTokenResponse.cs" t="Include" />
             <e p="AuthorizationCodePkceTokenRequest.cs" t="Include" />

--- a/.idea/.idea.Auth0.Net/.idea/contentModel.xml
+++ b/.idea/.idea.Auth0.Net/.idea/contentModel.xml
@@ -66,6 +66,7 @@
               </e>
             </e>
           </e>
+          <e p="OpenIdConfigurationCache.cs" t="Include" />
         </e>
         <e p="Auth0.Core" t="IncludeRecursive">
           <e p="ApiError.cs" t="Include" />

--- a/.idea/.idea.Auth0.Net/.idea/contentModel.xml
+++ b/.idea/.idea.Auth0.Net/.idea/contentModel.xml
@@ -289,6 +289,7 @@
           <e p="bin" t="ExcludeRecursive" />
           <e p="client-secrets.json" t="Include" />
           <e p="DatabaseConnectionTests.cs" t="Include" />
+          <e p="IdentityTokenValidatorTests.cs" t="Include" />
           <e p="ImpersonationTests.cs" t="Include" />
           <e p="MetadataTests.cs" t="Include" />
           <e p="obj" t="ExcludeRecursive">
@@ -299,6 +300,7 @@
               </e>
             </e>
           </e>
+          <e p="OpenIdConfigurationCacheTests.cs" t="Include" />
           <e p="PasswordlessTests.cs" t="Include" />
           <e p="TokenTests.cs" t="Include" />
           <e p="UriBuildersTests.cs" t="Include" />

--- a/.idea/.idea.Auth0.Net/.idea/contentModel.xml
+++ b/.idea/.idea.Auth0.Net/.idea/contentModel.xml
@@ -54,7 +54,7 @@
               <e p="net452" t="Include">
                 <e p="Auth0.AuthenticationApi.AssemblyInfo.cs" t="Include" />
               </e>
-              <e p="netstandard1.1" t="Include">
+              <e p="netstandard1.4" t="Include">
                 <e p="Auth0.AuthenticationApi.AssemblyInfo.cs" t="Include" />
               </e>
               <e p="netstandard2.0" t="Include">
@@ -93,7 +93,7 @@
               <e p="net452" t="Include">
                 <e p="Auth0.Core.AssemblyInfo.cs" t="Include" />
               </e>
-              <e p="netstandard1.1" t="Include">
+              <e p="netstandard1.4" t="Include">
                 <e p="Auth0.Core.AssemblyInfo.cs" t="Include" />
               </e>
               <e p="netstandard2.0" t="Include">
@@ -263,7 +263,7 @@
               <e p="net452" t="Include">
                 <e p="Auth0.ManagementApi.AssemblyInfo.cs" t="Include" />
               </e>
-              <e p="netstandard1.1" t="Include">
+              <e p="netstandard1.4" t="Include">
                 <e p="Auth0.ManagementApi.AssemblyInfo.cs" t="Include" />
               </e>
               <e p="netstandard2.0" t="Include">

--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -2,25 +2,20 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Auth0.AuthenticationApi</AssemblyTitle>
-    <TargetFrameworks>net452;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Auth0.AuthenticationApi</AssemblyName>
     <PackageId>Auth0.AuthenticationApi</PackageId>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.1\Auth0.AuthenticationApi.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard2.0\Auth0.AuthenticationApi.xml</DocumentationFile>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-
 </Project>

--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -18,4 +18,8 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.4" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
+  </ItemGroup>
 </Project>

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -250,9 +250,9 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="request">The <see cref="AuthorizationCodeTokenRequest"/> containing the information of the request.</param>
         /// <returns>An <see cref="AccessTokenResponse"/> containing the token information</returns>
-        public Task<AccessTokenResponse> GetTokenAsync(AuthorizationCodeTokenRequest request)
+        public async Task<AccessTokenResponse> GetTokenAsync(AuthorizationCodeTokenRequest request)
         {
-            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
+            var response = await Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
             {
                 {"grant_type", "authorization_code"},
                 {"client_id", request.ClientId},
@@ -264,6 +264,11 @@ namespace Auth0.AuthenticationApi
                 null,
                 null,
                 null);
+
+            IdentityTokenValidator validator = new IdentityTokenValidator();
+            await validator.ValidateAsync(response.IdToken, _baseUri.AbsoluteUri, request.ClientId);
+
+            return response;
         }
 
         /// <summary>
@@ -271,9 +276,9 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="request">The <see cref="AuthorizationCodePkceTokenRequest"/> containing the information of the request.</param>
         /// <returns>An <see cref="AccessTokenResponse"/> containing the token information</returns>
-        public Task<AccessTokenResponse> GetTokenAsync(AuthorizationCodePkceTokenRequest request)
+        public async Task<AccessTokenResponse> GetTokenAsync(AuthorizationCodePkceTokenRequest request)
         {
-            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
+            var response = await Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
             {
                 {"grant_type", "authorization_code"},
                 {"client_id", request.ClientId},
@@ -285,6 +290,11 @@ namespace Auth0.AuthenticationApi
                 null,
                 null,
                 null);
+
+            IdentityTokenValidator validator = new IdentityTokenValidator();
+            await validator.ValidateAsync(response.IdToken, _baseUri.AbsoluteUri, request.ClientId);
+
+            return response;
         }
 
         /// <summary>
@@ -292,9 +302,9 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="request">The <see cref="ClientCredentialsTokenRequest"/> containing the information of the request.</param>
         /// <returns>An <see cref="AccessTokenResponse"/> containing the token information</returns>
-        public Task<AccessTokenResponse> GetTokenAsync(ClientCredentialsTokenRequest request)
+        public async Task<AccessTokenResponse> GetTokenAsync(ClientCredentialsTokenRequest request)
         {
-            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
+            var response = await Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
                 {
                     {"grant_type", "client_credentials"},
                     {"client_id", request.ClientId},
@@ -305,6 +315,11 @@ namespace Auth0.AuthenticationApi
                 null,
                 null,
                 null);
+
+            IdentityTokenValidator validator = new IdentityTokenValidator();
+            await validator.ValidateAsync(response.IdToken, _baseUri.AbsoluteUri, request.ClientId);
+
+            return response;
         }
 
         /// <summary>
@@ -312,7 +327,7 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="request">The refresh token request details, containing a valid refresh token.</param>
         /// <returns>The new token issued by the server.</returns>
-        public Task<AccessTokenResponse> GetTokenAsync(RefreshTokenRequest request)
+        public async Task<AccessTokenResponse> GetTokenAsync(RefreshTokenRequest request)
         {
             var parameters = new Dictionary<string, object> {
                 { "grant_type", "refresh_token" },
@@ -330,7 +345,12 @@ namespace Auth0.AuthenticationApi
             {
                 parameters.Add("scope", request.Scope);
             }
-            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, null, null);
+            var response = await Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, null, null);
+            
+            IdentityTokenValidator validator = new IdentityTokenValidator();
+            await validator.ValidateAsync(response.IdToken, _baseUri.AbsoluteUri, request.ClientId);
+
+            return response;
         }
 
         /// <summary>
@@ -342,7 +362,7 @@ namespace Auth0.AuthenticationApi
         /// The grant_type parameter required by the /oauth/token endpoint will automatically be inferred from the <paramref name="request"/> parameter. If no Realm was specified,
         /// then the grant_type will be set to "password". If a Realm was specified, then the grant_type will be set to "http://auth0.com/oauth/grant-type/password-realm"
         /// </remarks>
-        public Task<AccessTokenResponse> GetTokenAsync(ResourceOwnerTokenRequest request)
+        public async Task<AccessTokenResponse> GetTokenAsync(ResourceOwnerTokenRequest request)
         {
             var parameters = new Dictionary<string, object>
             {
@@ -373,13 +393,17 @@ namespace Auth0.AuthenticationApi
             }
 
             var headers = new Dictionary<string, object>();
-
             if (!string.IsNullOrEmpty(request.ForwardedForIp))
             {
                 headers.Add("auth0-forwarded-for", request.ForwardedForIp);
             }
 
-            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, headers, null);
+            var response = await Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, headers, null);
+            
+            IdentityTokenValidator validator = new IdentityTokenValidator();
+            await validator.ValidateAsync(response.IdToken, _baseUri.AbsoluteUri, request.ClientId);
+
+            return response;
         }
 
         /// <inheritdoc />

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -372,7 +372,14 @@ namespace Auth0.AuthenticationApi
                 parameters.Add("realm", request.Realm);
             }
 
-            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, null, null);
+            var headers = new Dictionary<string, object>();
+
+            if (!string.IsNullOrEmpty(request.ForwardedForIp))
+            {
+                headers.Add("auth0-forwarded-for", request.ForwardedForIp);
+            }
+
+            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, parameters, null, null, headers, null);
         }
 
         /// <inheritdoc />

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -302,9 +302,9 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="request">The <see cref="ClientCredentialsTokenRequest"/> containing the information of the request.</param>
         /// <returns>An <see cref="AccessTokenResponse"/> containing the token information</returns>
-        public async Task<AccessTokenResponse> GetTokenAsync(ClientCredentialsTokenRequest request)
+        public Task<AccessTokenResponse> GetTokenAsync(ClientCredentialsTokenRequest request)
         {
-            var response = await Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
+            return Connection.PostAsync<AccessTokenResponse>("oauth/token", null, new Dictionary<string, object>
                 {
                     {"grant_type", "client_credentials"},
                     {"client_id", request.ClientId},
@@ -315,11 +315,6 @@ namespace Auth0.AuthenticationApi
                 null,
                 null,
                 null);
-
-            IdentityTokenValidator validator = new IdentityTokenValidator();
-            await validator.ValidateAsync(response.IdToken, _baseUri.AbsoluteUri, request.ClientId);
-
-            return response;
         }
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/Exceptions/IdentityTokenValidationException.cs
+++ b/src/Auth0.AuthenticationApi/Exceptions/IdentityTokenValidationException.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Auth0.AuthenticationApi.Exceptions
+{
+    public class IdentityTokenValidationException: Exception
+    {
+        public IdentityTokenValidationException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Auth0.AuthenticationApi/IdentityTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/IdentityTokenValidator.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Auth0.AuthenticationApi.Exceptions;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
+
+[assembly: InternalsVisibleTo("Auth0.AuthenticationApi.IntegrationTests")]
 
 namespace Auth0.AuthenticationApi
 {

--- a/src/Auth0.AuthenticationApi/IdentityTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/IdentityTokenValidator.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.IdentityModel.Tokens.Jwt;
-using System.Threading;
 using System.Threading.Tasks;
 using Auth0.AuthenticationApi.Exceptions;
-using Microsoft.IdentityModel.Protocols;
 using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 using Microsoft.IdentityModel.Tokens;
 
@@ -13,6 +11,9 @@ namespace Auth0.AuthenticationApi
     {
         public async Task ValidateAsync(string identityToken, string domain, string audience)
         {
+            if (string.IsNullOrEmpty(identityToken))
+                return;
+
             JwtSecurityToken token;
             
             var handler = new JwtSecurityTokenHandler();
@@ -34,8 +35,7 @@ namespace Auth0.AuthenticationApi
             {
                 try
                 {
-                    IConfigurationManager<OpenIdConnectConfiguration> configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>($"{domain}.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
-                    OpenIdConnectConfiguration openIdConfig = await configurationManager.GetConfigurationAsync(CancellationToken.None);
+                    OpenIdConnectConfiguration openIdConfig = await OpenIdConfigurationCache.Instance.GetAsync(domain);
                 
                     TokenValidationParameters validationParameters =
                         new TokenValidationParameters

--- a/src/Auth0.AuthenticationApi/IdentityTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/IdentityTokenValidator.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.AuthenticationApi.Exceptions;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AuthenticationApi
+{
+    public class IdentityTokenValidator
+    {
+        public async Task ValidateAsync(string identityToken, string domain, string audience)
+        {
+            JwtSecurityToken token;
+            
+            var handler = new JwtSecurityTokenHandler();
+
+            try
+            {
+                // Try and read the token
+                token = handler.ReadJwtToken(identityToken);
+            }
+            catch (Exception e)
+            {
+                throw new IdentityTokenValidationException($"Error validating identity token: {e.ToString()}");
+            }
+
+            // Determine the algorithm,
+            string algorithm = token.Header.Alg;
+
+            if (string.Equals(algorithm, "RS256", StringComparison.OrdinalIgnoreCase))
+            {
+                try
+                {
+                    IConfigurationManager<OpenIdConnectConfiguration> configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>($"{domain}.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
+                    OpenIdConnectConfiguration openIdConfig = await configurationManager.GetConfigurationAsync(CancellationToken.None);
+                
+                    TokenValidationParameters validationParameters =
+                        new TokenValidationParameters
+                        {
+                            ValidIssuer = domain,
+                            ValidAudiences = new[] {audience},
+                            IssuerSigningKeys = openIdConfig.SigningKeys
+                        };
+
+                    SecurityToken validatedToken;
+                    handler.ValidateToken(identityToken, validationParameters, out validatedToken);
+                }
+                catch (Exception e)
+                {
+                    throw new IdentityTokenValidationException($"Error validating identity token: {e.ToString()}");
+                }
+            }
+        }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
@@ -39,5 +39,10 @@
         /// Gets or sets the username.
         /// </summary>
         public string Username { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ip of the end user this token is requested for
+        /// </summary>
+        public string ForwardedForIp { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/OpenIdConfigurationCache.cs
+++ b/src/Auth0.AuthenticationApi/OpenIdConfigurationCache.cs
@@ -40,7 +40,9 @@ namespace Auth0.AuthenticationApi
 
             if (configuration == null)
             {
-                IConfigurationManager<OpenIdConnectConfiguration> configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>($"{domain}.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
+                var uri = new Uri(domain);
+                
+                IConfigurationManager<OpenIdConnectConfiguration> configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>($"{uri.AbsoluteUri}.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
                 configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
 
                 _innerCache[domain] = configuration;

--- a/src/Auth0.AuthenticationApi/OpenIdConfigurationCache.cs
+++ b/src/Auth0.AuthenticationApi/OpenIdConfigurationCache.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+
+namespace Auth0.AuthenticationApi
+{
+    internal class OpenIdConfigurationCache
+    {
+        private static volatile OpenIdConfigurationCache _instance;
+        private static readonly object SyncRoot = new object();
+
+        protected ReaderWriterLockSlim CacheLock = new ReaderWriterLockSlim(); // mutex 
+        protected Dictionary<string, OpenIdConnectConfiguration> InnerCache = new Dictionary<string, OpenIdConnectConfiguration>();
+
+        private OpenIdConfigurationCache() {}
+
+        public static OpenIdConfigurationCache Instance
+        {
+            get 
+            {
+                if (_instance == null) 
+                {
+                    lock (SyncRoot) 
+                    {
+                        if (_instance == null) 
+                            _instance = new OpenIdConfigurationCache();
+                    }
+                }
+
+                return _instance;
+            }
+        }
+
+        public async Task<OpenIdConnectConfiguration> GetAsync(string domain)
+        {
+            CacheLock.EnterReadLock();
+            try
+            {
+                InnerCache.TryGetValue(domain, out var configuration);
+
+                if (configuration == null)
+                {
+                    IConfigurationManager<OpenIdConnectConfiguration> configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>($"{domain}.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
+                    configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
+
+                    InnerCache[domain] = configuration;
+                }
+
+                return configuration;
+            }
+            finally
+            {
+                CacheLock.ExitReadLock();
+            }
+        }
+    }
+}

--- a/src/Auth0.AuthenticationApi/OpenIdConfigurationCache.cs
+++ b/src/Auth0.AuthenticationApi/OpenIdConfigurationCache.cs
@@ -42,7 +42,8 @@ namespace Auth0.AuthenticationApi
             {
                 var uri = new Uri(domain);
                 
-                IConfigurationManager<OpenIdConnectConfiguration> configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>($"{uri.AbsoluteUri}.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
+                IConfigurationManager<OpenIdConnectConfiguration> configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(
+                    $"{uri.Scheme}://{uri.Authority}/.well-known/openid-configuration", new OpenIdConnectConfigurationRetriever());
                 configuration = await configurationManager.GetConfigurationAsync(CancellationToken.None);
 
                 _innerCache[domain] = configuration;

--- a/src/Auth0.Core/Auth0.Core.csproj
+++ b/src/Auth0.Core/Auth0.Core.csproj
@@ -2,13 +2,13 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Auth0.Core</AssemblyTitle>
-    <TargetFrameworks>net452;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Auth0.Core</AssemblyName>
     <PackageId>Auth0.Core</PackageId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.1\Auth0.Core.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard2.0\Auth0.Core.xml</DocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +19,7 @@
     <Folder Include="Properties\" />
   </ItemGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
   

--- a/src/Auth0.Core/Http/Utils.cs
+++ b/src/Auth0.Core/Http/Utils.cs
@@ -44,7 +44,7 @@ namespace Auth0.Core.Http
             {
                 foreach (var urlSegment in urlSegments)
                 {
-                    resource = resource.Replace($"{{{urlSegment.Key}}}", Uri.EscapeUriString(urlSegment.Value ?? String.Empty));
+                    resource = resource.Replace($"{{{urlSegment.Key}}}", Uri.EscapeDataString(urlSegment.Value ?? String.Empty));
                 }
 
                 // Remove trailing slash
@@ -59,14 +59,14 @@ namespace Auth0.Core.Http
                         if (sb.Length > 0)
                             sb = sb.Append("&");
 
-                        sb.Append($"{Uri.EscapeUriString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}");
+                        sb.Append($"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}");
                     }
                     else if (includeEmptyParameters)
                     {
                         if (sb.Length > 0)
                             sb = sb.Append("&");
 
-                        sb.Append(Uri.EscapeUriString(kvp.Key));
+                        sb.Append(Uri.EscapeDataString(kvp.Key));
                     }
 
                     return sb;

--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
@@ -2,17 +2,17 @@
   <Import Project="..\..\build\common.props" />
   <PropertyGroup>
     <AssemblyTitle>Auth0.ManagementApi</AssemblyTitle>
-    <TargetFrameworks>net452;netstandard1.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netstandard1.4;netstandard2.0</TargetFrameworks>
     <AssemblyName>Auth0.ManagementApi</AssemblyName>
     <PackageId>Auth0.ManagementApi</PackageId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard1.1\Auth0.ManagementApi.xml</DocumentationFile>
+    <DocumentationFile>bin\Release\netstandard2.0\Auth0.ManagementApi.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -1,13 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\Auth0.ManagementApi.IntegrationTests\TestBase.cs" Link="TestBase.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
@@ -18,21 +15,17 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta2-build3683" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Auth0.Core\Auth0.Core.csproj" />
     <ProjectReference Include="..\..\src\Auth0.AuthenticationApi\Auth0.AuthenticationApi.csproj" />
     <ProjectReference Include="..\..\src\Auth0.ManagementApi\Auth0.ManagementApi.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="client-secrets.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
 </Project>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/IdentityTokenValidatorTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/IdentityTokenValidatorTests.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.AuthenticationApi.Exceptions;
+using Auth0.AuthenticationApi.Models;
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Models;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests
+{
+    public class IdentityTokenValidatorTests: TestBase, IAsyncLifetime
+    {
+        private ManagementApiClient _managementApiClient;
+        private Connection _connection;
+        private User _user;
+        private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
+
+        public async Task InitializeAsync()
+        {
+            string token = await GenerateManagementApiToken();
+
+            _managementApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
+
+            var tenantSettings = await _managementApiClient.TenantSettings.GetAsync();
+
+            if (string.IsNullOrEmpty(tenantSettings.DefaultDirectory))
+            {
+                throw new Exception("Tests require a tenant with a Default Directory selected.\r\n" +
+                    "Enable OAuth 2.0 API Authorization under Account Settings | General and "+
+                    "select a Default Directory under Account Settings | General");
+            }
+            
+            // We will need a connection to add the users to...
+            _connection = await _managementApiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            {
+                Name = Guid.NewGuid().ToString("N"),
+                Strategy = "auth0",
+                EnabledClients = new []{ GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
+            });
+
+            // And add a dummy user to test against
+            _user = await _managementApiClient.Users.CreateAsync(new UserCreateRequest
+            {
+                Connection = _connection.Name,
+                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                EmailVerified = true,
+                Password = Password
+            });
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_user != null)
+                await _managementApiClient.Users.DeleteAsync(_user.UserId);
+
+            if (_connection != null)
+                await _managementApiClient.Connections.DeleteAsync(_connection.Id);
+        }
+        
+        [Fact]
+        public async Task Passes_Token_Validation()
+        {
+            // Arrange
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            // Act
+            var authenticationResponse = await authenticationApiClient.GetTokenAsync(new ResourceOwnerTokenRequest
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                Realm = _connection.Name,
+                Scope = "openid",
+                Username = _user.Email,
+                Password = Password
+                
+            });
+
+            var validator = new IdentityTokenValidator();
+            Func<Task> validationFunc = async () =>
+                await validator.ValidateAsync(authenticationResponse.IdToken, $"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}/", GetVariable("AUTH0_CLIENT_ID"));
+
+            // Assert
+            authenticationResponse.IdToken.Should().NotBeNull();
+            validationFunc.ShouldNotThrow<IdentityTokenValidationException>();
+        }
+
+        [Fact]
+        public async Task Passes_Token_Validation_With_CNAME()
+        {            
+            // Arrange
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("BRUCKE_AUTHENTICATION_API_URL"));
+
+            // Act
+            var authenticationResponse = await authenticationApiClient.GetTokenAsync(new ResourceOwnerTokenRequest
+            {
+                ClientId = GetVariable("BRUCKE_CLIENT_ID"),
+                ClientSecret = GetVariable("BRUCKE_CLIENT_SECRET"),
+                Realm = GetVariable("BRUCKE_CONNECTION_NAME"),
+                Scope = "openid",
+                Username = GetVariable("BRUCKE_USERNAME"),
+                Password = GetVariable("BRUCKE_PASSWORD")
+                
+            });
+
+            var validator = new IdentityTokenValidator();
+            Func<Task> validationFunc = async () =>
+                await validator.ValidateAsync(authenticationResponse.IdToken, $"https://{GetVariable("BRUCKE_AUTHENTICATION_API_URL")}/", GetVariable("BRUCKE_CLIENT_ID"));
+
+            // Assert
+            authenticationResponse.IdToken.Should().NotBeNull();
+            validationFunc.ShouldNotThrow<IdentityTokenValidationException>();
+        }
+        
+        [Fact]
+        public async Task Fails_Token_Validation_With_Incorrect_Domain()
+        {
+            // Arrange
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            // Act
+            var authenticationResponse = await authenticationApiClient.GetTokenAsync(new ResourceOwnerTokenRequest
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                Realm = _connection.Name,
+                Scope = "openid",
+                Username = _user.Email,
+                Password = Password
+                
+            });
+
+            var validator = new IdentityTokenValidator();
+            Func<Task> validationFunc = async () =>
+                await validator.ValidateAsync(authenticationResponse.IdToken, $"https://auth0.auth0.com/", GetVariable("AUTH0_CLIENT_ID"));
+
+            // Assert
+            authenticationResponse.IdToken.Should().NotBeNull();
+            validationFunc.ShouldThrow<IdentityTokenValidationException>();
+        }
+
+        [Fact]
+        public async Task Fails_Token_Validation_With_Incorrect_Audience()
+        {
+            // Arrange
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            // Act
+            var authenticationResponse = await authenticationApiClient.GetTokenAsync(new ResourceOwnerTokenRequest
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                Realm = _connection.Name,
+                Scope = "openid",
+                Username = _user.Email,
+                Password = Password
+                
+            });
+
+            var validator = new IdentityTokenValidator();
+            Func<Task> validationFunc = async () =>
+                await validator.ValidateAsync(authenticationResponse.IdToken, $"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}/", "invalid_audience");
+
+            // Assert
+            authenticationResponse.IdToken.Should().NotBeNull();
+            validationFunc.ShouldThrow<IdentityTokenValidationException>();
+        }
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/OpenIdConfigurationCacheTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/OpenIdConfigurationCacheTests.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests
+{
+    public class OpenIdConfigurationCacheTests: TestBase
+    {
+        [Fact]
+        public async Task Throws_When_Incorrect_Domain_Passed()
+        {
+            Func<Task> getTask = async () => await OpenIdConfigurationCache.Instance.GetAsync("invalid_domain");
+
+            getTask.ShouldThrow<Exception>();
+        }
+
+        [Fact]
+        public async Task Does_Not_Throw_When_Domain_Without_Trailing_Slash_Is_Passed()
+        {
+            Func<Task> getTask = async () => await OpenIdConfigurationCache.Instance.GetAsync($"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}");
+
+            getTask.ShouldNotThrow();
+        }
+    }
+}


### PR DESCRIPTION
Added ID token validation to methods calling the `/oauth/token` endpoint.

The ID Token validation use the built-in JWT token validation methods which does a full validation for RS256 tokens - it checks `nbf` and `exp` claims, validates the issuer, validates the audience and validates the signature.

This also downloads (and caches) the JWKS from the `.well-known/openid-configuration` endpoint and will use those keys for the signature validation.

Test coverage ensures that token validation passes under correct circumstances for both normal tenant URL, as well as for CNAME.

Tests also ensures that validation fails when incorrect issuer and audience is passed.