### PR TITLE
ClientBase now has initiate_login_uri property

### DIFF
--- a/src/Auth0.ManagementApi/Models/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientBase.cs
@@ -41,6 +41,12 @@ namespace Auth0.ManagementApi.Models
         public string[] WebOrigins { get; set; }
 
         /// <summary>
+        /// The default login initiation endpoint.
+        /// </summary>
+        [JsonProperty("initiate_login_uri")]
+        public string InitiateLoginUri { get; set; }
+
+        /// <summary>
         /// A set of URLs that are valid to call back from Auth0 when authenticating users.
         /// </summary>
         [JsonProperty("callbacks")]
@@ -122,16 +128,16 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; }
-        
+
         /// <summary>
         /// The description of the client. Max character count is 140
         /// </summary>
         [JsonProperty("description")]
         public string Description { get; set; }
-        
+
         /// <summary>
-        /// The logo_uri of the client. The URL of the logo to display for the application, 
-        /// if none is set the default badge for this type of application will be shown. 
+        /// The logo_uri of the client. The URL of the logo to display for the application,
+        /// if none is set the default badge for this type of application will be shown.
         /// Recommended size is 150x150 pixels
         /// </summary>
         [JsonProperty("logo_uri")]

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -38,7 +38,8 @@ namespace Auth0.ManagementApi.IntegrationTests
                 {
                     Prop1 = "1",
                     Prop2 = "2"
-                }
+                },
+                InitiateLoginUri = "https://create.com/login"
             };
             var newClientResponse = await _apiClient.Clients.CreateAsync(newClientRequest);
             newClientResponse.Should().NotBeNull();
@@ -51,7 +52,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             string prop2 = newClientResponse.ClientMetaData.Prop2;
             prop2.Should().Be("2");
             newClientResponse.GrantTypes.Should().HaveCount(i => i > 0);
-
+            newClientResponse.InitiateLoginUri.Should().Be("https://create.com/login");
 
             // Update the client
             var updateClientRequest = new ClientUpdateRequest
@@ -59,7 +60,8 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"Integration testing {Guid.NewGuid():N}",
                 TokenEndpointAuthMethod = TokenEndpointAuthMethod.ClientSecretPost,
                 ApplicationType = ClientApplicationType.Spa,
-                GrantTypes = new string[0]
+                GrantTypes = new string[0],
+                InitiateLoginUri = "https://update.com/login"
             };
             var updateClientResponse = await _apiClient.Clients.UpdateAsync(newClientResponse.ClientId, updateClientRequest);
             updateClientResponse.Should().NotBeNull();
@@ -67,6 +69,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             updateClientResponse.TokenEndpointAuthMethod.Should().Be(TokenEndpointAuthMethod.ClientSecretPost);
             updateClientResponse.ApplicationType.Should().Be(ClientApplicationType.Spa);
             updateClientResponse.GrantTypes.Should().HaveCount(0);
+            updateClientResponse.InitiateLoginUri.Should().Be("https://update.com/login");
 
             // Get a single client
             var client = await _apiClient.Clients.GetAsync(newClientResponse.ClientId);
@@ -78,7 +81,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             Func<Task> getFunc = async () => await _apiClient.Clients.GetAsync(client.ClientId);
             getFunc.Should().Throw<ApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_client");
         }
-        
+
         [Fact]
         public async Task Test_client_rotate_secret()
         {
@@ -96,7 +99,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 ApplicationType = ClientApplicationType.Native
             };
             var newClientResponse = await _apiClient.Clients.CreateAsync(newClientRequest);
-          
+
             // Rotate the secret
             var updateClientResponse = await _apiClient.Clients.RotateClientSecret(newClientResponse.ClientId);
 
@@ -112,7 +115,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var clients = await _apiClient.Clients.GetAllAsync(new GetClientsRequest(), new PaginationInfo());
-            
+
             // Assert
             Assert.Null(clients.Paging);
         }
@@ -122,7 +125,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var clients = await _apiClient.Clients.GetAllAsync(new GetClientsRequest(), new PaginationInfo(0, 50, false));
-            
+
             // Assert
             Assert.Null(clients.Paging);
         }
@@ -132,7 +135,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var clients = await _apiClient.Clients.GetAllAsync(new GetClientsRequest(), new PaginationInfo(0, 50, true));
-            
+
             // Assert
             Assert.NotNull(clients.Paging);
         }
@@ -154,7 +157,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 ApplicationType = ClientApplicationType.Native
             };
             var newClientResponse = await _apiClient.Clients.CreateAsync(newClientRequest);
-          
+
             // Rotate the secret
             var connections = await _apiClient.Clients.GetAllAsync(new GetClientsRequest
             {


### PR DESCRIPTION
### Changes

There exists no current way to set the initiate_login_uri property on a client through this library support for the management API

- Added property InitiateLoginUri to Auth0.ManagementApi.Models.ClientBase class so this property can be set and retrieved
- Updated client CRUD integration test

### References

We require this change to support our development as we make use of this library in our application. We need a way to be able to get & set this property for CRUD operations on Client

### Testing

- Existing tests have been run and complete without errors
- Updated client CRUD integration test

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
