### PR TITLE
Add ClientId to the VerifyEmailJobRequest as per the API specification

### DIFF
--- a/src/Auth0.ManagementApi/Models/VerifyEmailJobRequest.cs
+++ b/src/Auth0.ManagementApi/Models/VerifyEmailJobRequest.cs
@@ -15,6 +15,11 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("user_id")]
         public string UserId { get; set; }
 
+        /// <summary>
+        /// The id of the client, if not provided the global one will be used
+        /// </summary>
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
     }
 
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
@@ -51,7 +51,8 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Send an email verification request
             var emailRequest = new VerifyEmailJobRequest
             {
-                UserId = _user.UserId
+                UserId = _user.UserId,
+                ClientId = GetVariable("AUTH0_CLIENT_ID")
             };
             var emailRequestResponse = await _apiClient.Jobs.SendVerificationEmailAsync(emailRequest);
             emailRequestResponse.Should().NotBeNull();


### PR DESCRIPTION
### Changes

@damieng, as discussed I've added ClientId parameter for the verify email job request to bring it in line with the API spec, changed the VerifyEmailJobRequest class

### References

https://github.com/auth0/auth0.net/issues/292
https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email

### Testing

I experience the `Global limit has been reached`, I ran each test individually so should be fine, anything should be caught in CI/CD test coverage

- [ ] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
