### PR TITLE
Split builders from auth client

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -21,6 +21,9 @@ namespace Auth0.AuthenticationApi
         readonly IAuthenticationConnection connection;
         bool disposed = false;
 
+        /// <inheritdoc />
+        public Uri BaseUri { get { return baseUri; } }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationApiClient" /> class.
         /// </summary>
@@ -53,43 +56,6 @@ namespace Auth0.AuthenticationApi
         public AuthenticationApiClient(string domain, IAuthenticationConnection connection = null)
             : this(new Uri($"https://{domain}"), connection)
         {
-        }
-
-        /// <summary>
-        /// Creates a <see cref="AuthorizationUrlBuilder" /> for building an authorization URL.
-        /// </summary>
-        /// <returns>A new <see cref="AuthorizationUrlBuilder" /> configured for this baseUrl.</returns>
-        public AuthorizationUrlBuilder BuildAuthorizationUrl()
-        {
-            return new AuthorizationUrlBuilder(baseUri.ToString());
-        }
-
-        /// <summary>
-        /// Creates a <see cref="LogoutUrlBuilder" /> for building a logout URL.
-        /// </summary>
-        /// <returns>A new <see cref="LogoutUrlBuilder" /> configured for this baseUrl.</returns>
-        public LogoutUrlBuilder BuildLogoutUrl()
-        {
-            return new LogoutUrlBuilder(baseUri.ToString());
-        }
-
-        /// <summary>
-        /// Creates a <see cref="SamlUrlBuilder" /> for building a SAML authentication URL.
-        /// </summary>
-        /// <param name="client">Name of the client.</param>
-        /// <returns>A new <see cref="SamlUrlBuilder" /> configured for this baseUrl and <paramref name="client"/>.</returns>
-        public SamlUrlBuilder BuildSamlUrl(string client)
-        {
-            return new SamlUrlBuilder(baseUri.ToString(), client);
-        }
-
-        /// <summary>
-        /// Creates a <see cref="WsFedUrlBuilder" /> for building a WS-Federation authentication URL.
-        /// </summary>
-        /// <returns>A new <see cref="WsFedUrlBuilder" /> configured for this baseUrl.</returns>
-        public WsFedUrlBuilder BuildWsFedUrl()
-        {
-            return new WsFedUrlBuilder(baseUri.ToString());
         }
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClientExtensions.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClientExtensions.cs
@@ -1,0 +1,48 @@
+﻿using Auth0.AuthenticationApi.Builders;
+
+namespace Auth0.AuthenticationApi
+{
+    public static class AuthenticationApiClientExtensions
+    {
+        /// <summary>
+        /// Creates a <see cref="AuthorizationUrlBuilder" /> for building an authorization URL.
+        /// </summary>
+        /// <param name="client"><see cref="IAuthenticationApiClient"/> capable of providing the Base URL.</param>
+        /// <returns>A new <see cref="AuthorizationUrlBuilder" /> configured for this baseUrl.</returns>
+        public static AuthorizationUrlBuilder BuildAuthorizationUrl(this IAuthenticationApiClient client)
+        {
+            return new AuthorizationUrlBuilder(client.BaseUri);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LogoutUrlBuilder" /> for building a logout URL.
+        /// </summary>
+        /// <param name="client"><see cref="IAuthenticationApiClient"/> capable of providing the Base URL.</param>
+        /// <returns>A new <see cref="LogoutUrlBuilder" /> configured for this baseUrl.</returns>
+        public static LogoutUrlBuilder BuildLogoutUrl(this IAuthenticationApiClient client)
+        {
+            return new LogoutUrlBuilder(client.BaseUri);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="SamlUrlBuilder" /> for building a SAML authentication URL.
+        /// </summary>
+        /// <param name="client"><see cref="IAuthenticationApiClient"/> capable of providing the Base URL.</param>
+        /// <param name="clientId">ID of the client.</param>
+        /// <returns>A new <see cref="SamlUrlBuilder" /> configured for this baseUrl and <paramref name="client"/>.</returns>
+        public static SamlUrlBuilder BuildSamlUrl(this IAuthenticationApiClient client, string clientId)
+        {
+            return new SamlUrlBuilder(client.BaseUri, clientId);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="WsFedUrlBuilder" /> for building a WS-Federation authentication URL.
+        /// </summary>
+        /// <param name="client"><see cref="IAuthenticationApiClient"/> capable of providing the Base URL.</param>
+        /// <returns>A new <see cref="WsFedUrlBuilder" /> configured for this baseUrl.</returns>
+        public static WsFedUrlBuilder BuildWsFedUrl(this IAuthenticationApiClient client)
+        {
+            return new WsFedUrlBuilder(client.BaseUri);
+        }
+    }
+}

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -1,5 +1,4 @@
-﻿using Auth0.AuthenticationApi.Builders;
-using Auth0.AuthenticationApi.Models;
+﻿using Auth0.AuthenticationApi.Models;
 using System;
 using System.Threading.Tasks;
 
@@ -14,29 +13,9 @@ namespace Auth0.AuthenticationApi
     public interface IAuthenticationApiClient
     {
         /// <summary>
-        /// Creates a <see cref="AuthorizationUrlBuilder"/> which is used to build an authorization URL.
+        /// Base URI that will be used for all the requests.
         /// </summary>
-        /// <returns>A new <see cref="AuthorizationUrlBuilder"/> instance.</returns>
-        AuthorizationUrlBuilder BuildAuthorizationUrl();
-
-        /// <summary>
-        /// Creates a <see cref="LogoutUrlBuilder"/> which is used to build a logout URL.
-        /// </summary>
-        /// <returns>A new <see cref="LogoutUrlBuilder"/> instance.</returns>
-        LogoutUrlBuilder BuildLogoutUrl();
-
-        /// <summary>
-        /// Creates a <see cref="SamlUrlBuilder" /> which is used to build a SAML authentication URL.
-        /// </summary>
-        /// <param name="client">The name of the client.</param>
-        /// <returns>A new <see cref="SamlUrlBuilder" /> instance.</returns>
-        SamlUrlBuilder BuildSamlUrl(string client);
-
-        /// <summary>
-        /// Creates a <see cref="WsFedUrlBuilder"/> which is used to build a WS-FED authentication URL.
-        /// </summary>
-        /// <returns>A new <see cref="WsFedUrlBuilder"/> instance.</returns>
-        WsFedUrlBuilder BuildWsFedUrl();
+        Uri BaseUri { get; }
 
         /// <summary>
         /// Given the user's details, Auth0 will send a forgot password email.


### PR DESCRIPTION
Right now the `IAuthenticationApiClient` interface exposes all the builders in order to be helpful and the `AuthenticationApiClient` implements them.

As these are just builders that require a URL and not any actual requirement on a connection unlike the rest of the client it really is a muddling of concerns.

I have instead split these methods out to an extension class so people using them will continue to do so without either the interface or class having to deal with multiple concerns.