### PR TITLE
Add missing User endpoints for Guardian

### DIFF
--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -195,12 +195,54 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="IList{User}"/> containing all users for this email address.</returns>
         public Task<IList<User>> GetUsersByEmailAsync(string email, string fields = null, bool? includeFields = null)
         {
-            return Connection.GetAsync<IList<User>>("users-by-email", null,
+            return Connection.GetAsync<IList<User>>("users/users-by-email", null,
                 new Dictionary<string, string>
                 {
                     {"email", email},
                     {"fields", fields},
-                    {"include_fields", includeFields?.ToString().ToLower()},
+                    {"include_fields", includeFields?.ToString().ToLower()}
+                }, null, null);
+        }
+
+        /// <summary>
+        /// Get a list of Guardian enrollments.
+        /// </summary>
+        /// <param name="id">The user_id of the user to retrieve.</param>
+        /// <returns>A Task representing the operation and potential return value.</returns>
+        public Task<IList<EnrollmentsResponse>> GetEnrollmentsAsync(string id)
+        {
+            return Connection.GetAsync<IList<EnrollmentsResponse>>("users/{id}/enrollments", null,
+                new Dictionary<string, string>
+                {
+                    {"id", id}
+                }, null, null);
+        }
+
+        /// <summary>
+        /// Invalidate all remembered browsers for MFA.
+        /// </summary>
+        /// <param name="id">The user_id of the user which will have its remembered browsers for MFA invalidated.</param>
+        /// <returns>A Task representing the operation and potential return value.</returns>
+        public Task InvalidateRememberBrowserAsync(string id)
+        {
+            return Connection.PostAsync<object>("users/{id}/multifactor/actions/invalidate-remember-browser", null, null, null,
+                new Dictionary<string, string>
+                {
+                    {"id", id}
+                }, null, null);
+        }
+
+        /// <summary>
+        /// Generate new Guardian recovery code.
+        /// </summary>
+        /// <param name="id">The user_id of the user which guardian code will be regenerated.</param>
+        /// <returns>A Task representing the operation and potential return value.</returns>
+        public Task<GenerateRecoveryCodeResponse> GenerateRecoveryCodeAsync(string id)
+        {
+            return Connection.PostAsync<GenerateRecoveryCodeResponse>("users/{id}/recovery-code-regeneration", null, null, null,
+                new Dictionary<string, string>
+                {
+                    {"id", id}
                 }, null, null);
         }
 
@@ -212,10 +254,11 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="IList{AccountLinkResponse}"/> containing details about this account link.</returns>
         public Task<IList<AccountLinkResponse>> LinkAccountAsync(string id, UserAccountLinkRequest request)
         {
-            return Connection.PostAsync<IList<AccountLinkResponse>>("users/{id}/identities", request, null, null, new Dictionary<string, string>
-            {
-                {"id", id}
-            }, null, null);
+            return Connection.PostAsync<IList<AccountLinkResponse>>("users/{id}/identities", request, null, null, 
+                new Dictionary<string, string>
+                {
+                    {"id", id}
+                }, null, null);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -195,7 +195,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="IList{User}"/> containing all users for this email address.</returns>
         public Task<IList<User>> GetUsersByEmailAsync(string email, string fields = null, bool? includeFields = null)
         {
-            return Connection.GetAsync<IList<User>>("users/users-by-email", null,
+            return Connection.GetAsync<IList<User>>("users-by-email", null,
                 new Dictionary<string, string>
                 {
                     {"email", email},

--- a/src/Auth0.ManagementApi/Models/EnrollmentAuthMethod.cs
+++ b/src/Auth0.ManagementApi/Models/EnrollmentAuthMethod.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Method of authentication for a Guardian Enrollment.
+    /// </summary>
+    public enum EnrollmentAuthMethod
+    {
+        [EnumMember(Value = "authentication")]
+        Authentication,
+
+        [EnumMember(Value = "guardian")]
+        Guardian,
+
+        [EnumMember(Value = "sms")]
+        SMS
+    }
+}

--- a/src/Auth0.ManagementApi/Models/EnrollmentStatus.cs
+++ b/src/Auth0.ManagementApi/Models/EnrollmentStatus.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Status of a Guardian Enrollment.
+    /// </summary>
+    public enum EnrollmentStatus
+    {
+        [EnumMember(Value = "pending")]
+        Pending,
+
+        [EnumMember(Value = "confirmed")]
+        Confirmed
+    }
+}

--- a/src/Auth0.ManagementApi/Models/EnrollmentsResponse.cs
+++ b/src/Auth0.ManagementApi/Models/EnrollmentsResponse.cs
@@ -1,0 +1,68 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents a Guardian Enrollment.
+    /// </summary>
+    public class EnrollmentsResponse
+    {
+        /// <summary>
+        /// Enrollment generated id.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Enrollment status.
+        /// </summary>
+        [JsonProperty("status")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EnrollmentStatus Status { get; set; }
+
+        /// <summary>
+        /// Enrollment type.
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Enrollment name (usually phone number).
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Device identifier (usually phone identifier) of this enrollment.
+        /// </summary>
+        [JsonProperty("identifier")]
+        public string Identifier { get; set; }
+
+        /// <summary>
+        /// Phone number for this enrollment. 
+        /// </summary>
+        [JsonProperty("phone_number")]
+        public string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// Authentication method for this enrollment. Can be `authentication`, `guardian`, or `sms`.
+        /// </summary>
+        [JsonProperty("auth_method")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EnrollmentAuthMethod AuthMethod { get; set; }
+
+        /// <summary>
+        /// Start date and time of this enrollment.
+        /// </summary>
+        [JsonProperty("enrolled_at")]
+        public DateTime EnrolledAt { get; set; }
+
+        /// <summary>
+        /// Last authentication date and time of this enrollment.
+        /// </summary>
+        [JsonProperty("last_auth")]
+        public DateTime LastAuth { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GenerateRecoveryCodeResponse.cs
+++ b/src/Auth0.ManagementApi/Models/GenerateRecoveryCodeResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents a Generate Recovery Code response.
+    /// </summary>
+    public class GenerateRecoveryCodeResponse
+    {
+        /// <summary>
+        /// New recovery code.
+        /// </summary>
+        [JsonProperty("recovery_code")]
+        public string RecoveryCode { get; set; }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -94,6 +94,29 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
+        public async Task Test_user_by_email()
+        {
+            var email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa";
+
+            var newUserRequest = new UserCreateRequest
+            {
+                Connection = _connection.Name,
+                Email = email,
+                EmailVerified = true,
+                Password = Password
+            };
+
+            var newUserResponse = await _apiClient.Users.CreateAsync(newUserRequest);
+
+            // Ensure we can find the user by email address
+            var users = await _apiClient.Users.GetUsersByEmailAsync(email);
+            Assert.Single(users);
+
+            // Make sure they are one and the same
+            Assert.Same(newUserResponse.UserId, users[0].UserId);
+        }
+
+        [Fact]
         public async Task Test_user_blocking()
         {
             // Add a new user, and ensure user is not blocked

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -113,7 +113,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             Assert.Single(users);
 
             // Make sure they are one and the same
-            Assert.Same(newUserResponse.UserId, users[0].UserId);
+            Assert.Equal(newUserResponse.UserId, users[0].UserId);
         }
 
         [Fact]


### PR DESCRIPTION
Three Guardian-related endpoints were missed in #240 as they live on the User endpoints not Guardian.

Also noticed "users-by-email" did not have an integration test.

Fixes #270 