### PR TITLE
Add missing properties to ResourceServer

### DIFF
--- a/src/Auth0.ManagementApi/Models/ResourceServerBase.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServerBase.cs
@@ -29,7 +29,7 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty("signing_alg")]
-        public SigningAlgorithm SigningAlgorithm { get; set; }
+        public SigningAlgorithm? SigningAlgorithm { get; set; }
 
         /// <summary>
         /// The secret used to sign tokens when using symmetric algorithms
@@ -54,12 +54,31 @@ namespace Auth0.ManagementApi.Models
         /// Allows issuance of refresh tokens for this entity
         /// </summary>
         [JsonProperty("allow_offline_access")]
-        public bool AllowOfflineAccess { get; set; }
+        public bool? AllowOfflineAccess { get; set; }
 
         /// <summary>
         /// Flag this entity as capable of skipping consent
         /// </summary>
         [JsonProperty("skip_consent_for_verifiable_first_party_clients")]
-        public bool SkipConsentForVerifiableFirstPartyClients { get; set; }
+        public bool? SkipConsentForVerifiableFirstPartyClients { get; set; }
+
+        /// <summary>
+        /// A uri from which to retrieve JWKs for this resource server used for verifying the JWT sent to Auth0 for token introspection.
+        /// </summary>
+        [JsonProperty("verificationLocation")]
+        public string VerificationLocation { get; set; }
+
+        /// <summary>
+        /// The dialect for the access token.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("token_dialect")]
+        public TokenDialect? TokenDialect { get; set; }
+
+        /// <summary>
+        /// Enables the enforcement of the authorization policies.
+        /// </summary>
+        [JsonProperty("enforce_policies")]
+        public bool? EnforcePolicies { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/TokenDialect.cs
+++ b/src/Auth0.ManagementApi/Models/TokenDialect.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    public enum TokenDialect
+    {
+        [EnumMember(Value = "access_token")]
+        AccessToken,
+
+        [EnumMember(Value = "access_token_authz")]
+        AccessTokenAuthZ
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
@@ -31,7 +31,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Add a new resource server
             var identifier = Guid.NewGuid();
-            var newResourceServerRequest = new ResourceServerCreateRequest()
+            var createResourceServerRequest = new ResourceServerCreateRequest()
             {
                 Identifier = identifier.ToString("N"),
                 Name = $"Integration testing {identifier:N}",
@@ -46,13 +46,18 @@ namespace Auth0.ManagementApi.IntegrationTests
                         Value = "scope1",
                         Description = "Scope number 1"
                     }
-                }
+                },
+                AllowOfflineAccess = true,
+                //EnforcePolicies = true,
+                //TokenDialect = TokenDialect.AccessTokenAuthZ,
+                VerificationLocation = "https://abc.auth0.com/def",
+                SkipConsentForVerifiableFirstPartyClients = true,
             };
-            var newResourceServerResponse = await _apiClient.ResourceServers.CreateAsync(newResourceServerRequest);
-            newResourceServerResponse.Should().BeEquivalentTo(newResourceServerRequest, options => options.Excluding(rs => rs.Id));
+            var newResourceServerResponse = await _apiClient.ResourceServers.CreateAsync(createResourceServerRequest);
+            newResourceServerResponse.Should().BeEquivalentTo(createResourceServerRequest, options => options.Excluding(rs => rs.Id));
 
             // Update the resource server
-            var resourceServerRequest = new ResourceServerUpdateRequest()
+            var updateResourceServerRequest = new ResourceServerUpdateRequest()
             {
                 Name = $"Integration testing {Guid.NewGuid():N}",
                 TokenLifetime = 2,
@@ -71,14 +76,19 @@ namespace Auth0.ManagementApi.IntegrationTests
                         Value = "scope2",
                         Description = "Scope number 2"
                     }
-                }
+                },
+                AllowOfflineAccess = false,
+                EnforcePolicies = false,
+                TokenDialect = TokenDialect.AccessToken,
+                VerificationLocation = "",
+                SkipConsentForVerifiableFirstPartyClients = false,
             };
-            var updateResourceServerResponse = await _apiClient.ResourceServers.UpdateAsync(newResourceServerResponse.Id, resourceServerRequest);
-            updateResourceServerResponse.Should().BeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
+            var updateResourceServerResponse = await _apiClient.ResourceServers.UpdateAsync(newResourceServerResponse.Id, updateResourceServerRequest);
+            updateResourceServerResponse.Should().BeEquivalentTo(updateResourceServerRequest, options => options.ExcludingMissingMembers());
 
             // Get a single resource server
             var resourceServer = await _apiClient.ResourceServers.GetAsync(newResourceServerResponse.Id);
-            resourceServer.Should().BeEquivalentTo(resourceServerRequest, options => options.ExcludingMissingMembers());
+            resourceServer.Should().BeEquivalentTo(updateResourceServerRequest, options => options.ExcludingMissingMembers());
 
             // Delete the client, and ensure we get exception when trying to fetch client again
             await _apiClient.ResourceServers.DeleteAsync(resourceServer.Id);


### PR DESCRIPTION
Added missing properties to the ResourceServer (Base) class:

1. VerificationLocation
2. TokenDialect 
3. EnforcePolicies 

Also made some properties that were supposed to be optional actually optional:

1. SigningAlgorithm
2. AllowOfflineAccess
3. SkipConsentForVerifiableFirstPartyClients 