### PR TITLE
Add ServerTime to ApiInfo

### DIFF
--- a/src/Auth0.Core/Http/ApiInfo.cs
+++ b/src/Auth0.Core/Http/ApiInfo.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Auth0.Core.Http
 {
     /// <summary>
@@ -6,17 +8,32 @@ namespace Auth0.Core.Http
     public class ApiInfo
     {
         /// <summary>
-        /// Information about the current rate limit.
+        ///   Information about the current rate limit.
         /// </summary>
         public RateLimit RateLimit { get; internal set; }
 
         /// <summary>
+        ///   The server time of the last request as provided by the Date http header
+        /// </summary>
+        public DateTimeOffset? ServerTime { get; internal set; }
+        
+        /// <summary>
         /// Creates a new instance of the ApiInfo class.
         /// </summary>
         /// <param name="rateLimit">The current rate limit information.</param>
-        public ApiInfo(RateLimit rateLimit)
+        public ApiInfo(RateLimit rateLimit) : this(rateLimit, null)
+        {
+        }
+        
+        /// <summary>
+        /// Creates a new instance of the ApiInfo class.
+        /// </summary>
+        /// <param name="rateLimit">The current rate limit information.</param>
+        /// <param name="serverTime">The current server time</param>
+        public ApiInfo(RateLimit rateLimit, DateTimeOffset? serverTime)
         {
             RateLimit = rateLimit;
+            ServerTime = serverTime;
         }
     }
 }

--- a/src/Auth0.Core/Http/ApiInfoParser.cs
+++ b/src/Auth0.Core/Http/ApiInfoParser.cs
@@ -10,7 +10,7 @@ namespace Auth0.Core.Http
         {
             RateLimit rateLimit = ParseRateLimit(headers);
 
-            return new ApiInfo(rateLimit);
+            return new ApiInfo(rateLimit, headers.Date);
         }
 
         private static RateLimit ParseRateLimit(HttpResponseHeaders headers)


### PR DESCRIPTION
This adds ServerTime to ApiInfo as discussed in #200.

Had to use a nullable DateTimeoffset because the header could technically have been left out by the server.