### PR TITLE
Add role permission endpoints to RoleClient

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientBase.cs
@@ -8,7 +8,7 @@ namespace Auth0.ManagementApi.Clients
     public class ClientBase
     {
         /// <summary>
-        /// The <see cref="IApiConnection"/> which is used to make all REST calls.
+        /// The <see cref="IApiConnection"/> which is used to make all HTTP API calls.
         /// </summary>
         internal IApiConnection Connection { get; }
 

--- a/src/Auth0.ManagementApi/Clients/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RolesClient.cs
@@ -132,7 +132,7 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="id">The ID of the role to query.</param>
         /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
-        /// <returns>An <see cref="IPagedList{AssignedUser}"/> containing the assigned user.</returns>
+        /// <returns>An <see cref="IPagedList{AssignedUser}"/> containing the assigned users.</returns>
         public Task<IPagedList<AssignedUser>> GetUsersAsync(string id, PaginationInfo pagination)
         {
             return Connection.GetAsync<IPagedList<AssignedUser>>("roles/{id}/users",
@@ -158,6 +158,48 @@ namespace Auth0.ManagementApi.Clients
                 {
                     {"id", id},
                 }, null, null);
+        }
+
+        /// <summary>
+        /// Gets the permissions for a role.
+        /// </summary>
+        /// <param name="id">The id of the role to obtain the permissions for.</param>
+        /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions.</returns>
+        public Task<IPagedList<Permission>> GetPermissionsAsync(string id, PaginationInfo pagination)
+        {
+            return Connection.GetAsync<IPagedList<Permission>>("roles/{id}/permissions",
+                new Dictionary<string, string>
+                {
+                        {"id", id},
+                        {"page", pagination.PageNo.ToString()},
+                        {"per_page", pagination.PerPage.ToString()},
+                        {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
+                }, null, null, new PagedListConverter<Permission>("users"));
+        }
+
+        /// <summary>
+        /// Add permissions to a role.
+        /// </summary>
+        /// <param name="id">The ID of the role to add permissions to.</param>
+        /// <param name="request">A <see cref="AssociatePermissionsRequest" /> containing the permission identifiers to remove from the role.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
+        public Task AssociatePermissionsAsync(string id, AssociatePermissionsRequest request)
+        {
+            return Connection.PostAsync<object>("roles/{id}/permissions", request, null, null,
+                new Dictionary<string, string> { { "id", id}, }, null, null);
+        }
+
+        /// <summary>
+        /// Remove permissions associated with a role.
+        /// </summary>
+        /// <param name="id">The ID of the role to remove permissions from.</param>
+        /// <param name="request">A <see cref="AssociatePermissionsRequest" /> containing the role IDs to remove to the user.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
+        public Task UnassociatePermissionsAsync(string id, AssociatePermissionsRequest request)
+        {
+            return Connection.DeleteAsync<object>("roles/{id}/permissions", request, 
+                new Dictionary<string, string> { {"id", id}, }, null);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Models/AssignRolesRequest.cs
+++ b/src/Auth0.ManagementApi/Models/AssignRolesRequest.cs
@@ -3,12 +3,12 @@ using Newtonsoft.Json;
 namespace Auth0.ManagementApi.Models
 {
     /// <summary>
-    ///
+    /// Contains details of roles that should be assigned to a user.
     /// </summary>
     public class AssignRolesRequest
     {
         /// <summary>
-        /// Role IDs to assign to the user
+        /// Role IDs to assign to the user.
         /// </summary>
         [JsonProperty("roles")]
         public string[] Roles { get; set; }

--- a/src/Auth0.ManagementApi/Models/AssignUsersRequest.cs
+++ b/src/Auth0.ManagementApi/Models/AssignUsersRequest.cs
@@ -3,12 +3,12 @@ using Newtonsoft.Json;
 namespace Auth0.ManagementApi.Models
 {
     /// <summary>
-    ///
+    /// Contains details of users that should be assigned to a role.
     /// </summary>
     public class AssignUsersRequest
     {
         /// <summary>
-        /// User IDs to assign to the role
+        /// User IDs to assign to the role.
         /// </summary>
         [JsonProperty("users")]
         public string[] Users { get; set; }

--- a/src/Auth0.ManagementApi/Models/AssociatePermissionsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/AssociatePermissionsRequest.cs
@@ -1,0 +1,17 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Contains details of permissions that should be assigned to a role.
+    /// </summary>
+    public class AssociatePermissionsRequest
+    {
+        /// <summary>
+        /// User IDs to assign to the role.
+        /// </summary>
+        [JsonProperty("permissions")]
+        public IList<PermissionIdentity> Permissions { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Permission.cs
+++ b/src/Auth0.ManagementApi/Models/Permission.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents a permission.
+    /// </summary>
+    public class Permission : PermissionIdentity
+    {
+        /// <summary>
+        /// The name of the resource server.
+        /// </summary>
+        [JsonProperty("resource_server_name")]
+        public string ResourceServerName { get; set; }
+
+        /// <summary>
+        /// The description of the permission.
+        /// </summary>
+        [JsonProperty("description")]
+        public string Description { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/PermissionIdentity.cs
+++ b/src/Auth0.ManagementApi/Models/PermissionIdentity.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents the properties of a permission that give it its unique identity.
+    /// </summary>
+    public class PermissionIdentity
+    {
+        /// <summary>
+        /// The resource server that the permission is attached to.
+        /// </summary>
+        [JsonProperty("resource_server_identifier")]
+        public string Identifier { get; set; }
+
+        /// <summary>
+        /// The name of the permission.
+        /// </summary>
+        [JsonProperty("permission_name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/ResourceServerBase.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServerBase.cs
@@ -41,7 +41,7 @@ namespace Auth0.ManagementApi.Models
         /// The amount of time (in seconds) that the token will be valid after being issued
         /// </summary>
         [JsonProperty("token_lifetime")]
-        public int TokenLifetime { get; set; }
+        public int? TokenLifetime { get; set; }
 
         /// <summary>
         /// The amount of time (in seconds) that the token will be valid after being issued from browser based flows.


### PR DESCRIPTION
Adds the permission endpoints as requested in #246 

Also fixes a couple of XML doc comments and makes ResourceServer.TokenLifetime nullable so you can patch it without changing it.