### PR TITLE
Add custom domain support

### DIFF
--- a/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
@@ -1,0 +1,58 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.Core.Http;
+using Auth0.ManagementApi.Models;
+
+namespace Auth0.ManagementApi.Clients
+{
+    /// <summary>
+    /// Contains all the methods to call the /custom-domains endpoints.
+    /// </summary>
+    public class CustomDomainsClient : ClientBase, ICustomDomainsClient
+    {
+        internal CustomDomainsClient(IApiConnection connection) : base(connection)
+        {
+        }
+
+        /// <inheritdoc />
+        public Task<CustomDomain> CreateAsync(CustomDomainCreateRequest request)
+        {
+            return Connection.PostAsync<CustomDomain>("custom-domains", request, null, null, null, null, null);
+        }
+
+        /// <inheritdoc />
+        public Task DeleteAsync(string id)
+        {
+            return Connection.DeleteAsync<object>("custom-domains/{id}", new Dictionary<string, string>
+            {
+                {"id", id}
+            }, null);
+        }
+
+        /// <inheritdoc />
+        public Task<IList<CustomDomain>> GetAllAsync()
+        {
+            return Connection.GetAsync<IList<CustomDomain>>("custom-domains", null, null, null, null);
+        }
+
+        /// <inheritdoc />
+        public Task<CustomDomain> GetAsync(string id)
+        {
+            return Connection.GetAsync<CustomDomain>("custom-domains/{id}",
+                new Dictionary<string, string>
+                {
+                    {"id", id}
+                },
+                null, null, null);
+        }
+
+        /// <inheritdoc />
+        public Task<CustomDomainVerificationResponse> VerifyAsync(string id)
+        {
+            return Connection.PostAsync<CustomDomainVerificationResponse>("custom-domains/{id}/verify", null, null, null, new Dictionary<string, string>
+            {
+                {"id", id}
+            }, null, null);
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Clients/ICustomDomainsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ICustomDomainsClient.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.ManagementApi.Models;
+
+namespace Auth0.ManagementApi.Clients
+{
+    /// <summary>
+    /// Contains all the methods to call the /custom-domains endpoints.
+    /// </summary>
+    public interface ICustomDomainsClient
+    {
+        /// <summary>
+        /// Creates a new custom domain and returns it.
+        /// </summary>
+        /// <param name="request">A <see cref="CustomDomainCreateRequest"/> representing the new domain.</param>
+        /// <returns>The new domain.</returns>
+        /// <remarks>The custom domain will need to be verified before it starts accepting requests.</remarks>
+        Task<CustomDomain> CreateAsync(CustomDomainCreateRequest request);
+
+        /// <summary>
+        /// Deletes a custom domain by its ID.
+        /// </summary>
+        /// <param name="id">The ID of the domain to delete.</param>
+        /// <returns></returns>
+        /// <remarks>When deleted, Auth0 will stop serving requests for this domain.</remarks>
+        Task DeleteAsync(string id);
+
+        /// <summary>
+        /// Retrieves a custom domain status by its ID
+        /// </summary>
+        /// <param name="id">The ID of the domain to retrieve.</param>
+        /// <returns>The domain.</returns>
+        Task<CustomDomain> GetAsync(string id);
+
+        /// <summary>
+        /// Retrieves the status of every custom domain.
+        /// </summary>
+        /// <returns>The list of custom domains</returns>
+        Task<IList<CustomDomain>> GetAllAsync();
+
+        /// <summary>
+        /// Run the verification process for the custom domain. 
+        /// </summary>
+        /// <param name="id">The ID of the domain to verify.</param>
+        /// <returns></returns>
+        Task<CustomDomainVerificationResponse> VerifyAsync(string id);
+    }
+}

--- a/src/Auth0.ManagementApi/IManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/IManagementApiClient.cs
@@ -29,6 +29,11 @@ namespace Auth0.ManagementApi
         IConnectionsClient Connections { get; }
 
         /// <summary>
+        /// Contains all the methods to call the /custom-domains endpoints.
+        /// </summary>
+        ICustomDomainsClient CustomDomains { get; }
+
+        /// <summary>
         /// Contains all the methods to call the /device-credentials endpoints.
         /// </summary>
         IDeviceCredentialsClient DeviceCredentials { get; }

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -36,6 +36,11 @@ namespace Auth0.ManagementApi
         public IConnectionsClient Connections { get; }
 
         /// <summary>
+        /// Contains all the methods to call the /custom-domains endpoints.
+        /// </summary>
+        public ICustomDomainsClient CustomDomains { get; }
+
+        /// <summary>
         /// Contains all the methods to call the /device-credentials endpoints.
         /// </summary>
         /// <value>The device credentials.</value>
@@ -121,6 +126,7 @@ namespace Auth0.ManagementApi
             ClientGrants = new ClientGrantsClient(_apiConnection);
             Clients = new ClientsClient(_apiConnection);
             Connections = new ConnectionsClient(_apiConnection);
+            CustomDomains = new CustomDomainsClient(_apiConnection);
             DeviceCredentials = new DeviceCredentialsClient(_apiConnection);
             EmailProvider = new EmailProviderClient(_apiConnection);
             EmailTemplates = new EmailTemplatesClient(_apiConnection);

--- a/src/Auth0.ManagementApi/Models/CustomDomain.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomain.cs
@@ -1,0 +1,9 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents a Custom Domain
+    /// </summary>
+    public class CustomDomain : CustomDomainBase
+    {
+    }
+}

--- a/src/Auth0.ManagementApi/Models/CustomDomainBase.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainBase.cs
@@ -1,0 +1,52 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Base class for custom domain responses.
+    /// </summary>
+    public abstract class CustomDomainBase
+    {
+        /// <summary>
+        /// The id of the custom domain.
+        /// </summary>
+        [JsonProperty("custom_domain_id")]
+        public string CustomDomainId { get; set; }
+
+        /// <summary>
+        /// The custom domain.
+        /// </summary>
+        [JsonProperty("domain")]
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// The intermediate address.
+        /// </summary>
+        [JsonProperty("origin_domain_name")]
+        public string OriginDomainName { get; set; }
+
+        /// <summary>
+        /// true if the domain was marked as "primary", false otherwise.
+        /// </summary>
+        [JsonProperty("primary")]
+        public bool Primary { get; set; }
+
+        /// <summary>
+        /// The custom domain configuration status.
+        /// </summary>
+        [JsonProperty("status")]
+        public CustomDomainStatus Status { get; set; }
+
+        /// <summary>
+        /// The custom domain provisioning type.
+        /// </summary>
+        [JsonProperty("type")]
+        public CustomDomainCertificateProvisioning Type { get; set; }
+
+        /// <summary>
+        /// The custom domain verification methods.
+        /// </summary>
+        [JsonProperty("verification")]
+        public CustomDomainVerification Verification { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/CustomDomainBase.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainBase.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Auth0.ManagementApi.Models
 {
@@ -35,12 +36,14 @@ namespace Auth0.ManagementApi.Models
         /// The custom domain configuration status.
         /// </summary>
         [JsonProperty("status")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public CustomDomainStatus Status { get; set; }
 
         /// <summary>
         /// The custom domain provisioning type.
         /// </summary>
         [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public CustomDomainCertificateProvisioning Type { get; set; }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Models/CustomDomainCertificateProvisioning.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainCertificateProvisioning.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The custom domain provisioning type.
+    /// </summary>
+    public enum CustomDomainCertificateProvisioning
+    {
+        /// <summary>
+        /// Using Auth0-managed Certificates.
+        /// </summary>
+        [EnumMember(Value = "auth0_managed_certs")]
+        Auth0ManagedCertificate,
+
+        /// <summary>
+        /// Using self-managed certificates.
+        /// </summary>
+        [EnumMember(Value = "self_managed_certs")]
+        SelfManagedCertificate
+    }
+}

--- a/src/Auth0.ManagementApi/Models/CustomDomainCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainCreateRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Auth0.ManagementApi.Models
 {
@@ -17,6 +18,7 @@ namespace Auth0.ManagementApi.Models
         /// The custom domain provisioning type.
         /// </summary>
         [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
         public CustomDomainCertificateProvisioning Type { get; set; }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Models/CustomDomainCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainCreateRequest.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents a request to create a new custom domain.
+    /// </summary>
+    public class CustomDomainCreateRequest
+    {
+        /// <summary>
+        /// The custom domain.
+        /// </summary>
+        [JsonProperty("domain")]
+        public string Domain { get; set; }
+
+        /// <summary>
+        /// The custom domain provisioning type.
+        /// </summary>
+        [JsonProperty("type")]
+        public CustomDomainCertificateProvisioning Type { get; set; }
+
+        /// <summary>
+        /// The custom domain verification method.
+        /// </summary>
+        [JsonProperty("verification_method")]
+        public string VerificationMethod { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/CustomDomainStatus.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainStatus.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The custom domain configuration status.
+    /// </summary>
+    public enum CustomDomainStatus
+    {
+        /// <summary>
+        /// Domain is disabled.
+        /// </summary>
+        [EnumMember(Value = "disabled")] Disabled,
+
+        /// <summary>
+        /// Domain is pending.
+        /// </summary>
+        [EnumMember(Value = "pending")] Pending,
+
+        /// <summary>
+        /// Domain is pending verification.
+        /// </summary>
+        [EnumMember(Value = "pending_verification")]
+        PendingVerification,
+
+        /// <summary>
+        /// Domain is ready
+        /// </summary>
+        [EnumMember(Value = "ready")] Ready
+    }
+}

--- a/src/Auth0.ManagementApi/Models/CustomDomainVerification.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainVerification.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The custom domain verification methods.
+    /// </summary>
+    public class CustomDomainVerification
+    {
+        /// <summary>
+        /// The custom domain verification methods.
+        /// </summary>
+        [JsonProperty("methods")]
+        public string[] Methods { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/CustomDomainVerificationResponse.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainVerificationResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Response when requesting a custom domain verification
+    /// </summary>
+    public class CustomDomainVerificationResponse : CustomDomainBase
+    {
+        
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/CustomDomainsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/CustomDomainsTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.Core.Exceptions;
+using Auth0.ManagementApi.Models;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.ManagementApi.IntegrationTests
+{
+    public class CustomDomainsTests : TestBase
+    {
+        // Tests for custom domains are limited. This is available only on the brucke tenant, and also, we cannot test full CRUD sequence because (1) the tenant
+        // allow for only one custom domain and (2) others depend on that domain, so we cannot just go and delete it. We are therefore limited in scope to
+        // what we can test. For now, this at least allow us to test that the serialization and the GET methods work correctly
+        [Fact(Skip = "Run manually")]
+        public async Task Test_custom_domains()
+        {
+            string token = "";
+
+            var apiClient = new ManagementApiClient(token, GetVariable("BRUCKE_MANAGEMENT_API_URL"));
+
+            // Test getting all custom domains
+            var domains = await apiClient.CustomDomains.GetAllAsync();
+            domains.Should().HaveCount(1); // There is only one custom domain currently registered on this tenant
+
+            string id = domains[0].CustomDomainId;
+
+            // Test getting a single custom domain
+            var domain = await apiClient.CustomDomains.GetAsync(id);
+            domain.Should().NotBeNull();
+            domain.CustomDomainId.Should().Be(id);
+
+            string non_existent_id = "cd_XXw4P8C04x1Aa9e5";
+
+            // Test deleting a non-existent domain
+            // (this does not throw for a non-existent domain?)
+            await apiClient.CustomDomains.DeleteAsync(non_existent_id);
+
+            // Test verifying a non-existing id. This will give 404
+            Func<Task<CustomDomainVerificationResponse>> verifyFunc = async () => await apiClient.CustomDomains.VerifyAsync(non_existent_id);
+            verifyFunc.ShouldThrow<ApiException>()
+                .WithMessage($"The custom domain {non_existent_id} does not exist");
+
+            // Test adding a new domain. The BRUCKE tenant only allows one, so this should throw
+            Func<Task<CustomDomain>> createFunc = async () => await apiClient.CustomDomains.CreateAsync(new CustomDomainCreateRequest
+            {
+                Domain = "test.brucke.club",
+                Type = CustomDomainCertificateProvisioning.Auth0ManagedCertificate,
+                VerificationMethod = "txt"
+            });
+            createFunc.ShouldThrow<ApiException>()
+                .WithMessage("You reached the maximum number of custom domains for your account (MAX ALLOWED: 1)");
+        }
+    }
+}


### PR DESCRIPTION
This adds support for the `/api/v2/custom-domains` endpoints to allow users to manage custom domains using the Auth0 .NET SDK.

Writing automated tests for this is challenging as the `auth0-dotnet-integration-tests.auth0.com` tenant does not support custom domains. I wrote some tests agains the `brucke.auth0.com` tenant, but this is also limited since that tenant allows for only one custom domain, and I cannot delete it since team Brucke actually depends on that custom domain for their tests.

I believe I have done enough though to exercise the various endpoints to ensure that endpoints are called correctly and that payload serialization and deserialization happens correctly.