### PR TITLE
Add IDisposable support to AuthenticationApiClient

### DIFF
--- a/src/Auth0.Core/Http/ApiConnection.cs
+++ b/src/Auth0.Core/Http/ApiConnection.cs
@@ -364,6 +364,9 @@ namespace Auth0.Core.Http
             return JsonConvert.DeserializeObject<T>(content, converters);
         }
 
+        /// <summary>
+        /// Disposes of any owned disposable resources such as a HttpClient if it was not supplied.
+        /// </summary>
         public void Dispose()
         {
             if (_disposeHttpClient)

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -205,6 +205,9 @@ namespace Auth0.ManagementApi
         {
         }
 
+        /// <summary>
+        /// Disposes of any owned disposable resources such as the ApiConnection.
+        /// </summary>
         public void Dispose()
         {
             _apiConnection.Dispose();

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/AuthenticationApiClientTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/AuthenticationApiClientTests.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests
+{
+    public class AuthenticationApiClientTests
+    {
+        [Fact]
+        public async Task Disposes_ApiConnection_it_creates_on_dispose()
+        {
+            var authClient = new AuthenticationApiClient("dotnet.auth0.com");
+            authClient.Dispose();
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => authClient.StartPasswordlessSmsFlowAsync(new Models.PasswordlessSmsRequest()));
+        }
+    }
+}


### PR DESCRIPTION
1. Add's IDisposable support to AuthenticationApiClient to match ManagementApiClient
2. Consolidates ManagementApiClient constructors in a source-compatible way
3. Adds missing Dispose xmldoc comments

cc @nicosabena 