### PR TITLE
Issue#284: Fixing pagination in UsersClient GetPermissionsAsync

### DIFF
--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -341,11 +341,14 @@ namespace Auth0.ManagementApi.Clients
             return Connection.GetAsync<IPagedList<Permission>>("users/{id}/permissions",
                 new Dictionary<string, string>
                 {
-                        {"id", id},
-                        {"page", pagination.PageNo.ToString()},
-                        {"per_page", pagination.PerPage.ToString()},
-                        {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }, null, null, new PagedListConverter<Permission>("users"));
+                     {"id", id}
+                },
+                new Dictionary<string, string>
+                {
+                    {"page", pagination.PageNo.ToString()},
+                    {"per_page", pagination.PerPage.ToString()},
+                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
+                }, null, new PagedListConverter<Permission>("users"));
         }
 
         /// <summary>


### PR DESCRIPTION
### Changes

Fixed the `UsersClient.GetPermissionsAsync` method's parameters. Split the `urlSegments` param and `queryStrings` param into two dictionaries while making the request. This change is now in line with other clients' GET methods that return paging information along with the response.

### References

Please include relevant links supporting this change such as a:

Issue 284: https://github.com/auth0/auth0.net/issues/284

### Testing

A call to `UsersClient.GetPermissionsAsync`  should return the paging information now in the `Paging` object on `IPagedList<Permission>`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
