### PR TITLE
Update dependencies

### DIFF
--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -19,7 +19,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.2.4" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.4.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.4.0" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="System.Net.Http" />

--- a/src/Auth0.Core/Auth0.Core.csproj
+++ b/src/Auth0.Core/Auth0.Core.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">

--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
@@ -13,7 +13,7 @@
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net452'">
     <Reference Include="System.Net.Http" />

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -6,9 +6,9 @@
     <Compile Include="..\Auth0.ManagementApi.IntegrationTests\TestBase.cs" Link="TestBase.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="AngleSharp" Version="0.9.9" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -9,7 +9,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="AngleSharp" Version="0.9.9" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/DatabaseConnectionTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/DatabaseConnectionTests.cs
@@ -73,7 +73,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 Password = Password2
             };
             Func<Task> changePasswordFunc = async () => await authenticationApiClient.ChangePasswordAsync(changePasswordRequest);
-            changePasswordFunc.ShouldThrow<ApiException>().And.ApiError.Error.Should().Be("password is not allowed");
+            changePasswordFunc.Should().Throw<ApiException>().And.ApiError.Error.Should().Be("password is not allowed");
         }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/IdentityTokenValidatorTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/IdentityTokenValidatorTests.cs
@@ -83,7 +83,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
 
             // Assert
             authenticationResponse.IdToken.Should().NotBeNull();
-            validationFunc.ShouldNotThrow<IdentityTokenValidationException>();
+            validationFunc.Should().NotThrow<IdentityTokenValidationException>();
         }
 
         [Fact]
@@ -110,7 +110,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
 
             // Assert
             authenticationResponse.IdToken.Should().NotBeNull();
-            validationFunc.ShouldNotThrow<IdentityTokenValidationException>();
+            validationFunc.Should().NotThrow<IdentityTokenValidationException>();
         }
         
         [Fact]
@@ -137,7 +137,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
 
             // Assert
             authenticationResponse.IdToken.Should().NotBeNull();
-            validationFunc.ShouldThrow<IdentityTokenValidationException>();
+            validationFunc.Should().Throw<IdentityTokenValidationException>();
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
 
             // Assert
             authenticationResponse.IdToken.Should().NotBeNull();
-            validationFunc.ShouldThrow<IdentityTokenValidationException>();
+            validationFunc.Should().Throw<IdentityTokenValidationException>();
         }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/OpenIdConfigurationCacheTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/OpenIdConfigurationCacheTests.cs
@@ -9,19 +9,19 @@ namespace Auth0.AuthenticationApi.IntegrationTests
     public class OpenIdConfigurationCacheTests: TestBase
     {
         [Fact]
-        public async Task Throws_When_Incorrect_Domain_Passed()
+        public void Throws_When_Incorrect_Domain_Passed()
         {
             Func<Task> getTask = async () => await OpenIdConfigurationCache.Instance.GetAsync("invalid_domain");
 
-            getTask.ShouldThrow<Exception>();
+            getTask.Should().Throw<Exception>();
         }
 
         [Fact]
-        public async Task Does_Not_Throw_When_Domain_Without_Trailing_Slash_Is_Passed()
+        public void Does_Not_Throw_When_Domain_Without_Trailing_Slash_Is_Passed()
         {
             Func<Task> getTask = async () => await OpenIdConfigurationCache.Instance.GetAsync($"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}");
 
-            getTask.ShouldNotThrow();
+            getTask.Should().NotThrow();
         }
     }
 }

--- a/tests/Auth0.Core.UnitTests/ApiErrorDeserializationTests.cs
+++ b/tests/Auth0.Core.UnitTests/ApiErrorDeserializationTests.cs
@@ -14,7 +14,7 @@ namespace Auth0.Core.UnitTests
         {
             var error = JsonConvert.DeserializeObject<ApiError>(content);
 
-            error.ShouldBeEquivalentTo(expected);
+            error.Should().BeEquivalentTo(expected);
         }
     }
 

--- a/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
+++ b/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
+++ b/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
+++ b/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
@@ -11,7 +11,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
@@ -8,7 +8,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
@@ -5,9 +5,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="FluentAssertions" Version="4.19.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
@@ -83,8 +83,8 @@ namespace Auth0.ManagementApi.IntegrationTests
             };
             var newClientGrantResponse = await _apiClient.ClientGrants.CreateAsync(newClientGrantRequest);
             newClientGrantResponse.Should().NotBeNull();
-            newClientGrantResponse.ShouldBeEquivalentTo(newClientGrantRequest,
-                options => options.Excluding(cg => cg.Id));
+            newClientGrantResponse.Should().BeEquivalentTo(newClientGrantRequest,
+                options => options.Excluding(cg => cg.ClientId));
 
             // Get all the client grants again, and verify we have one more
             var clientGrantsAfter = await _apiClient.ClientGrants.GetAllAsync(new GetClientGrantsRequest());

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -76,7 +76,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Delete the client, and ensure we get exception when trying to fetch client again
             await _apiClient.Clients.DeleteAsync(client.ClientId);
             Func<Task> getFunc = async () => await _apiClient.Clients.GetAsync(client.ClientId);
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_client");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_client");
         }
         
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
@@ -76,7 +76,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Delete the connection and ensure we get exception when trying to get connection again
             await _apiClient.Connections.DeleteAsync(newConnectionResponse.Id);
             Func<Task> getFunc = async () => await _apiClient.Connections.GetAsync(newConnectionResponse.Id);
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
         }
         
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/CustomDomainsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/CustomDomainsTests.cs
@@ -39,7 +39,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Test verifying a non-existing id. This will give 404
             Func<Task<CustomDomainVerificationResponse>> verifyFunc = async () => await apiClient.CustomDomains.VerifyAsync(non_existent_id);
