### PR TITLE
Nullable TokenLifetimeForWeb for backward compat

### DIFF
--- a/src/Auth0.ManagementApi/Models/ResourceServerBase.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServerBase.cs
@@ -48,7 +48,7 @@ namespace Auth0.ManagementApi.Models
         /// Value cannot be larger than <see cref="TokenLifetime" />
         /// </summary>
         [JsonProperty("token_lifetime_for_web")]
-        public int TokenLifetimeForWeb { get; set; }
+        public int? TokenLifetimeForWeb { get; set; }
 
         /// <summary>
         /// Allows issuance of refresh tokens for this entity

--- a/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
@@ -36,7 +36,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Identifier = identifier.ToString("N"),
                 Name = $"Integration testing {identifier:N}",
                 TokenLifetime = 1,
-                TokenLifetimeForWeb = 15,
+                TokenLifetimeForWeb = 1,
                 SigningAlgorithm = SigningAlgorithm.HS256,
                 SigningSecret = "thisismysecret0123456789",
                 Scopes = new List<ResourceServerScope>
@@ -55,8 +55,8 @@ namespace Auth0.ManagementApi.IntegrationTests
             var resourceServerRequest = new ResourceServerUpdateRequest()
             {
                 Name = $"Integration testing {Guid.NewGuid():N}",
-                TokenLifetime = 1,
-                TokenLifetimeForWeb = 10,
+                TokenLifetime = 2,
+                TokenLifetimeForWeb = 1,
                 SigningAlgorithm = SigningAlgorithm.HS256,
                 SigningSecret = "thisismysecret0123456789",
                 Scopes = new List<ResourceServerScope>


### PR DESCRIPTION
PR #208 added the TokenLifetimeForWeb property to the API however being an integer it defaults to zero which is invalid and would break existing clients until they set it to a valid value.

This PR makes it nullable so that if if a value is not set then it will not send a value and keep the existing behavior.