### PR TITLE
WithConnectionScope method added to AuthorizationUrlBuilder

### DIFF
--- a/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
@@ -137,5 +137,17 @@ namespace Auth0.AuthenticationApi.Builders
 
             return this;
         }
+
+        /// <summary>
+        /// Adds a new connection_scope query string parameter.
+        /// </summary>
+        /// <param name="connectionScope">The connection scope to be passed to the corresponding connection. Multiple scopes must be separated by a space character.</param>
+        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        public AuthorizationUrlBuilder WithConnectionScope(string connectionScope)
+        {
+            AddQueryString("connection_scope", connectionScope);
+
+            return this;
+        }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/UriBuildersTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/UriBuildersTests.cs
@@ -23,11 +23,12 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 .WithAudience("https://myapi.com/v2")
                 .WithNonce("MyNonce")
                 .WithState("MyState")
+                .WithConnectionScope("ConnectionScope")
                 .Build();
 
             authorizationUrl.Should()
                 .Be(
-                    new Uri("https://auth0-dotnet-integration-tests.auth0.com/authorize?response_type=code&client_id=rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW&connection=google-oauth2&redirect_uri=http%3A%2F%2Fwww.jerriepelser.com%2Ftest&scope=openid%20offline_access&audience=https%3A%2F%2Fmyapi.com%2Fv2&nonce=MyNonce&state=MyState"));
+                    new Uri("https://auth0-dotnet-integration-tests.auth0.com/authorize?response_type=code&client_id=rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW&connection=google-oauth2&redirect_uri=http%3A%2F%2Fwww.jerriepelser.com%2Ftest&scope=openid%20offline_access&audience=https%3A%2F%2Fmyapi.com%2Fv2&nonce=MyNonce&state=MyState&connection_scope=ConnectionScope"));
         }
 
         [Fact]


### PR DESCRIPTION
### Changes

Adding **WithConnectionScope** to **AuthorizationUrlBuilder **

Actually, the AuthorizationUrlBuilder does not offer any way to include Connection Scopes when building the authorization URL. This forces us to concatenate the aforementioned field manually, e.g.:

```
using (var authenticationApiClient = new AuthenticationApiClient(new Uri("BASE_URL")))
{
    var urlBuilder = authenticationApiClient.BuildAuthorizationUrl();
    urlBuilder
        // More stuff...
        .WithScope("offline_access openid");

    var url = urlBuilder.Build();

    return url.AbsoluteUri + "&connection_scope=IDP scopes";
}
```

By introducing this new method *WithConnectionScope*, we will be able to include connection scopes following the same fluent-api approach the builder already uses, resulting in a cleaner solution. E.g.:

```
using (var authenticationApiClient = new AuthenticationApiClient(new Uri("BASE_URL")))
{
    var urlBuilder = authenticationApiClient.BuildAuthorizationUrl();
    urlBuilder
        .WithResponseType(AuthorizationResponseType.Code)
        // More stuff...
        .WithConnectionScope("IDP scopes");

    var url = urlBuilder.Build();

    return url.AbsoluteUri;
}
```

### References

N/A

### Testing

This new method can be tested by calling **WithConnectionScope** method on the **AuthorizationUrlBuilder** with the scopes you want to pass to the IDP. A new query string parameter will be included in the constructed URL, e.g.:

https://auth0-dotnet-integration-tests.auth0.com/authorize?other_parameters&connection_scope=ConnectionScope

- [ ] This change adds unit test coverage

- [x] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
