### PR TITLE
Fix ApiConnection adds the default HttpHeader to HttpClient even if it exists

### DIFF
--- a/src/Auth0.Core/Http/ApiConnection.cs
+++ b/src/Auth0.Core/Http/ApiConnection.cs
@@ -50,6 +50,7 @@ namespace Auth0.Core.Http
             _baseUrl = baseUrl;
             _disposeHttpClient = false;
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+            _httpClient.DefaultRequestHeaders.Remove("Auth0-Client");
             _httpClient.DefaultRequestHeaders.Add("Auth0-Client", _agent);
         }
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/ApiConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ApiConnectionTests.cs
@@ -1,7 +1,9 @@
 ﻿using Auth0.Core.Http;
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
@@ -23,6 +25,21 @@ namespace Auth0.ManagementApi.IntegrationTests
             var apiConnection = new ApiConnection("token", "https://auth0.com", httpClient);
             apiConnection.Dispose();
             await apiConnection.GetAsync<string>("", null, null, null, null);
+        }
+        
+        [Fact]
+        public void Does_not_add_default_HttpHeader_if_HttpClient_already_has_it()
+        {
+            var httpClient = new HttpClient();
+
+            // create multiple ApiConnections
+            var apiConnection1 = new ApiConnection("token", "https://auth0.com", httpClient);
+            var apiConnection2 = new ApiConnection("token", "https://auth0.com", httpClient);
+
+            var headerValues = httpClient.DefaultRequestHeaders.GetValues("Auth0-Client");
+
+            // ensure HttpClient has only one value in Auth0-Client header
+            headerValues.Count().Should().Be(1);
         }
     }
 }


### PR DESCRIPTION
### Changes

ApiConnection in Auth0 versions 6.x adds DefaultRequestsHeader to HttpClient every time it is created.
It causes issues in environments that use a single HttpClient, headers collections keeps growing an eventually causes `400 Request Header Or Cookie Too Large` from Auth0 and other servers that HttpClient is used for. It is a significant production issue for us.
![image](https://user-images.githubusercontent.com/12251341/72227218-bbfb5f00-35fe-11ea-95fd-9fc9c666169b.png)

This PR makes change to replace the default `Auth0-Client` header instead of keep adding one.

This PR is based on #6.5.5 release tag, since there's no version 6.x branch, I could only chose `master` as PR base.

The real delta: https://github.com/auth0/auth0.net/pull/358/commits/30cebe53dab4e8f4abad89f0a40a96c4f3b23476

### References

Please include relevant links supporting this change such as a:

- I didn't end up creating an issue, ticket, etc. 

### Testing

It seems that this change can be easily covered by unit test

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
