### PR TITLE
ApiConnection should dispose HttpClient if it creates it

### DIFF
--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -8,7 +8,7 @@ namespace Auth0.ManagementApi
     /// <summary>
     /// Represents the Management API client.
     /// </summary>
-    public class ManagementApiClient
+    public class ManagementApiClient : IDisposable
     {
         private readonly ApiConnection _apiConnection;
 
@@ -203,6 +203,11 @@ namespace Auth0.ManagementApi
         public ManagementApiClient(string token, string domain)
             : this(token, new Uri($"https://{domain}/api/v2"), (HttpMessageHandler)null)
         {
+        }
+
+        public void Dispose()
+        {
+            _apiConnection.Dispose();
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ApiConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ApiConnectionTests.cs
@@ -1,0 +1,28 @@
+﻿using Auth0.Core.Http;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Auth0.ManagementApi.IntegrationTests
+{
+    public class ApiConnectionTests
+    {
+        [Fact]
+        public async Task Disposes_HttpClient_it_creates_on_dispose()
+        {
+            var apiConnection = new ApiConnection("token", "https://auth0.com");
+            apiConnection.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException >(() => apiConnection.GetAsync<string>("", null, null, null, null));
+        }
+
+        [Fact]
+        public async Task Does_not_dispose_HttpClient_it_was_given_on_dispose()
+        {
+            var httpClient = new HttpClient();
+            var apiConnection = new ApiConnection("token", "https://auth0.com", httpClient);
+            apiConnection.Dispose();
+            await apiConnection.GetAsync<string>("", null, null, null, null);
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/ManagementApiClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ManagementApiClientTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Auth0.ManagementApi.IntegrationTests
+{
+    public class ManagementApiClientTests
+    {
+        [Fact]
+        public async Task Disposes_ApiConnection_it_creates_on_dispose()
+        {
+            var management = new ManagementApiClient("token", "test");
+            management.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => management.Clients.GetAsync("1"));
+        }
+    }
+}


### PR DESCRIPTION
If ApiConnection creates a HttpClient it should dispose of it as well (ApiConnection owns it)

HttpClients that are created outside of ApiConnection and passed in via the constructor should not be disposed (ApiConnection does not own it)

Fixes #192