### PR TITLE
Simplify telemetry and deprecate DiagnosticsHeader

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -21,10 +21,9 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         private readonly Uri _baseUri;
 
-        private AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, ApiConnection connection)
+        private AuthenticationApiClient(Uri baseUri, ApiConnection connection)
         {
             _baseUri = baseUri;
-
             Connection = connection ?? throw new ArgumentNullException(nameof(ApiConnection));
         }
 
@@ -34,8 +33,9 @@ namespace Auth0.AuthenticationApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
-            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, handler))
+            : this(baseUri, handler)
         {
         }
 
@@ -45,8 +45,9 @@ namespace Auth0.AuthenticationApi
         /// <param name="baseUri"></param>
         /// <param name="diagnostics"></param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics, HttpClient httpClient)
-            : this(baseUri, diagnostics, new ApiConnection(null, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, httpClient))
+            : this(baseUri, httpClient)
         {
         }
 
@@ -56,7 +57,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(Uri baseUri, HttpMessageHandler handler)
-            : this(baseUri, null, handler)
+            : this(baseUri, new ApiConnection(null, baseUri.AbsoluteUri, handler))
         {
         }
 
@@ -67,7 +68,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="baseUri"></param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(Uri baseUri, HttpClient httpClient)
-            : this(baseUri, null, httpClient)
+            : this(baseUri, new ApiConnection(null, baseUri.AbsoluteUri, httpClient))
         {
         }
 
@@ -76,8 +77,9 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="baseUri">The base URI.</param>
         /// <param name="diagnostics">The diagnostics.</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public AuthenticationApiClient(Uri baseUri, DiagnosticsHeader diagnostics)
-            : this(baseUri, diagnostics, (HttpMessageHandler) null)
+            : this(baseUri, (HttpMessageHandler) null)
         {
         }
 
@@ -86,7 +88,7 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="baseUri">The base URI.</param>
         public AuthenticationApiClient(Uri baseUri)
-            : this(baseUri, null, (HttpMessageHandler) null)
+            : this(baseUri, (HttpMessageHandler) null)
         {
         }
 
@@ -96,8 +98,9 @@ namespace Auth0.AuthenticationApi
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public AuthenticationApiClient(string domain, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
-            : this(new Uri($"https://{domain}"), diagnostics, handler)
+            : this(new Uri($"https://{domain}"), handler)
         {
         }
 
@@ -107,8 +110,9 @@ namespace Auth0.AuthenticationApi
         /// <param name="domain"></param>
         /// <param name="diagnostics"></param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public AuthenticationApiClient(string domain, DiagnosticsHeader diagnostics, HttpClient httpClient)
-            : this(new Uri($"https://{domain}"), diagnostics, httpClient)
+            : this(new Uri($"https://{domain}"), httpClient)
         {
         }
 
@@ -118,7 +122,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(string domain, HttpMessageHandler handler)
-            : this(new Uri($"https://{domain}"), null, handler)
+            : this(new Uri($"https://{domain}"), handler)
         {
         }
 
@@ -128,7 +132,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="domain"></param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
         public AuthenticationApiClient(string domain, HttpClient httpClient)
-            : this(new Uri($"https://{domain}"), null, httpClient)
+            : this(new Uri($"https://{domain}"), httpClient)
         {
         }
 
@@ -137,8 +141,9 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="diagnostics">The diagnostics.</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public AuthenticationApiClient(string domain, DiagnosticsHeader diagnostics)
-            : this(new Uri($"https://{domain}"), diagnostics, (HttpMessageHandler) null)
+            : this(new Uri($"https://{domain}"))
         {
         }
 
@@ -147,7 +152,7 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         public AuthenticationApiClient(string domain)
-            : this(new Uri($"https://{domain}"), null, (HttpMessageHandler) null)
+            : this(new Uri($"https://{domain}"))
         {
         }
 

--- a/src/Auth0.Core/Auth0.Core.csproj
+++ b/src/Auth0.Core/Auth0.Core.csproj
@@ -7,6 +7,18 @@
     <PackageId>Auth0.Core</PackageId>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <DefineConstants>NET452</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
+    <DefineConstants>NETSTANDARD1_4</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>NETSTANDARD2_0</DefineConstants>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard2.0\Auth0.Core.xml</DocumentationFile>
   </PropertyGroup>

--- a/src/Auth0.Core/Http/DiagnosticsComponent.cs
+++ b/src/Auth0.Core/Http/DiagnosticsComponent.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Newtonsoft.Json;
 
@@ -6,6 +7,7 @@ namespace Auth0.Core.Http
     /// <summary>
     /// Represents information about a software component that's used for diagnostic purposes.
     /// </summary>
+    [Obsolete("Diagnostics are now automatic and not configurable. This class will be removed in a future update.")]
     public class DiagnosticsComponent
     {
         internal DiagnosticsComponent() { }

--- a/src/Auth0.Core/Http/DiagnosticsHeader.cs
+++ b/src/Auth0.Core/Http/DiagnosticsHeader.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -10,6 +11,7 @@ namespace Auth0.Core.Http
     /// <summary>
     ///     Represents important information pertaining to the SDK that is sent to Auth0 for diagnostic purposes.
     /// </summary>
+    [Obsolete("Diagnostics are now automatic and not configurable. This class will be removed in a future update.")]
     public class DiagnosticsHeader : DiagnosticsComponent
     {
         private static readonly object SyncRoot = new object();

--- a/src/Auth0.Core/Http/Utils.cs
+++ b/src/Auth0.Core/Http/Utils.cs
@@ -6,6 +6,7 @@ using System.Text;
 
 [assembly: InternalsVisibleTo("Auth0.AuthenticationApi")]
 [assembly: InternalsVisibleTo("Auth0.ManagementApi")]
+[assembly: InternalsVisibleTo("Auth0.Core.UnitTests")]
 namespace Auth0.Core.Http
 {
     internal static class Utils

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -21,7 +21,7 @@ namespace Auth0.ManagementApi
         /// <summary>
         /// Contains all the methods to call the /client-grants endpoints
         /// </summary>
-        public IClientGrantsClient ClientGrants { get;  }
+        public IClientGrantsClient ClientGrants { get; }
 
         /// <summary>
         /// Contains all the methods to call the /clients endpoints.
@@ -117,8 +117,7 @@ namespace Auth0.ManagementApi
             return _apiConnection.ApiInfo;
         }
 
-        private ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics,
-            ApiConnection apiConnection)
+        private ManagementApiClient(string token, Uri baseUri, ApiConnection apiConnection)
         {
             _apiConnection = apiConnection;
 
@@ -148,8 +147,9 @@ namespace Auth0.ManagementApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
-        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, handler))
+            : this(token, baseUri, handler)
         {
         }
 
@@ -160,8 +160,9 @@ namespace Auth0.ManagementApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics, HttpClient httpClient)
-        : this(token, baseUri, diagnostics, new ApiConnection(token, baseUri.AbsoluteUri, diagnostics ?? DiagnosticsHeader.Default, httpClient))
+            : this(token, baseUri, httpClient)
         {
 
         }
