### PR TITLE
Add missing ConfigureAwait(false) to HttpClient*Connection Get/Send

### DIFF
--- a/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
+++ b/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
@@ -60,7 +60,7 @@ namespace Auth0.AuthenticationApi
             using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
             {
                 ApplyHeaders(request, headers);
-                return await SendRequest<T>(request);
+                return await SendRequest<T>(request).ConfigureAwait(false);
             }
         }
 

--- a/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
+++ b/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
@@ -48,7 +48,7 @@ namespace Auth0.ManagementApi
             using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
             {
                 ApplyHeaders(request.Headers, headers);
-                return await SendRequest<T>(request, converters);
+                return await SendRequest<T>(request, converters).ConfigureAwait(false);
             }
         }
 
@@ -58,7 +58,7 @@ namespace Auth0.ManagementApi
             using (var request = new HttpRequestMessage(method, uri) { Content = BuildMessageContent(body, files) })
             {
                 ApplyHeaders(request.Headers, headers);
-                return await SendRequest<T>(request);
+                return await SendRequest<T>(request).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
`ConfigureAwait(false)` was missing in a couple of places in `HttpClientAuthenticationConnection` and `HttpClientManagementConnection`.