### PR TITLE
Modify cake to allow build+test+pack in a single step

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -64,7 +64,7 @@ Task("Test")
 
 Task("Pack")
     .IsDependentOn("Build")
-    .WithCriteria((IsOnAppVeyorAndNotPR || string.Equals(target, "pack", StringComparison.OrdinalIgnoreCase)) && IsRunningOnWindows())
+    .WithCriteria(IsRunningOnWindows())
     .Does(() =>
     {
         var settings = new DotNetCorePackSettings


### PR DESCRIPTION
The cake build script previously only ran the pack if it was on AppVeyor or the "pack" command was specifically called.  We want the default to run both on CI in a single build.