### PR TITLE
issue #366 solved for .Net framework applications

### DIFF
--- a/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
+++ b/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
@@ -43,12 +43,12 @@ namespace Auth0.ManagementApi
         }
 
         /// <inheritdoc />
-        public Task<T> GetAsync<T>(Uri uri, IDictionary<string, string> headers, JsonConverter[] converters = null)
+        public async Task<T> GetAsync<T>(Uri uri, IDictionary<string, string> headers, JsonConverter[] converters = null)
         {
             using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
             {
                 ApplyHeaders(request.Headers, headers);
-                return SendRequest<T>(request, converters);
+                return await SendRequest<T>(request, converters);
             }
         }
 


### PR DESCRIPTION
Yes v7.0 works for .Net core application but for .Net framework, it doesn't work.

If you look over the code, SendRequest is a task and after that using statements ends which actually disposing the request. After dispose of request, task SendRequest executes where request object is needed for "var response = await httpClient.SendAsync(request).ConfigureAwait(false);"

using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
            {
                ApplyHeaders(request.Headers, headers);
                return SendRequest<T>(request, converters);
            }

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
- Any alternative designs or approaches considered

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
