### PR TITLE
Improve API builders

### DIFF
--- a/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
@@ -1,153 +1,165 @@
 using Auth0.AuthenticationApi.Models;
+using System;
 using System.Linq;
 
 namespace Auth0.AuthenticationApi.Builders
 {
     /// <summary>
-    /// Used to build am authorization URL.
+    /// Builder class used to fluently construct an authorization URL.
     /// </summary>
+    /// <remarks>
+    /// See https://auth0.com/docs/api/authentication#login for more details.
+    /// </remarks>
     public class AuthorizationUrlBuilder : UrlBuilderBase<AuthorizationUrlBuilder>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizationUrlBuilder"/> class.
         /// </summary>
-        /// <param name="baseUrl">The base URL of the Authentication API.</param>
-        public AuthorizationUrlBuilder(string baseUrl) 
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="String"/>.</param>
+        public AuthorizationUrlBuilder(string baseUrl)
             : base(baseUrl, "authorize")
         {
         }
 
         /// <summary>
-        /// Adds an access_token query string parameter.
+        /// Initializes a new instance of the <see cref="AuthorizationUrlBuilder"/> class.
         /// </summary>
-        /// <param name="accessToken"></param>
-        /// <returns></returns>
-        public AuthorizationUrlBuilder WithAccessToken(string accessToken)
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="Uri"/>.</param>
+        public AuthorizationUrlBuilder(Uri baseUrl)
+            : base(baseUrl, "authorize")
         {
-            AddQueryString("access_token", accessToken);
-
-            return this;
         }
 
         /// <summary>
-        /// Adds a new client_id query string parameter.
+        /// Adds the `client_id` query string parameter specifying the Client ID of the application.
         /// </summary>
-        /// <param name="clientId">The client identifier.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <param name="clientId">Client ID of the application.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithClient(string clientId)
         {
-            AddQueryString("client_id", clientId);
-
-            return this;
+            return WithValue("client_id", clientId);
         }
 
         /// <summary>
-        /// Add a new connection query string parameter.
+        /// Adds the `connection` query string parameter specifying the connection name.
         /// </summary>
         /// <param name="connectionName">Name of the connection.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithConnection(string connectionName)
         {
-            AddQueryString("connection", connectionName);
-
-            return this;
+            return WithValue("connection", connectionName);
         }
 
         /// <summary>
-        /// Adds a new redirect_uri query string parameter
+        /// Adds the `redirect_uri` query string parameter specifying the redirect URI.
         /// </summary>
-        /// <param name="url">The URL of the redirect URI</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
-        public AuthorizationUrlBuilder WithRedirectUrl(string url)
+        /// <param name="uri">URI to redirect to.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        public AuthorizationUrlBuilder WithRedirectUrl(string uri)
         {
-            AddQueryString("redirect_uri", url);
-
-            return this;
+            return WithValue("redirect_uri", uri);
+        }
+        /// <summary>
+        /// Adds the `redirect_uri` query string parameter specifying the redirect URI.
+        /// </summary>
+        /// <param name="uri"><see cref="Uri"/> to redirect to.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        public AuthorizationUrlBuilder WithRedirectUrl(Uri uri)
+        {
+            return WithRedirectUrl(uri.OriginalString);
         }
 
         /// <summary>
-        /// Adds a new response_type query string parameter indicating 
-        /// the type of response that the client expects.
+        /// Adds the `response_type` query string parameter specifying the types of responses 
+        /// that the client expects.
         /// </summary>
-        /// <param name="responseType">Type of the response.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <param name="responseType"><see cref="AuthorizationResponseType"/> the client expects.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithResponseType(params AuthorizationResponseType[] responseType)
         {
-            AddQueryString("response_type", string.Join(" ",responseType.Select(AuthorizationResponseTypeHelper.ConvertToString)));
-
-            return this;
+            return WithValue("response_type", string.Join(" ", responseType.Select(AuthorizationResponseTypeHelper.ConvertToString)));
         }
 
         /// <summary>
-        /// Adds a new scope query string parameter.
+        /// Adds the `scope` query string parameter indicating the scopes the client wants to request.
         /// </summary>
-        /// <param name="scope">The scope. Multiple scopes must be separated by a space character.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <param name="scope">Scopes to request. Multiple scopes must be separated by a space character.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithScope(string scope)
         {
-            AddQueryString("scope", scope);
-
-            return this;
+            return WithValue("scope", scope);
         }
 
         /// <summary>
-        /// Adds a new state query string parameter.
+        /// Adds the `scope` query string parameter indicating the scopes the client wants to request.
         /// </summary>
-        /// <param name="state">The state.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <param name="scopes">Scopes the client wants to request.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        public AuthorizationUrlBuilder WithScopes(params string[] scopes)
+        {
+            return WithScope(String.Join(" ", scopes));
+        }
+
+        /// <summary>
+        /// Adds the `state` query string parameter specifying a value to be returned on completion in 
+        /// order to prevent CSRF attacks.
+        /// </summary>
+        /// <param name="state">State value to be passed back on successful authorization.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithState(string state)
         {
-            AddQueryString("state", state);
-
-            return this;
+            return WithValue("state", state);
         }
 
         /// <summary>
-        /// Adds a new audience query string parameter.
+        /// Adds the `audience` query string parameter to request API access.
         /// </summary>
-        /// <param name="audience">The audience.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <param name="audience">Audience to request API access for.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithAudience(string audience)
         {
-            AddQueryString("audience", audience);
-
-            return this;
+            return WithValue("audience", audience);
         }
 
         /// <summary>
-        /// Adds a new nonce query string parameter.
+        /// Adds the `nonce` query string parameter specifying a cryptographically random nonce.
         /// </summary>
         /// <param name="nonce">The nonce.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        /// <remarks>See https://auth0.com/docs/api-auth/tutorials/nonce for more details</remarks>
         public AuthorizationUrlBuilder WithNonce(string nonce)
         {
-            AddQueryString("nonce", nonce);
-
-            return this;
+            return WithValue("nonce", nonce);
         }
 
         /// <summary>
-        /// Adds a new response_mode query string parameter.
+        /// Adds the `response_mode` query string parameter.
         /// </summary>
         /// <param name="responseMode">The response mode.</param>
         /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
         public AuthorizationUrlBuilder WithResponseMode(AuthorizationResponseMode responseMode)
         {
-            AddQueryString("response_mode", AuthorizationResponseModeHelper.ConvertToString(responseMode));
-
-            return this;
+            return WithValue("response_mode", AuthorizationResponseModeHelper.ConvertToString(responseMode));
         }
 
         /// <summary>
-        /// Adds a new connection_scope query string parameter.
+        /// Adds the `connection_scope` query string parameter.
         /// </summary>
-        /// <param name="connectionScope">The connection scope to be passed to the corresponding connection. Multiple scopes must be separated by a space character.</param>
-        /// <returns>The <see cref="AuthorizationUrlBuilder"/>.</returns>
+        /// <param name="connectionScope">Connection scope to be passed to the corresponding connection. Multiple scopes must be separated by a space character.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithConnectionScope(string connectionScope)
         {
-            AddQueryString("connection_scope", connectionScope);
+            return WithValue("connection_scope", connectionScope);
+        }
 
-            return this;
+        /// <summary>
+        /// Adds the `connection_scope` query string parameter.
+        /// </summary>
+        /// <param name="connectionScope">Connection scopes to be passed to the corresponding connection.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        public AuthorizationUrlBuilder WithConnectionScopes(params string[] connectionScope)
+        {
+            return WithConnectionScope(String.Join(" ", connectionScope));
         }
     }
 }

