### PR TITLE
Allow management connections to be shared between hosts

### DIFF
--- a/src/Auth0.ManagementApi/Clients/BaseClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BaseClient.cs
@@ -20,14 +20,21 @@ namespace Auth0.ManagementApi.Clients
         protected Uri BaseUri { get; }
 
         /// <summary>
+        /// Default headers included with every request this client makes.
+        /// </summary>
+        protected IDictionary<string, string> DefaultHeaders { get; }
+
+        /// <summary>
         /// Initializes a new instance of <see cref="BaseClient"/>.
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        protected BaseClient(IManagementConnection connection, Uri baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        protected BaseClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
         {
             Connection = connection;
             BaseUri = baseUri;
+            DefaultHeaders = defaultHeaders;
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/BaseClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BaseClient.cs
@@ -32,9 +32,9 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
         protected BaseClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
         {
-            Connection = connection;
-            BaseUri = baseUri;
-            DefaultHeaders = defaultHeaders;
+            Connection = connection ?? throw new ArgumentNullException(nameof(connection));
+            BaseUri = baseUri ?? throw new ArgumentNullException(nameof(baseUri));
+            DefaultHeaders = defaultHeaders ?? throw new ArgumentNullException(nameof(defaultHeaders));
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/BlacklistedTokensClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BlacklistedTokensClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public BlacklistedTokensClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public BlacklistedTokensClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -28,7 +29,9 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A list of <see cref="BlacklistedToken"/> objects.</returns>
         public Task<IList<BlacklistedToken>> GetAllAsync(string aud)
         {
-            return Connection.GetAsync<IList<BlacklistedToken>>(BuildUri("blacklists/tokens"));
+            return Connection.GetAsync<IList<BlacklistedToken>>(BuildUri("blacklists/tokens", new Dictionary<string, string> {
+                {  "aud", aud }
+            }), DefaultHeaders);
         }
 
         /// <summary>
@@ -38,7 +41,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous create operation.</returns>
         public Task CreateAsync(BlacklistedTokenCreateRequest request)
         {
-            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri("blacklists/tokens"), request);
+            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri("blacklists/tokens"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
@@ -20,8 +20,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public ClientGrantsClient(IManagementConnection connection, Uri baseUri) 
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public ClientGrantsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders) 
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -32,7 +33,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The new <see cref="ClientGrant"/> that has been created.</returns>
         public Task<ClientGrant> CreateAsync(ClientGrantCreateRequest request)
         {
-            return Connection.SendAsync<ClientGrant>(HttpMethod.Post, BuildUri("client-grants"), request);
+            return Connection.SendAsync<ClientGrant>(HttpMethod.Post, BuildUri("client-grants"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"client-grants/{id}"), null); 
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"client-grants/{id}"), null, DefaultHeaders); 
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: converters);
+                }), DefaultHeaders, converters);
         }
 
         /// <summary>
