### PR TITLE
Add missing user permissions endpoints

### DIFF
--- a/src/Auth0.ManagementApi/Clients/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RolesClient.cs
@@ -161,11 +161,11 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <summary>
-        /// Gets the permissions for a role.
+        /// Gets the permissions assigned to a role.
         /// </summary>
         /// <param name="id">The id of the role to obtain the permissions for.</param>
         /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
-        /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions.</returns>
+        /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions for this role.</returns>
         public Task<IPagedList<Permission>> GetPermissionsAsync(string id, PaginationInfo pagination)
         {
             return Connection.GetAsync<IPagedList<Permission>>("roles/{id}/permissions",
@@ -178,28 +178,42 @@ namespace Auth0.ManagementApi.Clients
                 }, null, null, new PagedListConverter<Permission>("users"));
         }
 
-        /// <summary>
-        /// Add permissions to a role.
-        /// </summary>
-        /// <param name="id">The ID of the role to add permissions to.</param>
-        /// <param name="request">A <see cref="AssociatePermissionsRequest" /> containing the permission identifiers to remove from the role.</param>
-        /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
+        // TODO: Remove in 7.0.0
+        [Obsolete("Use AssignPermissionsAsync instead")]
         public Task AssociatePermissionsAsync(string id, AssociatePermissionsRequest request)
+        {
+            return AssignPermissionsAsync(id, request);
+        }
+
+        /// <summary>
+        /// Assign permissions to a role.
+        /// </summary>
+        /// <param name="id">The ID of the role to assign permissions to.</param>
+        /// <param name="request">A <see cref="AssignPermissionsRequest" /> containing the permission identifiers to assign to the role.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous assignment operation.</returns>
+        public Task AssignPermissionsAsync(string id, AssignPermissionsRequest request)
         {
             return Connection.PostAsync<object>("roles/{id}/permissions", request, null, null,
                 new Dictionary<string, string> { { "id", id}, }, null, null);
         }
 
         /// <summary>
-        /// Remove permissions associated with a role.
+        /// Remove permissions assigned to a role.
         /// </summary>
         /// <param name="id">The ID of the role to remove permissions from.</param>
-        /// <param name="request">A <see cref="AssociatePermissionsRequest" /> containing the role IDs to remove to the user.</param>
+        /// <param name="request">A <see cref="AssignPermissionsRequest" /> containing the permission identifiers to remove from the role.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
-        public Task UnassociatePermissionsAsync(string id, AssociatePermissionsRequest request)
+        public Task RemovePermissionsAsync(string id, AssignPermissionsRequest request)
         {
             return Connection.DeleteAsync<object>("roles/{id}/permissions", request, 
                 new Dictionary<string, string> { {"id", id}, }, null);
+        }
+
+        // TODO: Remove in 7.0.0
+        [Obsolete("Use RemovePermissionsAsync instead")]
+        public Task UnassociatePermissionsAsync(string id, AssociatePermissionsRequest request)
+        {
+            return RemovePermissionsAsync(id, request);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -318,7 +318,7 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <summary>
-        /// Removes permissions assign to a user.
+        /// Removes permissions assigned to a user.
         /// </summary>
         /// <param name="id">The ID of the user to remove permissions from.</param>
         /// <param name="request">A <see cref="AssignPermissionsRequest" /> containing the permission identifiers to remove from the user.</param>

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -286,5 +286,47 @@ namespace Auth0.ManagementApi.Clients
                 {"id", id}
             });
         }
+
+        /// <summary>
+        /// Get the permissions assigned to the user.
+        /// </summary>
+        /// <param name="id">The id of the user to obtain the permissions for.</param>
+        /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
+        /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions for this user.</returns>
+        public Task<IPagedList<Permission>> GetPermissionsAsync(string id, PaginationInfo pagination)
+        {
+            return Connection.GetAsync<IPagedList<Permission>>("users/{id}/permissions",
+                new Dictionary<string, string>
+                {
+                        {"id", id},
+                        {"page", pagination.PageNo.ToString()},
+                        {"per_page", pagination.PerPage.ToString()},
+                        {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
+                }, null, null, new PagedListConverter<Permission>("users"));
+        }
+
+        /// <summary>
+        /// Assign permissions to a user.
+        /// </summary>
+        /// <param name="id">The ID of the user to assign permissions to.</param>
+        /// <param name="request">A <see cref="AssignPermissionsRequest" /> containing the permission identifiers to assign to the user.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous assignment operation.</returns>
+        public Task AssignPermissionsAsync(string id, AssignPermissionsRequest request)
+        {
+            return Connection.PostAsync<object>("users/{id}/permissions", request, null, null,
+                new Dictionary<string, string> { { "id", id }, }, null, null);
+        }
+
+        /// <summary>
+        /// Removes permissions assign to a user.
+        /// </summary>
+        /// <param name="id">The ID of the user to remove permissions from.</param>
+        /// <param name="request">A <see cref="AssignPermissionsRequest" /> containing the permission identifiers to remove from the user.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
+        public Task RemovePermissionsAsync(string id, AssignPermissionsRequest request)
+        {
+            return Connection.DeleteAsync<object>("users/{id}/permissions", request,
+                new Dictionary<string, string> { { "id", id }, }, null);
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Models/AssociatePermissionsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/AssociatePermissionsRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace Auth0.ManagementApi.Models
@@ -6,12 +7,18 @@ namespace Auth0.ManagementApi.Models
     /// <summary>
     /// Contains details of permissions that should be assigned to a role.
     /// </summary>
-    public class AssociatePermissionsRequest
+    public class AssignPermissionsRequest
     {
         /// <summary>
         /// User IDs to assign to the role.
         /// </summary>
         [JsonProperty("permissions")]
         public IList<PermissionIdentity> Permissions { get; set; }
+    }
+
+    // TODO: Remove in 7.0.0
+    [Obsolete("Use AssignPermissionsRequest class instead")]
+    public class AssociatePermissionsRequest : AssignPermissionsRequest
+    {
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
@@ -228,11 +228,11 @@ namespace Auth0.ManagementApi.IntegrationTests
             });
 
             // Associate a permission with the role
-            var assignPermissionsRequest = new AssociatePermissionsRequest()
+            var assignPermissionsRequest = new AssignPermissionsRequest()
             {
                 Permissions = new[] { new PermissionIdentity { Identifier = resourceServer.Identifier, Name = newScope.Value } } 
             };
-            await _apiClient.Roles.AssociatePermissionsAsync(role.Id, assignPermissionsRequest);
+            await _apiClient.Roles.AssignPermissionsAsync(role.Id, assignPermissionsRequest);
 
             // Ensure the permission is associated with the role
             var associatedPermissions = await _apiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo());
@@ -242,7 +242,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             associatedPermissions.First().Name.Should().Be(newScope.Value);
 
             // Unassociate a permission with the role
-            await _apiClient.Roles.UnassociatePermissionsAsync(role.Id, assignPermissionsRequest);
+            await _apiClient.Roles.RemovePermissionsAsync(role.Id, assignPermissionsRequest);
 
             // Ensure the permission is unassociated with the role
             associatedPermissions = await _apiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo());


### PR DESCRIPTION
1. Adds `GET users/{id}/permissions` endpoint as `Users.GetPermissionsAsync(...)`
2. Adds `POST users/{id}/permissions` endpoint as `Users.AssignPermissionsAsync(...)`
3. Adds `DELETE users/{id}/permissions` endpoint as `Users.RemovePermissionsAsync(...)`

Also adjusts the existing naming on RolesClient permissions endpoints to be consistent with the API documentation.  Associate and Unassociate is now Assign and Remove. 