--- a/src/Auth0.AuthenticationApi/Builders/LogoutUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/LogoutUrlBuilder.cs
@@ -1,54 +1,70 @@
+using System;
+
 namespace Auth0.AuthenticationApi.Builders
 {
     /// <summary>
-    /// Used to build a logout URL.
+    /// Builder class used to fluently construct a logout URL.
     /// </summary>
+    /// <remarks>
+    /// See https://auth0.com/docs/api/authentication#logout
+    /// </remarks>
     public class LogoutUrlBuilder : UrlBuilderBase<LogoutUrlBuilder>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="LogoutUrlBuilder"/> class.
         /// </summary>
-        /// <param name="baseUrl">The base URL.</param>
-        public LogoutUrlBuilder(string baseUrl) 
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="String"/>.</param>
+        public LogoutUrlBuilder(string baseUrl)
             : base(baseUrl, "v2/logout")
         {
         }
 
         /// <summary>
-        /// Adds a returnTo query string parameter.
+        /// Initializes a new instance of the <see cref="LogoutUrlBuilder"/> class.
         /// </summary>
-        /// <param name="url">The URL.</param>
-        /// <returns>The <see cref="LogoutUrlBuilder"/>.</returns>
-        public LogoutUrlBuilder WithReturnUrl(string url)
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="Uri"/>.</param>
+        public LogoutUrlBuilder(Uri baseUrl)
+            : base(baseUrl, "v2/logout")
         {
-            AddQueryString("returnTo", url);
-
-            return this;
         }
 
         /// <summary>
-        /// Adds a client_id query string parameter.
+        /// Adds the `redirect_uri` query string parameter specifying the redirect URI.
         /// </summary>
-        /// <param name="clientId">The URL.</param>
-        /// <returns>The <see cref="LogoutUrlBuilder"/>.</returns>
+        /// <param name="uri">URI to redirect to.</param>
+        /// <returns>Current <see cref="LogoutUrlBuilder"/> to allow fluent configuration.</returns>
+        public LogoutUrlBuilder WithReturnUrl(string uri)
+        {
+            return WithValue("returnTo", uri);
+        }
+
+        /// <summary>
+        /// Adds the `redirect_uri` query string parameter specifying the redirect URI.
+        /// </summary>
+        /// <param name="uri"><see cref="Uri"/> to redirect to.</param>
+        /// <returns>Current <see cref="LogoutUrlBuilder"/> to allow fluent configuration.</returns>
+        public LogoutUrlBuilder WithReturnUrl(Uri uri)
+        {
+            return WithReturnUrl(uri.OriginalString);
+        }
+
+        /// <summary>
+        /// Adds the `client_id` query string parameter specifying the Client ID of the application.
+        /// </summary>
+        /// <param name="clientId">Client ID of the application.</param>
+        /// <returns>Current <see cref="LogoutUrlBuilder"/> to allow fluent configuration.</returns>
         public LogoutUrlBuilder WithClientId(string clientId)
         {
-            AddQueryString("client_id", clientId);
-
-            return this;
+            return WithValue("client_id", clientId);
         }
 
         /// <summary>
-        /// Adds a federated query string parameter.
+        /// Adds the `federated` flag query string parameter (no value).
         /// </summary>
-        /// <returns>The <see cref="LogoutUrlBuilder"/>.</returns>
+        /// <returns>Current <see cref="LogoutUrlBuilder"/> to allow fluent configuration.</returns>
         public LogoutUrlBuilder Federated()
         {
-            AddQueryString("federated", null);
-
-            return this;
+            return WithValue("federated", null);
         }
-
-
     }
 }

