### PR TITLE
Improved OIDC compliance (part 3, wire up HS256) 

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -323,7 +323,7 @@ namespace Auth0.AuthenticationApi
 
                 case JwtSignatureAlgorithm.HS256:
                     if (String.IsNullOrWhiteSpace(clientSecret))
-                        throw new ArgumentException("ClientSecret must contain a value when using HS256", nameof(issuer));
+                        throw new ArgumentException("ClientSecret must contain a value when using HS256", nameof(clientSecret));
                     return SymmetricSignatureVerifier.FromClientSecret(clientSecret);
 
                 default:

--- a/src/Auth0.AuthenticationApi/JwtSignatureAlgorithm.cs
+++ b/src/Auth0.AuthenticationApi/JwtSignatureAlgorithm.cs
@@ -1,0 +1,22 @@
+﻿namespace Auth0.AuthenticationApi
+{
+    /// <summary>
+    /// Represents possible signing algorithms for JsonWebTokens (JWTs).
+    /// </summary>
+    public enum JwtSignatureAlgorithm
+    {
+        /// <summary>
+        /// RS256 asymmetric algorithm verified using public key via JWKS.
+        /// </summary>
+        RS256,
+
+        /// <summary>
+        /// HS256 symmetric algorithm verified using client secret.
+        /// </summary>
+        /// <remarks>
+        /// Should only be used in environments where a client secret can be kept secure.
+        /// e.g. Web server-side applications.  NOT mobile or desktop.
+        /// </remarks>
+        HS256
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
@@ -12,10 +12,20 @@
         /// </summary>
         public string ClientId { get; set; }
 
+        /// <summary>
+        /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature
+        /// of Id Tokens.
+        /// </summary>
+        public JwtSignatureAlgorithm SigningAlgorithm {  get; set; }
 
         /// <summary>
         /// Rredirect URI passed during the login process.
         /// </summary>
         public string RedirectUri { get; set; }
+
+        /// <summary>
+        /// Optional client secret of the application for Id Token verification.
+        /// </summary>
+        public virtual string ClientSecret { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
@@ -24,8 +24,11 @@
         public string RedirectUri { get; set; }
 
         /// <summary>
-        /// Optional client secret of the application for Id Token verification.
+        /// Client secret of the application for Id Token verification.
         /// </summary>
-        public virtual string ClientSecret { get; set; }
+        /// <remarks>
+        /// Optional except when using <see cref="AuthorizationCodeRequestBase"/>.
+        /// </remarks>
+        public string ClientSecret { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeTokenRequest.cs
@@ -5,9 +5,5 @@
     /// </summary>
     public class AuthorizationCodeTokenRequest : AuthorizationCodeRequestBase
     {
-        /// <summary>
-        /// Client secret of the application.
-        /// </summary>
-        public override string ClientSecret { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeTokenRequest.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// Client secret of the application.
         /// </summary>
-        public string ClientSecret { get; set; }
+        public override string ClientSecret { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/ClientCredentialsTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ClientCredentialsTokenRequest.cs
@@ -19,5 +19,11 @@
         /// Client Secret of the application.
         /// </summary>
         public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature
+        /// of Id Tokens.
+        /// </summary>
+        public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
@@ -34,5 +34,11 @@
         /// Client secret for which the refresh token was issued.
         /// </summary>
         public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature
+        /// of Id Tokens.
+        /// </summary>
+        public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
@@ -51,5 +51,11 @@
         /// See https://auth0.com/docs/api-auth/tutorials/using-resource-owner-password-from-server-side for more details.
         /// </remarks>
         public string ForwardedForIp { get; set; }
+
+        /// <summary>
+        /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature
+        /// of Id Tokens.
+        /// </summary>
+        public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
@@ -19,24 +19,24 @@ namespace Auth0.AuthenticationApi.Tokens
         /// </summary>
         /// <param name="required"><see cref="IdTokenRequirements"/> that should be asserted.</param>
         /// <param name="rawIDToken">Raw ID token to assert requirements against.</param>
-        /// <param name="pointInTime">Optional <see cref="DateTime"/> to act as "Now" in order to facilitate unit testing with static tokens.</param>
         /// <param name="signatureVerifier">Optional <see cref="ISignatureVerifier"/> to perform signature verification and token extraction. If unspecified
         /// <see cref="AsymmetricSignatureVerifier"/> is used against the <paramref name="required"/> Issuer.</param>
+        /// <param name="pointInTime">Optional <see cref="DateTime"/> to act as "Now" in order to facilitate unit testing with static tokens.</param>
         /// <exception cref="IdTokenValidationException">Exception thrown if <paramref name="rawIDToken"/> fails to
         /// meet the requirements specified by <paramref name="required"/>.
         /// </exception>
         /// <returns><see cref="Task"/> that will complete when the token is validated.</returns>
-        internal static async Task AssertTokenMeetsRequirements(this IdTokenRequirements required, string rawIDToken, DateTime? pointInTime = null, ISignatureVerifier signatureVerifier = null)
+        internal static async Task AssertTokenMeetsRequirements(this IdTokenRequirements required, string rawIDToken, ISignatureVerifier signatureVerifier, DateTime? pointInTime = null)
         {
             if (string.IsNullOrWhiteSpace(rawIDToken))
                 throw new IdTokenValidationException("ID token is required but missing.");
 
+            if (signatureVerifier == null)
+                throw new ArgumentNullException("Signature Verifier is required for asserting requirements.", nameof(signatureVerifier));
+
+            signatureVerifier.VerifySignature(rawIDToken);
+
             var token = DecodeToken(rawIDToken);
-
-            // TODO: Make signatureVerifier non-optional and not skipped for 'HS256' in 7.0.0
-            if (token.SignatureAlgorithm != "HS256" || signatureVerifier != null)
-               (signatureVerifier ?? await AsymmetricSignatureVerifier.ForJwks(required.Issuer)).VerifySignature(rawIDToken);
-
             AssertTokenClaimsMeetRequirements(required, token, pointInTime ?? DateTime.Now);
         }
 

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
@@ -26,7 +26,7 @@ namespace Auth0.AuthenticationApi.Tokens
         /// meet the requirements specified by <paramref name="required"/>.
         /// </exception>
         /// <returns><see cref="Task"/> that will complete when the token is validated.</returns>
-        internal static async Task AssertTokenMeetsRequirements(this IdTokenRequirements required, string rawIDToken, ISignatureVerifier signatureVerifier, DateTime? pointInTime = null)
+        internal static Task AssertTokenMeetsRequirements(this IdTokenRequirements required, string rawIDToken, ISignatureVerifier signatureVerifier, DateTime? pointInTime = null)
         {
             if (string.IsNullOrWhiteSpace(rawIDToken))
                 throw new IdTokenValidationException("ID token is required but missing.");
@@ -38,6 +38,8 @@ namespace Auth0.AuthenticationApi.Tokens
 
             var token = DecodeToken(rawIDToken);
             AssertTokenClaimsMeetRequirements(required, token, pointInTime ?? DateTime.Now);
+
+            return Task.FromResult(true);
         }
 
         private static JwtSecurityToken DecodeToken(string rawIDToken)

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenValidatorIntegrationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenValidatorIntegrationTests.cs
@@ -74,11 +74,12 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
                     Scope = "openid",
                     Username = _user.Email,
                     Password = Password
-
                 });
 
-                var idTokenValidation = new IdTokenRequirements($"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}/", GetVariable("AUTH0_CLIENT_ID"), TimeSpan.FromMinutes(1));
-                await idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken);
+                var issuer = $"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}/";
+                var idTokenValidation = new IdTokenRequirements(issuer, GetVariable("AUTH0_CLIENT_ID"), TimeSpan.FromMinutes(1));
+                var verifier = await AsymmetricSignatureVerifier.ForJwks(issuer);
+                await idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken, verifier);
             }
         }
 
@@ -97,11 +98,12 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
                     Scope = "openid",
                     Username = GetVariable("BRUCKE_USERNAME"),
                     Password = GetVariable("BRUCKE_PASSWORD")
-
                 });
 