-            verifyFunc.ShouldThrow<ApiException>()
+            verifyFunc.Should().Throw<ApiException>()
                 .WithMessage($"The custom domain {non_existent_id} does not exist");
 
             // Test adding a new domain. The BRUCKE tenant only allows one, so this should throw
@@ -49,7 +49,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Type = CustomDomainCertificateProvisioning.Auth0ManagedCertificate,
                 VerificationMethod = "txt"
             });
-            createFunc.ShouldThrow<ApiException>()
+            createFunc.Should().Throw<ApiException>()
                 .WithMessage("You reached the maximum number of custom domains for your account (MAX ALLOWED: 1)");
         }
     }

--- a/tests/Auth0.ManagementApi.IntegrationTests/EmailProviderTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/EmailProviderTests.cs
@@ -22,7 +22,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Getting the email provider now should throw, since none is configured
             Func<Task> getFunc = async () => await apiClient.EmailProvider.GetAsync("name,enabled,credentials,settings");
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
 
             // Configure the email provider
             var configureRequest = new EmailProviderConfigureRequest
@@ -65,7 +65,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Check than once again the email provider should throw, since none is configured
             getFunc = async () => await apiClient.EmailProvider.GetAsync("name,enabled,credentials,settings");
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
 
         }
 
@@ -81,7 +81,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Getting the email provider now should throw, since none is configured
             Func<Task> getFunc = async () => await apiClient.EmailProvider.GetAsync("name,enabled,credentials,settings");
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
 
             // Configure the email provider
             var configureRequest = new EmailProviderConfigureRequest
@@ -136,7 +136,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Check than once again the email provider should throw, since none is configured
             getFunc = async () => await apiClient.EmailProvider.GetAsync("name,enabled,credentials,settings");
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_email_provider");
 
         }
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
@@ -35,7 +35,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             var singleLogEntry = await _apiClient.Logs.GetAsync(firstLogEntry.Id);
 
             // Compare both log entries. They should be the same
-            singleLogEntry.ShouldBeEquivalentTo(firstLogEntry);
+            singleLogEntry.Should().BeEquivalentTo(firstLogEntry);
         }
 
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
@@ -49,7 +49,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             };
             var newResourceServerResponse = await _apiClient.ResourceServers.CreateAsync(newResourceServerRequest);
-            newResourceServerResponse.ShouldBeEquivalentTo(newResourceServerRequest, options => options.Excluding(rs => rs.Id));
+            newResourceServerResponse.Should().BeEquivalentTo(newResourceServerRequest, options => options.Excluding(rs => rs.Id));
 
             // Update the resource server
             var resourceServerRequest = new ResourceServerUpdateRequest()
@@ -74,16 +74,16 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             };
             var updateResourceServerResponse = await _apiClient.ResourceServers.UpdateAsync(newResourceServerResponse.Id, resourceServerRequest);
-            updateResourceServerResponse.ShouldBeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
+            updateResourceServerResponse.Should().BeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
 
             // Get a single resource server
             var resourceServer = await _apiClient.ResourceServers.GetAsync(newResourceServerResponse.Id);
-            resourceServer.ShouldBeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
+            resourceServer.Should().BeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
 
             // Delete the client, and ensure we get exception when trying to fetch client again
             await _apiClient.ResourceServers.DeleteAsync(resourceServer.Id);
             Func<Task> getFunc = async () => await _apiClient.ResourceServers.GetAsync(resourceServer.Id);
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_resource_server");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_resource_server");
         }
 
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
@@ -64,7 +64,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Delete the rule, and ensure we get exception when trying to fetch it again
             await _apiClient.Rules.DeleteAsync(rule.Id);
             Func<Task> getFunc = async () => await _apiClient.Rules.GetAsync(rule.Id);
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_rule");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_rule");
         }
         
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
@@ -35,7 +35,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 SupportUrl = $"www.{Guid.NewGuid():N}.aaa/support"
             };
             var settingsUpdateResponse = await apiClient.TenantSettings.UpdateAsync(settingsUpdateRequest);
-            settingsUpdateResponse.ShouldBeEquivalentTo(settingsUpdateRequest);
+            settingsUpdateResponse.Should().BeEquivalentTo(settingsUpdateRequest);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -79,7 +79,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Delete the user and ensure we get an exception when trying to fetch them again
             await _apiClient.Users.DeleteAsync(user.UserId);
             Func<Task> getFunc = async () => await _apiClient.Users.GetAsync(user.UserId);
-            getFunc.ShouldThrow<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_user");
+            getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_user");
         }
 
         [Theory]
@@ -89,7 +89,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public void Attempting_to_delete_users_with_null_or_empty_id_should_throw(string id)
         {
             Func<Task> deleteFunc = async () => await _apiClient.Users.DeleteAsync(id);
-            deleteFunc.ShouldThrow<ArgumentException>().And.Message.Should().Be($"Value cannot be null or whitespace.{Environment.NewLine}Parameter name: id");
+            deleteFunc.Should().Throw<ArgumentException>().And.Message.Should().Be($"Value cannot be null or whitespace.{Environment.NewLine}Parameter name: id");
         }
 
         [Fact]


### PR DESCRIPTION
This brings all the dependencies up to date except for JSON.Net as that is very commonly used by other apps by switching our dependency up to the latest version we may inadvertently force consumers of our SDK to also have to upgrade theirs.  