--- a/src/Auth0.AuthenticationApi/Builders/SamlUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/SamlUrlBuilder.cs
@@ -18,9 +18,9 @@ namespace Auth0.AuthenticationApi.Builders
         /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="String"/>.</param>
         /// <param name="clientId">Client ID of the application.</param>
         public SamlUrlBuilder(string baseUrl, string clientId)
-            : base(baseUrl, "samlp/{client}")
+            : base(baseUrl, "samlp/{clientId}")
         {
-            AddUrlSegment("client", clientId);
+            AddUrlSegment("clientId", clientId);
         }
 
         /// <summary>
@@ -29,9 +29,9 @@ namespace Auth0.AuthenticationApi.Builders
         /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="Uri"/>.</param>
         /// <param name="clientId">Client ID of the application.</param>
         public SamlUrlBuilder(Uri baseUrl, string clientId)
-            : base(baseUrl, "samlp/{client}")
+            : base(baseUrl, "samlp/{clientId}")
         {
-            AddUrlSegment("client", clientId);
+            AddUrlSegment("clientId", clientId);
         }
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/Builders/SamlUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/SamlUrlBuilder.cs
@@ -1,64 +1,74 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Auth0.AuthenticationApi.Builders
 {
     /// <summary>
-    /// Used to build a SAML authorization URL.
+    /// Builder class used to fluently construct a SAML authorization URL.
     /// </summary>
+    /// <remarks>
+    /// See https://auth0.com/docs/api/authentication#accept-request for more details.
+    /// </remarks>
     public class SamlUrlBuilder : UrlBuilderBase<SamlUrlBuilder>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SamlUrlBuilder"/> class.
         /// </summary>
-        /// <param name="baseUrl">The base URL.</param>
-        /// <param name="client">The client id.</param>
-        public SamlUrlBuilder(string baseUrl, string client)
-            :base(baseUrl, "samlp/{client}")
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="String"/>.</param>
+        /// <param name="clientId">Client ID of the application.</param>
+        public SamlUrlBuilder(string baseUrl, string clientId)
+            : base(baseUrl, "samlp/{client}")
         {
-            AddUrlSegment("client", client);
+            AddUrlSegment("client", clientId);
         }
 
         /// <summary>
-        /// Adds a connection query string parameter.
+        /// Initializes a new instance of the <see cref="SamlUrlBuilder"/> class.
+        /// </summary>
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="Uri"/>.</param>
+        /// <param name="clientId">Client ID of the application.</param>
+        public SamlUrlBuilder(Uri baseUrl, string clientId)
+            : base(baseUrl, "samlp/{client}")
+        {
+            AddUrlSegment("client", clientId);
+        }
+
+        /// <summary>
+        /// Adds the `connection` query string parameter specifying the connection name.
         /// </summary>
         /// <param name="connectionName">Name of the connection.</param>
-        /// <returns>The <see cref="SamlUrlBuilder"/>.</returns>
+        /// <returns>Current <see cref="SamlUrlBuilder"/> to allow fluent configuration.</returns>
         public SamlUrlBuilder WithConnection(string connectionName)
         {
-            AddQueryString("connection", connectionName);
-
-            return this;
+            return WithValue("connection", connectionName);
         }
 
         /// <summary>
-        /// Adds a relayState query string parameter.
+        /// Adds the `RelayState` query string parameter.
         /// </summary>
-        /// <param name="value">A string with the value of relayState parameter. Must be in a name-value pair format, e.g. xcrf=abc&amp;ru=/foo</param>
-        /// <returns>The <see cref="SamlUrlBuilder"/>.</returns>
+        /// <param name="value">Value of `RelayState` parameter in key-value format, e.g. <code>xcrf=abc&amp;ru=/foo</code>.</param>
+        /// <returns>Current <see cref="SamlUrlBuilder"/> to allow fluent configuration.</returns>
+        /// <remarks>
+        /// See https://auth0.com/docs/protocols/saml/saml-configuration/special-configuration-scenarios/idp-initiated-sso#auth0-as-identity-provider-where-idp-initiates-sso for more details on RelayState.
+        /// </remarks>
         public SamlUrlBuilder WithRelayState(string value)
         {
-            // Note to future maintainers:
-            // It is important to use correct casing! This parameter must use PascalCase (i.e. RelayState),
-            // otherwise it will not be passed on correctly. See https://github.com/auth0/auth0.net/issues/186 
-            AddQueryString("RelayState", value);
-
-            return this;
+            // This parameter must use PascalCase (i.e. RelayState) see https://github.com/auth0/auth0.net/issues/186 
+            return WithValue("RelayState", value);
         }
 
         /// <summary>
-        /// Adds a relayState query string parameter.
+        /// Adds the `RelayState` query string parameter.
         /// </summary>
-        /// <param name="values">A dictionary containing the name-value pairs of the relayState parameter.</param>
-        /// <returns>The <see cref="SamlUrlBuilder"/>.</returns>
-        public SamlUrlBuilder WithRelayState(System.Collections.Generic.IDictionary<string, string> values)
+        /// <param name="values"><see cref="Dictionary{String, String}"/>containing key-value pairs for the `RelayState` parameter.</param>
+        /// <returns>Current <see cref="SamlUrlBuilder"/> to allow fluent configuration.</returns>
+        /// <remarks>
+        /// See https://auth0.com/docs/protocols/saml/saml-configuration/special-configuration-scenarios/idp-initiated-sso#auth0-as-identity-provider-where-idp-initiates-sso for more details on RelayState.
+        /// </remarks>
+        public SamlUrlBuilder WithRelayState(IDictionary<string, string> values)
         {
-            // Note to future maintainers:
-            // It is important to use correct casing! This parameter must use PascalCase (i.e. RelayState),
-            // otherwise it will not be passed on correctly. See https://github.com/auth0/auth0.net/issues/186 
-            AddQueryString("RelayState", string.Join("&", values.Select(kvp => $"{kvp.Key}={kvp.Value}")));
-
-            return this;
+            return WithRelayState(String.Join("&", values.Select(kvp => $"{kvp.Key}={kvp.Value}")));
         }
-
     }
 }