@@ -172,8 +173,9 @@ namespace Auth0.ManagementApi
         /// <param name="token">The token.</param>
         /// <param name="baseUri">The base URI.</param>
         /// <param name="diagnostics">The diagnostics.</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public ManagementApiClient(string token, Uri baseUri, DiagnosticsHeader diagnostics)
-            : this(token, baseUri, diagnostics, (HttpMessageHandler) null)
+            : this(token, baseUri, (HttpMessageHandler)null)
         {
         }
 
@@ -184,7 +186,7 @@ namespace Auth0.ManagementApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public ManagementApiClient(string token, Uri baseUri, HttpMessageHandler handler)
-            : this(token, baseUri, null, handler)
+            : this(token, baseUri, new ApiConnection(token, baseUri.AbsoluteUri, handler))
         {
         }
 
@@ -196,9 +198,8 @@ namespace Auth0.ManagementApi
         /// <param name="baseUri">The base URI.</param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
         public ManagementApiClient(string token, Uri baseUri, HttpClient httpClient)
-            : this(token, baseUri, null, httpClient)
+            : this(token, baseUri, new ApiConnection(token, baseUri.AbsoluteUri, httpClient))
         {
-
         }
 
         /// <summary>
@@ -207,7 +208,7 @@ namespace Auth0.ManagementApi
         /// <param name="token">The token.</param>
         /// <param name="baseUri">The base URI.</param>
         public ManagementApiClient(string token, Uri baseUri)
-            : this(token, baseUri, null, (HttpMessageHandler) null)
+            : this(token, baseUri, (HttpMessageHandler)null)
         {
         }
 
@@ -218,8 +219,9 @@ namespace Auth0.ManagementApi
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public ManagementApiClient(string token, string domain, DiagnosticsHeader diagnostics, HttpMessageHandler handler)
-            : this(token, new Uri($"https://{domain}/api/v2"), diagnostics, handler)
+            : this(token, new Uri($"https://{domain}/api/v2"), handler)
         {
         }
 
@@ -230,8 +232,9 @@ namespace Auth0.ManagementApi
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="diagnostics">The diagnostics.</param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public ManagementApiClient(string token, string domain, DiagnosticsHeader diagnostics, HttpClient httpClient)
-            : this(token, new Uri($"https://{domain}/api/v2"), diagnostics, httpClient)
+            : this(token, new Uri($"https://{domain}/api/v2"), httpClient)
         {
         }
 
@@ -241,8 +244,9 @@ namespace Auth0.ManagementApi
         /// <param name="token">The token.</param>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="diagnostics">The diagnostics.</param>