@@ -77,7 +78,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="ClientGrant"/> that has been updated.</returns>
         public Task<ClientGrant> UpdateAsync(string id, ClientGrantUpdateRequest request)
         {
-            return Connection.SendAsync<ClientGrant>(new HttpMethod("PATCH"), BuildUri($"client-grants/{id}"), request);
+            return Connection.SendAsync<ClientGrant>(new HttpMethod("PATCH"), BuildUri($"client-grants/{id}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -21,8 +21,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public ClientsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public ClientsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -33,7 +34,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The new <see cref="Client"/> that has been created.</returns>
         public Task<Client> CreateAsync(ClientCreateRequest request)
         {
-            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri("clients"), request);
+            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri("clients"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -43,7 +44,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"clients/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"clients/{id}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -73,7 +74,7 @@ namespace Auth0.ManagementApi.Clients
             if (request.AppType != null)
                 queryStrings.Add("app_type", string.Join(",", request.AppType.Select(ExtensionMethods.ToEnumString)));
 
-            return Connection.GetAsync<IPagedList<Client>>(BuildUri("clients", queryStrings), converters: converters);
+            return Connection.GetAsync<IPagedList<Client>>(BuildUri("clients", queryStrings), DefaultHeaders, converters);
         }
 
         /// <summary>
@@ -96,7 +97,7 @@ namespace Auth0.ManagementApi.Clients
                 {
                     {"fields", fields},
                     {"include_fields", includeFields.ToString().ToLower()}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -106,7 +107,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Client"/> that has had its secret rotated.</returns>
         public Task<Client> RotateClientSecret(string id)
         {
-            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri($"clients/{id}/rotate-secret"), null);
+            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri($"clients/{id}/rotate-secret"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -117,7 +118,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Client"/> that was updated.</returns>
         public Task<Client> UpdateAsync(string id, ClientUpdateRequest request)
         {
-            return Connection.SendAsync<Client>(new HttpMethod("PATCH"), BuildUri($"clients/{id}"), request);
+            return Connection.SendAsync<Client>(new HttpMethod("PATCH"), BuildUri($"clients/{id}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -20,8 +20,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public ConnectionsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public ConnectionsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -32,7 +33,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Connection"/> containing the newly created Connection.</returns>
         public Task<Connection> CreateAsync(ConnectionCreateRequest request)
         {
-            return Connection.SendAsync<Connection>(HttpMethod.Post, BuildUri("connections"), request, null);
+            return Connection.SendAsync<Connection>(HttpMethod.Post, BuildUri("connections"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{id}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -57,7 +58,7 @@ namespace Auth0.ManagementApi.Clients
         public Task DeleteUserAsync(string id, string email)
         {
             return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{id}/users",
-                new Dictionary<string, string> { {"email", email} }), null);
+                new Dictionary<string, string> { {"email", email} }), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -74,7 +75,7 @@ namespace Auth0.ManagementApi.Clients
                 {
                     {"fields", fields},
                     {"include_fields", includeFields.ToString().ToLower()}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -105,7 +106,7 @@ namespace Auth0.ManagementApi.Clients
                 foreach (var s in request.Strategy)
                     queryStrings.Add("strategy", s);
 
-            return Connection.GetAsync<IPagedList<Connection>>(BuildUri("connections", queryStrings), converters: converters);
+            return Connection.GetAsync<IPagedList<Connection>>(BuildUri("connections", queryStrings), DefaultHeaders, converters);
         }
 
         /// <summary>
@@ -116,7 +117,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Connection"/> that has been updated.</returns>
         public Task<Connection> UpdateAsync(string id, ConnectionUpdateRequest request)
         {
-            return Connection.SendAsync<Connection>(new HttpMethod("PATCH"), BuildUri($"connections/{id}"), request);
+            return Connection.SendAsync<Connection>(new HttpMethod("PATCH"), BuildUri($"connections/{id}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public CustomDomainsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public CustomDomainsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -29,7 +30,7 @@ namespace Auth0.ManagementApi.Clients
         /// <remarks>The custom domain will need to be verified before it starts accepting requests.</remarks>
         public Task<CustomDomain> CreateAsync(CustomDomainCreateRequest request)
         {
-            return Connection.SendAsync<CustomDomain>(HttpMethod.Post, BuildUri("custom-domains"), request);
+            return Connection.SendAsync<CustomDomain>(HttpMethod.Post, BuildUri("custom-domains"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Auth0.ManagementApi.Clients
         /// <remarks>When deleted, Auth0 will stop serving requests for this domain.</remarks>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"custom-domains/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"custom-domains/{id}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -49,7 +50,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="IList{CustomDomain}"/> containing the details of every custom domain.
         public Task<IList<CustomDomain>> GetAllAsync()
         {
-            return Connection.GetAsync<IList<CustomDomain>>(BuildUri("custom-domains"));
+            return Connection.GetAsync<IList<CustomDomain>>(BuildUri("custom-domains"), DefaultHeaders);
         }
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="CustomDomain"/> that was requested.</returns>
         public Task<CustomDomain> GetAsync(string id)
         {
-            return Connection.GetAsync<CustomDomain>(BuildUri($"custom-domains/{id}"));
+            return Connection.GetAsync<CustomDomain>(BuildUri($"custom-domains/{id}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -69,7 +70,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="CustomDomainVerification"/> that was requested.</returns>
         public Task<CustomDomainVerificationResponse> VerifyAsync(string id)
         {
-            return Connection.SendAsync<CustomDomainVerificationResponse>(HttpMethod.Post, BuildUri($"custom-domains/{id}/verify"), null);
+            return Connection.SendAsync<CustomDomainVerificationResponse>(HttpMethod.Post, BuildUri($"custom-domains/{id}/verify"), null, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public DeviceCredentialsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public DeviceCredentialsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -40,7 +41,7 @@ namespace Auth0.ManagementApi.Clients
                     {"user_id", userId},
                     {"client_id", clientId},
                     {"type", type}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -50,7 +51,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="DeviceCredential"/>.</returns>
         public Task<DeviceCredential> CreateAsync(DeviceCredentialCreateRequest request)
         {
-            return Connection.SendAsync<DeviceCredential>(HttpMethod.Post, BuildUri("device-credentials"), request);
+            return Connection.SendAsync<DeviceCredential>(HttpMethod.Post, BuildUri("device-credentials"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -60,7 +61,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"device-credentials/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"device-credentials/{id}"), null, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/EmailProviderClient.cs
+++ b/src/Auth0.ManagementApi/Clients/EmailProviderClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public EmailProviderClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public EmailProviderClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -31,7 +32,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="EmailProvider" /> instance containing the email provider details.</returns>
         public Task<EmailProvider> ConfigureAsync(EmailProviderConfigureRequest request)
         {
-            return Connection.SendAsync<EmailProvider>(HttpMethod.Post, BuildUri("emails/provider"), request, null);
+            return Connection.SendAsync<EmailProvider>(HttpMethod.Post, BuildUri("emails/provider"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync()
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri("emails/provider"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri("emails/provider"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -62,7 +63,7 @@ namespace Auth0.ManagementApi.Clients
                 {
                     {"fields", fields},
                     {"include_fields", includeFields.ToString().ToLower()}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -75,7 +76,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="EmailProvider" /> instance containing the email provider details.</returns>
         public Task<EmailProvider> UpdateAsync(EmailProviderUpdateRequest request)
         {
-            return Connection.SendAsync<EmailProvider>(new HttpMethod("PATCH"), BuildUri("emails/provider"), request);
+            return Connection.SendAsync<EmailProvider>(new HttpMethod("PATCH"), BuildUri("emails/provider"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/EmailTemplatesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/EmailTemplatesClient.cs
@@ -1,5 +1,6 @@
 ﻿using Auth0.ManagementApi.Models;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -15,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public EmailTemplatesClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public EmailTemplatesClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -27,7 +29,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="EmailTemplate"/>.</returns>
         public Task<EmailTemplate> CreateAsync(EmailTemplateCreateRequest request)
         {
-            return Connection.SendAsync<EmailTemplate>(HttpMethod.Post, BuildUri("email-templates"), request, null);
+            return Connection.SendAsync<EmailTemplate>(HttpMethod.Post, BuildUri("email-templates"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -37,7 +39,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="EmailTemplate"/> that was requested.</returns>
         public Task<EmailTemplate> GetAsync(EmailTemplateName templateName)
         {
-            return Connection.GetAsync<EmailTemplate>(BuildUri($"email-templates/{templateName.ToEnumString()}"));
+            return Connection.GetAsync<EmailTemplate>(BuildUri($"email-templates/{templateName.ToEnumString()}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -48,7 +50,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="EmailTemplate"/>.</returns>
         public Task<EmailTemplate> PatchAsync(EmailTemplateName templateName, EmailTemplatePatchRequest request)
         {
-            return Connection.SendAsync<EmailTemplate>(new HttpMethod("PATCH"), BuildUri($"email-templates/{templateName.ToEnumString()}"), request);
+            return Connection.SendAsync<EmailTemplate>(new HttpMethod("PATCH"), BuildUri($"email-templates/{templateName.ToEnumString()}"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -59,7 +61,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="EmailTemplate"/>.</returns>
         public Task<EmailTemplate> UpdateAsync(EmailTemplateName templateName, EmailTemplateUpdateRequest request)
         {
-            return Connection.SendAsync<EmailTemplate>(HttpMethod.Put, BuildUri($"email-templates/{templateName.ToEnumString()}"), request);
+            return Connection.SendAsync<EmailTemplate>(HttpMethod.Put, BuildUri($"email-templates/{templateName.ToEnumString()}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/GuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/GuardianClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public GuardianClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public GuardianClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -34,7 +35,8 @@ namespace Auth0.ManagementApi.Clients
                 .SendAsync<CreateGuardianEnrollmentTicketResponse>(
                 HttpMethod.Post,
                 BuildUri("guardian/enrollments/ticket"),
-                request);
+                request,
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -48,7 +50,8 @@ namespace Auth0.ManagementApi.Clients
                 .SendAsync<object>(
                 HttpMethod.Delete,
                 BuildUri($"guardian/enrollments/{id}"),
-                null);
+                null,
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -60,7 +63,8 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection
                 .GetAsync<GuardianEnrollment>(
-                BuildUri($"guardian/enrollments/{id}"));
+                BuildUri($"guardian/enrollments/{id}"),
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -71,7 +75,8 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection
                 .GetAsync<IList<GuardianFactor>>(
-                BuildUri("guardian/factors"));
+                BuildUri("guardian/factors"),
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -82,7 +87,8 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection
                 .GetAsync<GuardianSmsEnrollmentTemplates>(
-                BuildUri("guardian/factors/sms/templates"));
+                BuildUri("guardian/factors/sms/templates"),
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -93,7 +99,8 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection
                 .GetAsync<GuardianSnsConfiguration>(
-                BuildUri("guardian/factors/push-notification/providers/sns"));
+                BuildUri("guardian/factors/push-notification/providers/sns"),
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -104,7 +111,8 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection
                 .GetAsync<GuardianTwilioConfiguration>(
-                BuildUri("guardian/factors/sms/providers/twilio"));
+                BuildUri("guardian/factors/sms/providers/twilio"),
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -120,7 +128,8 @@ namespace Auth0.ManagementApi.Clients
                 .SendAsync<UpdateGuardianFactorResponse>(
                 HttpMethod.Put,
                 BuildUri($"guardian/factors/{name}"),
-                new { enabled = request.IsEnabled });
+                new { enabled = request.IsEnabled },
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -134,7 +143,8 @@ namespace Auth0.ManagementApi.Clients
                 .SendAsync<GuardianSmsEnrollmentTemplates>(
                 HttpMethod.Put,
                 BuildUri("guardian/factors/sms/templates"),
-                templates);
+                templates,
+                DefaultHeaders);
         }
 
         /// <summary>
@@ -150,7 +160,8 @@ namespace Auth0.ManagementApi.Clients
                 .SendAsync<GuardianTwilioConfiguration>(
                 HttpMethod.Put,
                 BuildUri("guardian/factors/sms/providers/twilio"),
-                request);
+                request,
+                DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/JobsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/JobsClient.cs
@@ -17,8 +17,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public JobsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public JobsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -32,7 +33,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Job"/> instance containing the information about the job.</returns>
         public Task<Job> GetAsync(string id)
         {
-            return Connection.GetAsync<Job>(BuildUri($"jobs/{id}"));
+            return Connection.GetAsync<Job>(BuildUri($"jobs/{id}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace Auth0.ManagementApi.Clients
                 }
             };
 
-            return Connection.SendAsync<Job>(HttpMethod.Post, BuildUri("jobs/users-imports"), parameters, files: fileParameters);
+            return Connection.SendAsync<Job>(HttpMethod.Post, BuildUri("jobs/users-imports"), parameters, DefaultHeaders, files: fileParameters);
         }
 
         /// <summary>
@@ -76,7 +77,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Job"/> instance containing the information about the job.</returns>
         public Task<Job> SendVerificationEmailAsync(VerifyEmailJobRequest request)
         {
-            return Connection.SendAsync<Job>(HttpMethod.Post, BuildUri("jobs/verification-email"), request);
+            return Connection.SendAsync<Job>(HttpMethod.Post, BuildUri("jobs/verification-email"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/LogsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogsClient.cs
@@ -19,8 +19,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public LogsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public LogsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -49,7 +50,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: converters);
+                }), DefaultHeaders, converters);
         }
 
         /// <summary>
@@ -59,7 +60,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="LogEntry"/> instance containing the information about the log entry.</returns>
         public Task<LogEntry> GetAsync(string id)
         {
-            return Connection.GetAsync<LogEntry>(BuildUri($"logs/{id}"));
+            return Connection.GetAsync<LogEntry>(BuildUri($"logs/{id}"), DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
@@ -20,8 +20,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public ResourceServersClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public ResourceServersClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -32,7 +33,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="ResourceServer"/>.</returns>
         public Task<ResourceServer> CreateAsync(ResourceServerCreateRequest request)
         {
-            return Connection.SendAsync<ResourceServer>(HttpMethod.Post, BuildUri("resource-servers"), request);
+            return Connection.SendAsync<ResourceServer>(HttpMethod.Post, BuildUri("resource-servers"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"resource-servers/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"resource-servers/{id}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="ResourceServer"/> that was requested.</returns>
         public Task<ResourceServer> GetAsync(string id)
         {
-            return Connection.GetAsync<ResourceServer>(BuildUri($"resource-servers/{id}"));
+            return Connection.GetAsync<ResourceServer>(BuildUri($"resource-servers/{id}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -68,7 +69,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: converters);
+                }), DefaultHeaders, converters);
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="ResourceServer"/>.</returns>
         public Task<ResourceServer> UpdateAsync(string id, ResourceServerUpdateRequest request)
         {
-            return Connection.SendAsync<ResourceServer>(new HttpMethod("PATCH"), BuildUri($"resource-servers/{id}"), request);
+            return Connection.SendAsync<ResourceServer>(new HttpMethod("PATCH"), BuildUri($"resource-servers/{id}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RolesClient.cs
@@ -22,8 +22,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public RolesClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public RolesClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -34,7 +35,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="Role" />.</returns>
         public Task<Role> CreateAsync(RoleCreateRequest request)
         {
-            return Connection.SendAsync<Role>(HttpMethod.Post, BuildUri("roles"), request);
+            return Connection.SendAsync<Role>(HttpMethod.Post, BuildUri("roles"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -44,7 +45,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{id}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -59,7 +60,8 @@ namespace Auth0.ManagementApi.Clients
 
             return Connection.GetAsync<IPagedList<Role>>(BuildUri("roles",
                 new Dictionary<string, string> { { "name_filter", request.NameFilter } }),
-                converters: rolesConverters);
+                DefaultHeaders,
+                rolesConverters);
         }
 
         /// <summary>
@@ -82,7 +84,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: rolesConverters);
+                }), DefaultHeaders, rolesConverters);
         }
 
         /// <summary>
@@ -92,7 +94,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Role"/> that was requested.</returns>
         public Task<Role> GetAsync(string id)
         {
-            return Connection.GetAsync<Role>(BuildUri($"roles/{id}"));
+            return Connection.GetAsync<Role>(BuildUri($"roles/{id}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -103,7 +105,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="Role"/>.</returns>
         public Task<Role> UpdateAsync(string id, RoleUpdateRequest request)
         {
-            return Connection.SendAsync<Role>(new HttpMethod("PATCH"), BuildUri($"roles/{id}"), request);
+            return Connection.SendAsync<Role>(new HttpMethod("PATCH"), BuildUri($"roles/{id}"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -113,7 +115,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>An <see cref="IPagedList{AssignedUser}"/> containing the assigned users.</returns>
         public Task<IPagedList<AssignedUser>> GetUsersAsync(string id)
         {
-            return Connection.GetAsync<IPagedList<AssignedUser>>(BuildUri($"roles/{id}/users"), converters: assignedUsersConverters);
+            return Connection.GetAsync<IPagedList<AssignedUser>>(BuildUri($"roles/{id}/users"), DefaultHeaders, assignedUsersConverters);
         }
 
         /// <summary>
@@ -130,7 +132,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: assignedUsersConverters);
+                }), DefaultHeaders, assignedUsersConverters);
         }
 
         /// <summary>
@@ -141,7 +143,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assign operation.</returns>
         public Task AssignUsersAsync(string id, AssignUsersRequest request)
         {
-            return Connection.SendAsync<AssignUsersRequest>(HttpMethod.Post, BuildUri($"roles/{id}/users"), request);
+            return Connection.SendAsync<AssignUsersRequest>(HttpMethod.Post, BuildUri($"roles/{id}/users"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -158,7 +160,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: permissionsConverters);
+                }), DefaultHeaders, permissionsConverters);
         }
 
         /// <summary>
@@ -169,7 +171,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assignment operation.</returns>
         public Task AssignPermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"roles/{id}/permissions"), request);
+            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"roles/{id}/permissions"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -180,7 +182,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
         public Task RemovePermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{id}/permissions"), request);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{id}/permissions"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/RulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RulesClient.cs
@@ -20,8 +20,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public RulesClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public RulesClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -32,7 +33,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="Rule" />.</returns>
         public Task<Rule> CreateAsync(RuleCreateRequest request)
         {
-            return Connection.SendAsync<Rule>(HttpMethod.Post, BuildUri("rules"), request, null);
+            return Connection.SendAsync<Rule>(HttpMethod.Post, BuildUri("rules"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"rules/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"rules/{id}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -68,7 +69,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: rulesConverters);
+                }), DefaultHeaders, rulesConverters);
         }
 
         /// <summary>
@@ -91,7 +92,7 @@ namespace Auth0.ManagementApi.Clients
                 {
                     {"fields", fields},
                     {"include_fields", includeFields.ToString().ToLower()}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -102,7 +103,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="Rule"/>.</returns>
         public Task<Rule> UpdateAsync(string id, RuleUpdateRequest request)
         {
-            return Connection.SendAsync<Rule>(new HttpMethod("PATCH"), BuildUri($"rules/{id}"), request);
+            return Connection.SendAsync<Rule>(new HttpMethod("PATCH"), BuildUri($"rules/{id}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/StatsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/StatsClient.cs
@@ -15,8 +15,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public StatsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public StatsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -26,7 +27,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The number of users that have logged in during the last 30 days.</returns>
         public Task<long> GetActiveUsersAsync()
         {
-            return Connection.GetAsync<long>(BuildUri("stats/active-users"));
+            return Connection.GetAsync<long>(BuildUri("stats/active-users"), DefaultHeaders);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
                 {
                     { "from", from.ToString("yyyyMMdd") },
                     { "to", to.ToString("yyyyMMdd") }
-                }));
+                }), DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/TenantSettingsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/TenantSettingsClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public TenantSettingsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public TenantSettingsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -40,7 +41,7 @@ namespace Auth0.ManagementApi.Clients
                 {
                     {"fields", fields},
                     {"include_fields", includeFields.ToString().ToLower()}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -52,7 +53,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="TenantSettings" /> containing the updated settings for the tenant.</returns>
         public Task<TenantSettings> UpdateAsync(TenantSettingsUpdateRequest request)
         {
-            return Connection.SendAsync<TenantSettings>(new HttpMethod("PATCH"), BuildUri("tenants/settings"), request);
+            return Connection.SendAsync<TenantSettings>(new HttpMethod("PATCH"), BuildUri("tenants/settings"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/TicketsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/TicketsClient.cs
@@ -1,5 +1,6 @@
 ﻿using Auth0.ManagementApi.Models;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -15,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public TicketsClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public TicketsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -27,7 +29,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="Ticket"/>.</returns>
         public Task<Ticket> CreateEmailVerificationTicketAsync(EmailVerificationTicketRequest request)
         {
-            return Connection.SendAsync<Ticket>(HttpMethod.Post, BuildUri("tickets/email-verification"), request);
+            return Connection.SendAsync<Ticket>(HttpMethod.Post, BuildUri("tickets/email-verification"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -37,7 +39,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="Ticket"/>.</returns>
         public Task<Ticket> CreatePasswordChangeTicketAsync(PasswordChangeTicketRequest request)
         {
-            return Connection.SendAsync<Ticket>(HttpMethod.Post, BuildUri("tickets/password-change"), request);
+            return Connection.SendAsync<Ticket>(HttpMethod.Post, BuildUri("tickets/password-change"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/UserBlocksClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UserBlocksClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public UserBlocksClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public UserBlocksClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -32,7 +33,7 @@ namespace Auth0.ManagementApi.Clients
                 new Dictionary<string, string>
                 {
                     {"identifier", identifier}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -42,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="UserBlocks"/> relating to the user requested.</returns>
         public Task<UserBlocks> GetByUserIdAsync(string id)
         {
-            return Connection.GetAsync<UserBlocks>(BuildUri($"user-blocks/{id}"));
+            return Connection.GetAsync<UserBlocks>(BuildUri($"user-blocks/{id}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -53,7 +54,7 @@ namespace Auth0.ManagementApi.Clients
         public Task UnblockByIdentifierAsync(string identifier)
         {
             return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri("user-blocks",
-                new Dictionary<string, string> { { "identifier", identifier } }), null);
+                new Dictionary<string, string> { { "identifier", identifier } }), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -64,7 +65,7 @@ namespace Auth0.ManagementApi.Clients
         public Task UnblockByUserIdAsync(string id)
         {
             return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"user-blocks/{id}", 
-                new Dictionary<string, string> { { "id", id } }), null);
+                new Dictionary<string, string> { { "id", id } }), null, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -3,6 +3,7 @@ using Auth0.ManagementApi.Paging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -23,8 +24,9 @@ namespace Auth0.ManagementApi.Clients
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
-        public UsersClient(IManagementConnection connection, Uri baseUri)
-            : base(connection, baseUri)
+        /// <param name="defaultHeaders"><see cref="IDictionary{string, string}"/> containing default headers included with every request this client makes.</param>
+        public UsersClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
         {
         }
 
@@ -36,7 +38,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assign operation.</returns>
         public Task AssignRolesAsync(string id, AssignRolesRequest request)
         {
-            return Connection.SendAsync<AssignRolesRequest>(HttpMethod.Post, BuildUri($"users/{id}/roles"), request);
+            return Connection.SendAsync<AssignRolesRequest>(HttpMethod.Post, BuildUri($"users/{id}/roles"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -46,7 +48,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly created <see cref="User"/>.</returns>
         public Task<User> CreateAsync(UserCreateRequest request)
         {
-            return Connection.SendAsync<User>(HttpMethod.Post, BuildUri("users"), request, null);
+            return Connection.SendAsync<User>(HttpMethod.Post, BuildUri("users"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -59,7 +61,7 @@ namespace Auth0.ManagementApi.Clients
             if (string.IsNullOrWhiteSpace(id))
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(id));
 
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -70,7 +72,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteMultifactorProviderAsync(string id, string provider)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/multifactor/{provider}"), null);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/multifactor/{provider}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -98,7 +100,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()},
-                }), converters: usersConverters);
+                }), DefaultHeaders, usersConverters);
         }
 
         /// <summary>
@@ -121,7 +123,7 @@ namespace Auth0.ManagementApi.Clients
                 {
                     {"fields", fields},
                     {"include_fields", includeFields.ToString().ToLower()}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -144,7 +146,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: logsConverters);
+                }), DefaultHeaders, logsConverters);
         }
 
         /// <summary>
@@ -164,7 +166,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: rolesConverters);
+                }), DefaultHeaders, rolesConverters);
         }
 
         /// <summary>
@@ -182,7 +184,7 @@ namespace Auth0.ManagementApi.Clients
                     {"email", email},
                     {"fields", fields},
                     {"include_fields", includeFields?.ToString().ToLower()}
-                }));
+                }), DefaultHeaders);
         }
 
         /// <summary>
@@ -192,7 +194,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A Task representing the operation and potential return value.</returns>
         public Task<IList<EnrollmentsResponse>> GetEnrollmentsAsync(string id)
         {
-            return Connection.GetAsync<IList<EnrollmentsResponse>>(BuildUri($"users/{id}/enrollments"));
+            return Connection.GetAsync<IList<EnrollmentsResponse>>(BuildUri($"users/{id}/enrollments"), DefaultHeaders);
         }
 
         /// <summary>
@@ -202,7 +204,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A Task representing the operation and potential return value.</returns>
         public Task InvalidateRememberBrowserAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{id}/multifactor/actions/invalidate-remember-browser"), null);
+            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{id}/multifactor/actions/invalidate-remember-browser"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -212,7 +214,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A Task representing the operation and potential return value.</returns>
         public Task<GenerateRecoveryCodeResponse> GenerateRecoveryCodeAsync(string id)
         {
-            return Connection.SendAsync<GenerateRecoveryCodeResponse>(HttpMethod.Post, BuildUri($"users/{id}/recovery-code-regeneration"), null);
+            return Connection.SendAsync<GenerateRecoveryCodeResponse>(HttpMethod.Post, BuildUri($"users/{id}/recovery-code-regeneration"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -223,7 +225,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="IList{AccountLinkResponse}"/> containing details about this account link.</returns>
         public Task<IList<AccountLinkResponse>> LinkAccountAsync(string id, UserAccountLinkRequest request)
         {
-            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Post, BuildUri($"users/{id}/identities"), request);
+            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Post, BuildUri($"users/{id}/identities"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -240,8 +242,12 @@ namespace Auth0.ManagementApi.Clients
                 LinkWith = secondaryJwtToken
             };
 
-            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Post, BuildUri($"users/{id}/identities"), request,
-                new Dictionary<string, string> { { "Authorization", $"Bearer {primaryJwtToken}" } }, null);
+            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Post,
+                BuildUri($"users/{id}/identities"), request,
+                new Dictionary<string, string>(DefaultHeaders)
+                {
+                    ["Authorization"] = $"Bearer {primaryJwtToken}"
+                });
         }
 
         /// <summary>
@@ -252,7 +258,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
         public Task RemoveRolesAsync(string id, AssignRolesRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/roles"), request);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/roles"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -264,7 +270,8 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="IList{AccountLinkResponse}"/> containing details about this account link.</returns>
         public Task<IList<AccountLinkResponse>> UnlinkAccountAsync(string primaryUserId, string provider, string secondaryUserId)
         {
-            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Delete, BuildUri($"users/{primaryUserId}/identities/{provider}/{secondaryUserId}"), null);
+            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Delete,
+                BuildUri($"users/{primaryUserId}/identities/{provider}/{secondaryUserId}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -275,7 +282,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="User"/>.</returns>
         public Task<User> UpdateAsync(string id, UserUpdateRequest request)
         {
-            return Connection.SendAsync<User>(new HttpMethod("PATCH"), BuildUri($"users/{id}"), request);
+            return Connection.SendAsync<User>(new HttpMethod("PATCH"), BuildUri($"users/{id}"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -292,7 +299,7 @@ namespace Auth0.ManagementApi.Clients
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), converters: permissionsConverters);
+                }), DefaultHeaders, permissionsConverters);
         }
 
         /// <summary>
@@ -303,7 +310,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assignment operation.</returns>
         public Task AssignPermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{id}/permissions"), request);
+            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{id}/permissions"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -314,7 +321,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
         public Task RemovePermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/permissions"), request);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/permissions"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
+++ b/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
@@ -18,8 +18,6 @@ namespace Auth0.ManagementApi
     {
         static readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
         readonly HttpClient httpClient;
-
-        IDictionary<string, string> defaultHeaders = new Dictionary<string, string>();
         bool ownHttpClient;
 
         /// <summary>
@@ -46,20 +44,7 @@ namespace Auth0.ManagementApi
         }
 
         /// <inheritdoc />
-        public void SetDefaultHeaders(IDictionary<string, string> headers)
-        {
-            if (ownHttpClient)
-            {
-                ApplyHeaders(httpClient.DefaultRequestHeaders, headers);
-            }
-            else
-            {
-                defaultHeaders = headers;
-            }
-        }
-
-        /// <inheritdoc />
-        public Task<T> GetAsync<T>(Uri uri, IDictionary<string, string> headers = null, JsonConverter[] converters = null)
+        public Task<T> GetAsync<T>(Uri uri, IDictionary<string, string> headers, JsonConverter[] converters = null)
         {
             using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
             {
@@ -69,7 +54,7 @@ namespace Auth0.ManagementApi
         }
 
         /// <inheritdoc />
-        public async Task<T> SendAsync<T>(HttpMethod method, Uri uri, object body, IDictionary<string, string> headers = null, IList<FileUploadParameter> files = null)
+        public async Task<T> SendAsync<T>(HttpMethod method, Uri uri, object body, IDictionary<string, string> headers, IList<FileUploadParameter> files = null)
         {
             using (var request = new HttpRequestMessage(method, uri) { Content = BuildMessageContent(body, files) })
             {
@@ -89,8 +74,6 @@ namespace Auth0.ManagementApi
                 httpClient.Dispose();
                 ownHttpClient = false;
             }
-
-            defaultHeaders = null;
         }
 
         /// <summary>
@@ -103,9 +86,6 @@ namespace Auth0.ManagementApi
 
         private async Task<T> SendRequest<T>(HttpRequestMessage request, JsonConverter[] converters = null)
         {
-            if (!ownHttpClient)
-                ApplyHeaders(request.Headers, defaultHeaders);
-
             var response = await httpClient.SendAsync(request).ConfigureAwait(false);
             {
                 if (!response.IsSuccessStatusCode)

--- a/src/Auth0.ManagementApi/IManagementConnection.cs
+++ b/src/Auth0.ManagementApi/IManagementConnection.cs
@@ -1,5 +1,4 @@
-﻿using Auth0.ManagementApi.Models;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -20,13 +19,6 @@ namespace Auth0.ManagementApi
     public interface IManagementConnection
     {
         /// <summary>
-        /// Sets the default headers that will be used by requests. This includes
-        /// Authorization and the Auth0 User-Agent.
-        /// </summary>
-        /// <param name="headers"><see cref="Dictionary{string, string}"/> of header key/values to send with each request unless overrided on a per-request basis.</param>
-        void SetDefaultHeaders(IDictionary<string, string> headers);
-
-        /// <summary>
         /// Perform a HTTP GET operation against a given <see cref="Uri"/> and return the materialized response body as <typeparamref name="T"/>.
         /// </summary>
         /// <typeparam name="T">Type of object to deserialize the result content as.</typeparam>
@@ -34,7 +26,7 @@ namespace Auth0.ManagementApi
         /// <param name="headers">Optional <see cref="Dictionary{string, string}"/> containing additional headers that may override the defaults.</param>
         /// <param name="converters">Optional <see cref="JsonConverter[]"/> used to deserialize the resulting <typeparamref name="T"/>.</param>
         /// <returns><see cref="Task{T}"/> representing the async operation containing response body as <typeparamref name="T"/>.</returns>
-        Task<T> GetAsync<T>(Uri uri, IDictionary<string, string> headers = null, JsonConverter[] converters = null);
+        Task<T> GetAsync<T>(Uri uri, IDictionary<string, string> headers, JsonConverter[] converters = null);
 
         /// <summary>
         /// Perform a HTTP operation against a given <see cref="Uri"/> and return any materialized response body as <typeparamref name="T"/>.
@@ -51,6 +43,6 @@ namespace Auth0.ManagementApi
         /// <remarks>
         /// <paramref name="files"/> can only be specified if <paramref name="body"/> is <see cref="IDictionary{string, object}"/>.
         /// </remarks>
-        Task<T> SendAsync<T>(HttpMethod method, Uri uri, object body, IDictionary<string, string> headers = null, IList<FileUploadParameter> files = null);
+        Task<T> SendAsync<T>(HttpMethod method, Uri uri, object body, IDictionary<string, string> headers, IList<FileUploadParameter> files = null);
     }
 }

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -126,27 +126,27 @@ namespace Auth0.ManagementApi
                 connectionToDispose = ownedManagementConnection;
             }
 
-            managementConnection.SetDefaultHeaders(CreateDefaultHeaders(token));
+            var defaultHeaders = CreateDefaultHeaders(token);
 
-            BlacklistedTokens = new BlacklistedTokensClient(managementConnection, baseUri);
-            ClientGrants = new ClientGrantsClient(managementConnection, baseUri);
-            Clients = new ClientsClient(managementConnection, baseUri);
-            Connections = new ConnectionsClient(managementConnection, baseUri);
-            CustomDomains = new CustomDomainsClient(managementConnection, baseUri);
-            DeviceCredentials = new DeviceCredentialsClient(managementConnection, baseUri);
-            EmailProvider = new EmailProviderClient(managementConnection, baseUri);
-            EmailTemplates = new EmailTemplatesClient(managementConnection, baseUri);
-            Guardian = new GuardianClient(managementConnection, baseUri);
-            Jobs = new JobsClient(managementConnection, baseUri);
-            Logs = new LogsClient(managementConnection, baseUri);
-            ResourceServers = new ResourceServersClient(managementConnection, baseUri);
-            Roles = new RolesClient(managementConnection, baseUri);
-            Rules = new RulesClient(managementConnection, baseUri);
-            Stats = new StatsClient(managementConnection, baseUri);
-            TenantSettings = new TenantSettingsClient(managementConnection, baseUri);
-            Tickets = new TicketsClient(managementConnection, baseUri);
-            UserBlocks = new UserBlocksClient(managementConnection, baseUri);
-            Users = new UsersClient(managementConnection, baseUri);
+            BlacklistedTokens = new BlacklistedTokensClient(managementConnection, baseUri, defaultHeaders);
+            ClientGrants = new ClientGrantsClient(managementConnection, baseUri, defaultHeaders);
+            Clients = new ClientsClient(managementConnection, baseUri, defaultHeaders);
+            Connections = new ConnectionsClient(managementConnection, baseUri, defaultHeaders);
+            CustomDomains = new CustomDomainsClient(managementConnection, baseUri, defaultHeaders);
+            DeviceCredentials = new DeviceCredentialsClient(managementConnection, baseUri, defaultHeaders);
+            EmailProvider = new EmailProviderClient(managementConnection, baseUri, defaultHeaders);
+            EmailTemplates = new EmailTemplatesClient(managementConnection, baseUri, defaultHeaders);
+            Guardian = new GuardianClient(managementConnection, baseUri, defaultHeaders);
+            Jobs = new JobsClient(managementConnection, baseUri, defaultHeaders);
+            Logs = new LogsClient(managementConnection, baseUri, defaultHeaders);
+            ResourceServers = new ResourceServersClient(managementConnection, baseUri, defaultHeaders);
+            Roles = new RolesClient(managementConnection, baseUri, defaultHeaders);
+            Rules = new RulesClient(managementConnection, baseUri, defaultHeaders);
+            Stats = new StatsClient(managementConnection, baseUri, defaultHeaders);
+            TenantSettings = new TenantSettingsClient(managementConnection, baseUri, defaultHeaders);
+            Tickets = new TicketsClient(managementConnection, baseUri, defaultHeaders);
+            UserBlocks = new UserBlocksClient(managementConnection, baseUri, defaultHeaders);
+            Users = new UsersClient(managementConnection, baseUri, defaultHeaders);
         }
 
         private static Dictionary<string, string> CreateDefaultHeaders(string token)

--- a/tests/Auth0.ManagementApi.IntegrationTests/HttpClientManagementConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/HttpClientManagementConnectionTests.cs
@@ -1,5 +1,6 @@
 ﻿using Auth0.Tests.Shared;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
@@ -13,7 +14,8 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var connection = new HttpClientManagementConnection();
             connection.Dispose();
-            await Assert.ThrowsAsync<ObjectDisposedException >(() => connection.GetAsync<string>(new Uri("https://" + GetVariable("AUTH0_MANAGEMENT_API_URL"))));
+            await Assert.ThrowsAsync<ObjectDisposedException >(() =>
+                connection.GetAsync<string>(new Uri("https://" + GetVariable("AUTH0_MANAGEMENT_API_URL")), new Dictionary<string, string>()));
         }
 
         [Fact]


### PR DESCRIPTION
Part of the new connection design was the intent to allow management connections to be shared between clients giving another vector for sharing HttpClients that is easier than manually creating them and passing to each connection.

Unfortunately, the design included a default headers mechanism that prevented the management connection from being used for more than one tenant at a time.  While we could have documented this it's easier to just not have this edge case ever happen and as a benefit, it simplifies the code and the interface.

This moves the responsibility for managing the headers out from the connection and up into the client with the baseclient taking care to capture them.

Most of this PR is just adding "DefaultHeaders" to various calls (all the *Client classes). In fact there's only one place we ever mess with the default headers for account linking. 