### PR TITLE
Fix permission paging bug

### DIFF
--- a/src/Auth0.ManagementApi/Clients/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RolesClient.cs
@@ -181,7 +181,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }, null, new PagedListConverter<Permission>("users"));
+                }, null, new PagedListConverter<Permission>("permissions"));
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -348,7 +348,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }, null, new PagedListConverter<Permission>("users"));
+                }, null, new PagedListConverter<Permission>("permissions"));
         }
 
         /// <summary>

--- a/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
@@ -288,5 +288,13 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Assert
             Assert.NotNull(roles.Paging);
         }
+
+        [Fact]
+        public async Task Test_permissions_can_be_retrieved()
+        {
+            var userPermissions = await _apiClient.Roles.GetPermissionsAsync("rol_XzVrldh70ox7yjl2", new PaginationInfo(0, 50, true));
+
+            Assert.Equal(2, userPermissions.Count);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -354,6 +354,14 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
+        public async Task Test_permissions_can_be_retrieved()
+        {
+            var userPermissions = await _apiClient.Users.GetPermissionsAsync("auth0|5d4344cd2c016b0e7a14313a", new PaginationInfo(0, 50, true));
+            
+            Assert.Equal(2, userPermissions.Count);
+        }
+
+        [Fact]
         public async Task Test_roles_assign_unassign_permission_to_user()
         {
             var userCreateRequest = new UserCreateRequest


### PR DESCRIPTION
Permission paging was broken as it was looking for the wrong property in the returned object.

Added integration tests.