-                var idTokenValidation = new IdTokenRequirements($"https://{GetVariable("BRUCKE_AUTHENTICATION_API_URL")}/", GetVariable("BRUCKE_CLIENT_ID"), TimeSpan.FromMinutes(1));
-                await idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken);
+                var issuer = $"https://{GetVariable("BRUCKE_AUTHENTICATION_API_URL")}/";
+                var idTokenValidation = new IdTokenRequirements(issuer, GetVariable("BRUCKE_CLIENT_ID"), TimeSpan.FromMinutes(1));
+                var verifier = await AsymmetricSignatureVerifier.ForJwks(issuer);
+                await idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken, verifier);
             }
         }
 
@@ -124,10 +126,11 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
                 });
 
                 var idTokenValidation = new IdTokenRequirements("https://auth0.auth0.com/", GetVariable("AUTH0_CLIENT_ID"), TimeSpan.FromMinutes(1));
+                var verifier = await AsymmetricSignatureVerifier.ForJwks("https://auth0.auth0.com/");
 
                 // Assert
                 authenticationResponse.IdToken.Should().NotBeNull();
-                await Assert.ThrowsAsync<IdTokenValidationException>(() => idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken));
+                await Assert.ThrowsAsync<IdTokenValidationException>(() => idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken, verifier));
             }
         }
 
@@ -149,11 +152,13 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
 
                 });
 
-                var idTokenValidation = new IdTokenRequirements($"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}/", "invalid_audience", TimeSpan.FromMinutes(1));
+                var issuer = $"https://{GetVariable("AUTH0_AUTHENTICATION_API_URL")}/";
+                var idTokenValidation = new IdTokenRequirements(issuer, "invalid_audience", TimeSpan.FromMinutes(1));
+                var verifier = await AsymmetricSignatureVerifier.ForJwks(issuer);
 
                 // Assert
                 authenticationResponse.IdToken.Should().NotBeNull();
-                await Assert.ThrowsAsync<IdTokenValidationException>(() => idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken));
+                await Assert.ThrowsAsync<IdTokenValidationException>(() => idTokenValidation.AssertTokenMeetsRequirements(authenticationResponse.IdToken, verifier));
             }
         }
     }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenValidatorTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenValidatorTests.cs
@@ -29,7 +29,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
 
         private Task ValidateToken(string token, IdTokenRequirements reqs = null, DateTime? when = null, ISignatureVerifier signatureVerifier = null)
         {
-            return IdTokenValidator.AssertTokenMeetsRequirements(reqs ?? defaultReqs, token, when ?? tokensWereValid, signatureVerifier ?? rs256NoSignature);
+            return IdTokenValidator.AssertTokenMeetsRequirements(reqs ?? defaultReqs, token, signatureVerifier ?? rs256NoSignature, when ?? tokensWereValid);
         }
 
         [Fact]


### PR DESCRIPTION
This wires up the previously checked in HS256 symmetric signature verifier from #326 completing the OIDC compliance work for this SDK with the exception of Jwks caching and invalidation to follow.

Developers can chose between HS256 and RS256 depending on what their client/application is configured for. This is done on a per-request basis just like ClientId and ClientSecret.  Ideally I think the auth client should take all three pieces of information once but there have been enough breaking changes in this major.

I have made RS256 the default.  If developers are using HS256 they will need to set their requests to RS256 or they will get token validation errors.  This will be included in the migration guide.