--- a/src/Auth0.AuthenticationApi/Builders/UrlBuilderBase.cs
+++ b/src/Auth0.AuthenticationApi/Builders/UrlBuilderBase.cs
@@ -1,76 +1,87 @@
+using Auth0.Core.Http;
 using System;
 using System.Collections.Generic;
-using Auth0.Core.Http;
+
 namespace Auth0.AuthenticationApi.Builders
 {
     /// <summary>
-    /// The base class for all URL builders.
+    /// Base class for all strongly-typed fluent URL builders.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     public class UrlBuilderBase<T> where T : UrlBuilderBase<T>
     {
-        private readonly string _baseUrl;
-        private readonly string _resource;
-        private readonly IDictionary<string, string> _queryStrings = new Dictionary<string, string>();
-        private readonly IDictionary<string, string> _urlSegments = new Dictionary<string, string>();
+        readonly Uri _baseUrl;
+        readonly string _resource;
+        readonly IDictionary<string, string> _queryStrings = new Dictionary<string, string>();
+        readonly IDictionary<string, string> _urlSegments = new Dictionary<string, string>();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UrlBuilderBase{T}"/> class.
         /// </summary>
-        /// <param name="baseUrl">The base URL.</param>
-        /// <param name="resource">The resource being accessed.</param>
-        /// <exception cref="System.ArgumentNullException">
-        /// </exception>
+        /// <param name="baseUrl">Base URL represented as a <see cref="String"/>.</param>
+        /// <param name="resource">Resource being accessed.</param>
+        /// <exception cref="ArgumentNullException" />
         public UrlBuilderBase(string baseUrl, string resource)
+            : this(new Uri(baseUrl), resource)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UrlBuilderBase{T}"/> class.
+        /// </summary>
+        /// <param name="baseUrl">Base URL represented as a <see cref="Uri"/>.</param>
+        /// <param name="resource">Resource being accessed.</param>
+        /// <exception cref="ArgumentNullException" />
+        public UrlBuilderBase(Uri baseUrl, string resource)
         {
             _baseUrl = baseUrl ?? throw new ArgumentNullException(nameof(baseUrl));
             _resource = resource ?? throw new ArgumentNullException(nameof(resource));
         }
 
         /// <summary>
-        /// Adds a new URL segment.
+        /// Adds or replaces a URL segment based on name.
         /// </summary>
         /// <remarks>
-        /// When specifying the resource, a URL segment can be specified with curly braces. For example, the resource can specified as "samlp/{client}". This method
+        /// When specifying the resource, a URL segment can be specified with curly braces. 
+        /// For example, the resource can specified as "samlp/{client}". This method
         /// can be used to specify a value for the {client} segment of the resource.
         /// </remarks>
-        /// <param name="name">The name of the segment (without the curly braces).</param>
-        /// <param name="value">The value of the segment.</param>
+        /// <param name="name">Name of the segment (without the curly braces).</param>
+        /// <param name="value">Value the segment should contain.</param>
         protected void AddUrlSegment(string name, string value)
         {
             _urlSegments[name] = value;
         }
 
         /// <summary>
-        /// Adds the query string parameter to the URL.
+        /// Adds or replaces a query string parameter.
         /// </summary>
-        /// <param name="name">The name of the query string parameter.</param>
-        /// <param name="value">The value of the query string parameter.</param>
+        /// <param name="name">Name of the query string parameter.</param>
+        /// <param name="value">Value of the query string parameter.</param>
         protected void AddQueryString(string name, string value)
         {
             _queryStrings[name] = value;
         }
 
         /// <summary>
-        /// Adds an arbitrary query string parameter to the URL.
+        /// Adds an arbitrary query string parameter.
         /// </summary>
-        /// <param name="name">The name of the query string parameter.</param>
-        /// <param name="value">The value of the query string parameter.</param>
-        /// <returns>T.</returns>
+        /// <param name="name">Name of the query string parameter.</param>
+        /// <param name="value">Value of the query string parameter.</param>
+        /// <returns>Current <see cref="{T}"/> to allow fluent configuration.</returns>
         public T WithValue(string name, string value)
         {
             AddQueryString(name, value);
-
             return (T) this;
         }
 
         /// <summary>
-        /// Builds the URL.
+        /// Builds the complete URL based on the values added so far.
         /// </summary>
-        /// <returns>A <see cref="Uri"/> with the URL.</returns>
+        /// <returns><see cref="Uri"/> containing the complete URL.</returns>
         public Uri Build()
         {
-            return Utils.BuildUri(_baseUrl, _resource, _urlSegments, _queryStrings, true);
+            return Utils.BuildUri(_baseUrl.OriginalString, _resource, _urlSegments, _queryStrings, true);
         }
     }
 }