+        [Obsolete("Diagnostics are now automatic and not configurable. Please use a constructor without the DiagnosticsHeader parameter. This constructor will be removed in a future update.")]
         public ManagementApiClient(string token, string domain, DiagnosticsHeader diagnostics)
-            : this(token, new Uri($"https://{domain}/api/v2"), diagnostics, (HttpMessageHandler) null)
+            : this(token, new Uri($"https://{domain}/api/v2"), (HttpMessageHandler)null)
         {
         }
 
@@ -253,7 +257,7 @@ namespace Auth0.ManagementApi
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="handler">The <see cref="HttpMessageHandler"/> which is used for HTTP requests</param>
         public ManagementApiClient(string token, string domain, HttpMessageHandler handler)
-            : this(token, new Uri($"https://{domain}/api/v2"), null, handler)
+            : this(token, new Uri($"https://{domain}/api/v2"), handler)
         {
         }
 
@@ -264,7 +268,7 @@ namespace Auth0.ManagementApi
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         /// <param name="httpClient">The <see cref="HttpClient"/> which is used for HTTP requests</param>
         public ManagementApiClient(string token, string domain, HttpClient httpClient)
-            : this(token, new Uri($"https://{domain}/api/v2"), null, httpClient)
+            : this(token, new Uri($"https://{domain}/api/v2"), httpClient)
         {
         }
 
@@ -274,7 +278,7 @@ namespace Auth0.ManagementApi
         /// <param name="token">The token.</param>
         /// <param name="domain">Your Auth0 domain, e.g. tenant.auth0.com.</param>
         public ManagementApiClient(string token, string domain)
-            : this(token, new Uri($"https://{domain}/api/v2"), null, (HttpMessageHandler) null)
+            : this(token, new Uri($"https://{domain}/api/v2"), (HttpMessageHandler)null)
         {
         }
 

--- a/tests/Auth0.Core.UnitTests/Auth0ClientTests.cs
+++ b/tests/Auth0.Core.UnitTests/Auth0ClientTests.cs
@@ -1,0 +1,79 @@
+﻿using Auth0.Core.Http;
+using Newtonsoft.Json.Linq;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Auth0.Core.UnitTests
+{
+    public class Auth0ClientTests
+    {
+        [Fact]
+        public void Auth0Client_is_added_to_http_client_default_headers()
+        {
+            var client = SetupClient();
+            var headers = GetAuth0ClientHeaders(client);
+
+            Assert.Single(headers);
+        }
+
+        [Fact]
+        public void Auth0Client_payload_is_valid_base64_url_json()
+        {
+            var client = SetupClient();
+            var payload = GetPayload(client);
+
+            Assert.NotNull(payload);
+        }
+
+        [Fact]
+        public void Auth0Client_has_name_auth0_dot_net()
+        {
+            var client = SetupClient();
+            var payload = GetPayload(client);
+
+            Assert.Equal("Auth0.Net", payload["name"].ToString());
+        }
+
+        [Fact]
+        public void Auth0Client_has_version_from_core_assembly()
+        {
+            var client = SetupClient();
+            var payload = GetPayload(client);
+
+            var v = typeof(ApiConnection).GetTypeInfo().Assembly.GetName().Version;
+            Assert.Equal($"{v.Major}.{v.Minor}.{v.Revision}", payload["version"].ToString());
+        }
+
+        [Fact]
+        public void Auth0Client_has_a_target_inside_env()
+        {
+            var client = SetupClient();
+            var payload = GetPayload(client);
+
+            var v = typeof(ApiConnection).GetTypeInfo().Assembly.GetName().Version;
+            Assert.NotNull(payload["env"]["target"].ToString());
+        }
+
+        private HttpClient SetupClient()
+        {
+            var httpClient = new HttpClient();
+            var apiClient = new ApiConnection("abc", "nettest.auth0.com", httpClient);
+            return httpClient;
+        }
+
+        private string[] GetAuth0ClientHeaders(HttpClient client)
+        {
+            return client.DefaultRequestHeaders.GetValues("Auth0-Client").ToArray();
+        }
+
+        private JObject GetPayload(HttpClient client)
+        {
+            var headers = GetAuth0ClientHeaders(client);
+            var decoded = Encoding.ASCII.GetString(Utils.Base64UrlDecode(headers[0]));
+            return JObject.Parse(decoded);
+        }
+    }
+}


### PR DESCRIPTION
- Changes SDK name to 'Auth0.net'
- Deprecate dependencies and environment telemetry
- Add limited 'target' via 'env' which tracks build of the SDK
- Deprecates DiagnosticsHeader entirely as it now has little use and doubles number of constructors on entry classes

Example:

```json
{"name":"Auth0.Net","version":"5.11.0","env":{"target":"NETSTANDARD2.0"}}
```

Adding CLR runtime is unfortunately non-trivial.  Operating System could be added but is of limited value.