### PR TITLE
Use GenerateDocumentationFile instead to specify if the xml documentation should be created.

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -118,4 +118,7 @@
     <InformationalVersion>$(Major).$(Minor).$(Revision)</InformationalVersion>
     <PackageVersion>$(Major).$(Minor).$(Revision)</PackageVersion>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
 </Project>

--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -6,9 +6,6 @@
     <AssemblyName>Auth0.AuthenticationApi</AssemblyName>
     <PackageId>Auth0.AuthenticationApi</PackageId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Auth0.AuthenticationApi.xml</DocumentationFile>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>

--- a/src/Auth0.Core/Auth0.Core.csproj
+++ b/src/Auth0.Core/Auth0.Core.csproj
@@ -19,10 +19,6 @@
     <DefineConstants>NETSTANDARD2_0</DefineConstants>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Auth0.Core.xml</DocumentationFile>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
   </ItemGroup>

--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
@@ -6,9 +6,6 @@
     <AssemblyName>Auth0.ManagementApi</AssemblyName>
     <PackageId>Auth0.ManagementApi</PackageId>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\Auth0.ManagementApi.xml</DocumentationFile>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>


### PR DESCRIPTION
### Changes

This PR changes the explicit declaration of `DocumentationFile` into `GenerateDocumentationFile` where the name of the xml file will be determined automatically.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