--- a/src/Auth0.AuthenticationApi/Builders/WsFedUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/WsFedUrlBuilder.cs
@@ -1,81 +1,85 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Auth0.AuthenticationApi.Builders
 {
     /// <summary>
-    /// Used to build a WS Federation authorization URL.
+    /// Builder class used to fluently construct a WS Federation authorization URL.
     /// </summary>
     public class WsFedUrlBuilder : UrlBuilderBase<WsFedUrlBuilder>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="WsFedUrlBuilder"/> class.
         /// </summary>
-        /// <param name="baseUrl">The base URL.</param>
-        public WsFedUrlBuilder(string baseUrl) 
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="String"/>.</param>
+        /// <param name="clientId">Optional Client ID of the application.</param>
+        public WsFedUrlBuilder(string baseUrl, string clientId = null)
             : base(baseUrl, "wsfed/{client}")
         {
-            AddUrlSegment("client", null); // Default to not using the client
+            AddUrlSegment("client", clientId);
         }
 
         /// <summary>
-        /// Specifies the client ID for the URL.
+        /// Initializes a new instance of the <see cref="WsFedUrlBuilder"/> class.
         /// </summary>
-        /// <param name="clientId">The client ID.</param>
-        /// <returns>WsFedUrlBuilder.</returns>
+        /// <param name="baseUrl">Base URL of the Authentication API represented as a <see cref="Uri"/>.</param>
+        /// <param name="clientId">Optional Client ID of the application.</param>
+        public WsFedUrlBuilder(Uri baseUrl, string clientId = null)
+            : base(baseUrl, "wsfed/{client}")
+        {
+            AddUrlSegment("client", clientId);
+        }
+
+        /// <summary>
+        /// Adds the `client` URL segment specifying the Client ID of the application.
+        /// </summary>
+        /// <param name="clientId">Client ID of the application.</param>
+        /// <returns>Current <see cref="WsFedUrlBuilder"/> to allow fluent configuration.</returns>
         public WsFedUrlBuilder WithClient(string clientId)
         {
             AddUrlSegment("client", clientId);
-
             return this;
         }
 
         /// <summary>
-        /// Adds a qhr query string parameter.
+        /// Adds the `whr` query string parameter.
         /// </summary>
-        /// <param name="value">The value of the whr parameter.</param>
-        /// <returns>WsFedUrlBuilder.</returns>
+        /// <param name="value">Value of the `whr` parameter.</param>
+        /// <returns>Current <see cref="WsFedUrlBuilder"/> to allow fluent configuration.</returns>
         public WsFedUrlBuilder WithWhr(string value)
         {
-            AddQueryString("whr", value);
-
-            return this;
+            return WithValue("whr", value);
         }
 
         /// <summary>
-        /// Adds a wctx query string parameter.
+        /// Adds the `wctx` query string parameter.
         /// </summary>
-        /// <param name="value">A string with the value of the wctx parameter. Must be in a name-value pair format, e.g. xcrf=abc&amp;ru=/foo</param>
-        /// <returns>WsFedUrlBuilder.</returns>
+        /// <param name="value">Value of the `wctx` parameter in key-value pair format, e.g. <code>xcrf=abc&amp;ru=/foo</code>.</param>
+        /// <returns>Current <see cref="WsFedUrlBuilder"/> to allow fluent configuration.</returns>
         public WsFedUrlBuilder WithWctx(string value)
         {
-            AddQueryString("wctx", value);
-
-            return this;
+            return WithValue("wctx", value);
         }
 
         /// <summary>
-        /// Adds a wctx query string parameter.
+        /// Adds the `wctx` query string parameter.
         /// </summary>
-        /// <param name="values">A dictionary containing the name-value pairs of the wctx parameter.</param>
-        /// <returns>WsFedUrlBuilder.</returns>
+        /// <param name="values"><see cref="Dictionary{String, String}"/> containing the key-value pairs of the `wctx` parameter.</param>
+        /// <returns>Current <see cref="WsFedUrlBuilder"/> to allow fluent configuration.</returns>
         public WsFedUrlBuilder WithWctx(IDictionary<string, string> values)
         {
-            AddQueryString("wctx", string.Join("&", values.Select(kvp => $"{kvp.Key}={kvp.Value}")));
-
-            return this;
+            return WithWctx(String.Join("&", values.Select(kvp => $"{kvp.Key}={kvp.Value}")));
         }
 
         /// <summary>
-        /// Adds a wtrealm query string parameter.
+        /// Adds the `wtrealm` query string parameter.
         /// </summary>
-        /// <param name="value">The value of the wtrealm query string parameter.</param>
-        /// <returns>WsFedUrlBuilder.</returns>
+        /// <param name="value">Value of the `wtrealm` query string parameter.</param>
+        /// <returns>Current <see cref="WsFedUrlBuilder"/> to allow fluent configuration.</returns>
         public WsFedUrlBuilder WithWtrealm(string value)
         {
-            AddQueryString("wtrealm", value);
-
-            return this;
+            return WithValue("wtrealm", value);
         }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationResponseType.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationResponseType.cs
@@ -6,17 +6,17 @@ namespace Auth0.AuthenticationApi.Models
     public enum AuthorizationResponseType
     {
         /// <summary>
-        /// The response type is an authorization code.
+        /// Response is an authorization code.
         /// </summary>
         Code,
 
         /// <summary>
-        /// The response type is an access_token.
+        /// Response is an access_token.
         /// </summary>
         Token,
 
         /// <summary>
-        /// The response type is an id_token.
+        /// Response is an id_token.
         /// </summary>
         IdToken
     }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/UriBuildersTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/UriBuildersTests.cs
@@ -32,6 +32,23 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         }
 
         [Fact]
+        public void Can_build_authorization_uri_with_params_overloads()
+        {
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            var authorizationUrl = authenticationApiClient.BuildAuthorizationUrl()
+                .WithResponseType(AuthorizationResponseType.Code)
+                .WithScopes("openid", "offline_access")
+                .WithState("MyState")
+                .WithConnectionScopes("ConnectionScope", "More")
+                .Build();
+
+            authorizationUrl.Should()
+                .Be(
+                    new Uri("https://auth0-dotnet-integration-tests.auth0.com/authorize?response_type=code&scope=openid%20offline_access&state=MyState&connection_scope=ConnectionScope%20More"));
+        }
+
+        [Fact]
         public void Can_provide_multiple_response_type()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
@@ -84,12 +101,26 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         }
 
         [Fact]
-        public void Can_build_logout_url_with_return_url()
+        public void Can_build_logout_url_with_return_url_as_string()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
 
             var logoutUrl = authenticationApiClient.BuildLogoutUrl()
                 .WithReturnUrl("http://www.jerriepelser.com/test")
+                .Build();
+
+            logoutUrl.Should()
+                .Be(
+                    @"https://auth0-dotnet-integration-tests.auth0.com/v2/logout?returnTo=http%3A%2F%2Fwww.jerriepelser.com%2Ftest");
+        }
+
+        [Fact]
+        public void Can_build_logout_url_with_return_url_as_uri()
+        {
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            var logoutUrl = authenticationApiClient.BuildLogoutUrl()
+                .WithReturnUrl(new Uri("http://www.jerriepelser.com/test"))
                 .Build();
 
             logoutUrl.Should()

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/UriBuildersTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/UriBuildersTests.cs
@@ -129,6 +129,21 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         }
 
         [Fact]
+        public void Can_build_logout_url_with_federated()
+        {
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            var logoutUrl = authenticationApiClient.BuildLogoutUrl()
+                .Federated()
+                .WithReturnUrl(new Uri("http://www.jerriepelser.com/test"))
+                .Build();
+
+            logoutUrl.Should()
+                .Be(
+                    @"https://auth0-dotnet-integration-tests.auth0.com/v2/logout?federated&returnTo=http%3A%2F%2Fwww.jerriepelser.com%2Ftest");
+        }
+
+        [Fact]
         public void Can_build_saml_url()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
@@ -181,7 +196,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         }
 
         [Fact]
-        public void Can_build_wsfed_with_realm()
+        public void Can_build_wsfed_with_wtrealm()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
 
@@ -205,7 +220,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         }
 
         [Fact]
-        public void Can_build_wsfed_with_wxtx_dictionary()
+        public void Can_build_wsfed_with_wctx_dictionary()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
 
@@ -221,7 +236,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         }
 
         [Fact]
-        public void Can_build_wsfed_with_wxtx_string()
+        public void Can_build_wsfed_with_wctx_string()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
 


### PR DESCRIPTION
Improves the URL builders by:

1. Improving the doc comments everywhere including adding links to online Auth API ref
2. Adding `Url` class alternatives to the `string` ones that take URLs (constructors and methods)
3. Switches from `AddQueryValue` + `return` to just `WithValue` for shorter code
4. Adds methods that take arrays of parameters for things like Scopes so users don't need to know separator rules
5. Removes the `WithAccessToken` method from AuthorizationBuilder... no idea what this was supposed to be for but it's not part of what's accepted.