### PR TITLE
Encode all path parameters in the Managment API

### DIFF
--- a/src/Auth0.ManagementApi/Clients/BaseClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BaseClient.cs
@@ -48,5 +48,15 @@ namespace Auth0.ManagementApi.Clients
         {
             return Utils.BuildUri(BaseUri.AbsoluteUri, resource, null, queryStrings);
         }
+
+        /// <summary>
+        /// Encode a value so it can be successfully used in the path.
+        /// </summary>
+        /// <param name="value">Value to encode for the path.</param>
+        /// <returns>URI encoded/escaped value that can be used in the path.</returns>
+        protected string EncodePath(string value)
+        {
+            return Uri.EscapeUriString(value);
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
@@ -43,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"client-grants/{id}"), null, DefaultHeaders); 
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"client-grants/{EncodePath(id)}"), null, DefaultHeaders); 
         }
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="ClientGrant"/> that has been updated.</returns>
         public Task<ClientGrant> UpdateAsync(string id, ClientGrantUpdateRequest request)
         {
-            return Connection.SendAsync<ClientGrant>(new HttpMethod("PATCH"), BuildUri($"client-grants/{id}"), request, DefaultHeaders);
+            return Connection.SendAsync<ClientGrant>(new HttpMethod("PATCH"), BuildUri($"client-grants/{EncodePath(id)}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -44,7 +44,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"clients/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"clients/{EncodePath(id)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Client"/> retrieved.</returns>
         public Task<Client> GetAsync(string id, string fields = null, bool includeFields = true)
         {
-            return Connection.GetAsync<Client>(BuildUri($"clients/{id}",
+            return Connection.GetAsync<Client>(BuildUri($"clients/{EncodePath(id)}",
                 new Dictionary<string, string>
                 {
                     {"fields", fields},
@@ -107,7 +107,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Client"/> that has had its secret rotated.</returns>
         public Task<Client> RotateClientSecret(string id)
         {
-            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri($"clients/{id}/rotate-secret"), null, DefaultHeaders);
+            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri($"clients/{EncodePath(id)}/rotate-secret"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Client"/> that was updated.</returns>
         public Task<Client> UpdateAsync(string id, ClientUpdateRequest request)
         {
-            return Connection.SendAsync<Client>(new HttpMethod("PATCH"), BuildUri($"clients/{id}"), request, DefaultHeaders);
+            return Connection.SendAsync<Client>(new HttpMethod("PATCH"), BuildUri($"clients/{EncodePath(id)}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -43,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{EncodePath(id)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteUserAsync(string id, string email)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{id}/users",
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{EncodePath(id)}/users",
                 new Dictionary<string, string> { {"email", email} }), null, DefaultHeaders);
         }
 
@@ -70,7 +70,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Connection"/>.</returns>
         public Task<Connection> GetAsync(string id, string fields = null, bool includeFields = true)
         {
-            return Connection.GetAsync<Connection>(BuildUri($"connections/{id}",
+            return Connection.GetAsync<Connection>(BuildUri($"connections/{EncodePath(id)}",
                 new Dictionary<string, string>
                 {
                     {"fields", fields},
@@ -117,7 +117,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Connection"/> that has been updated.</returns>
         public Task<Connection> UpdateAsync(string id, ConnectionUpdateRequest request)
         {
-            return Connection.SendAsync<Connection>(new HttpMethod("PATCH"), BuildUri($"connections/{id}"), request, DefaultHeaders);
+            return Connection.SendAsync<Connection>(new HttpMethod("PATCH"), BuildUri($"connections/{EncodePath(id)}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
@@ -41,7 +41,7 @@ namespace Auth0.ManagementApi.Clients
         /// <remarks>When deleted, Auth0 will stop serving requests for this domain.</remarks>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"custom-domains/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"custom-domains/{EncodePath(id)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="CustomDomain"/> that was requested.</returns>
         public Task<CustomDomain> GetAsync(string id)
         {
-            return Connection.GetAsync<CustomDomain>(BuildUri($"custom-domains/{id}"), DefaultHeaders);
+            return Connection.GetAsync<CustomDomain>(BuildUri($"custom-domains/{EncodePath(id)}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -70,7 +70,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="CustomDomainVerification"/> that was requested.</returns>
         public Task<CustomDomainVerificationResponse> VerifyAsync(string id)
         {
-            return Connection.SendAsync<CustomDomainVerificationResponse>(HttpMethod.Post, BuildUri($"custom-domains/{id}/verify"), null, DefaultHeaders);
+            return Connection.SendAsync<CustomDomainVerificationResponse>(HttpMethod.Post, BuildUri($"custom-domains/{EncodePath(id)}/verify"), null, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
@@ -61,7 +61,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"device-credentials/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"device-credentials/{EncodePath(id)}"), null, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/GuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/GuardianClient.cs
@@ -49,7 +49,7 @@ namespace Auth0.ManagementApi.Clients
             return Connection
                 .SendAsync<object>(
                 HttpMethod.Delete,
-                BuildUri($"guardian/enrollments/{id}"),
+                BuildUri($"guardian/enrollments/{EncodePath(id)}"),
                 null,
                 DefaultHeaders);
         }
@@ -63,7 +63,7 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection
                 .GetAsync<GuardianEnrollment>(
-                BuildUri($"guardian/enrollments/{id}"),
+                BuildUri($"guardian/enrollments/{EncodePath(id)}"),
                 DefaultHeaders);
         }
 

--- a/src/Auth0.ManagementApi/Clients/JobsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/JobsClient.cs
@@ -33,7 +33,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Job"/> instance containing the information about the job.</returns>
         public Task<Job> GetAsync(string id)
         {
-            return Connection.GetAsync<Job>(BuildUri($"jobs/{id}"), DefaultHeaders);
+            return Connection.GetAsync<Job>(BuildUri($"jobs/{EncodePath(id)}"), DefaultHeaders);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/LogsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogsClient.cs
@@ -60,7 +60,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="LogEntry"/> instance containing the information about the log entry.</returns>
         public Task<LogEntry> GetAsync(string id)
         {
-            return Connection.GetAsync<LogEntry>(BuildUri($"logs/{id}"), DefaultHeaders);
+            return Connection.GetAsync<LogEntry>(BuildUri($"logs/{EncodePath(id)}"), DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
@@ -43,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"resource-servers/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"resource-servers/{EncodePath(id)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="ResourceServer"/> that was requested.</returns>
         public Task<ResourceServer> GetAsync(string id)
         {
-            return Connection.GetAsync<ResourceServer>(BuildUri($"resource-servers/{id}"), DefaultHeaders);
+            return Connection.GetAsync<ResourceServer>(BuildUri($"resource-servers/{EncodePath(id)}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="ResourceServer"/>.</returns>
         public Task<ResourceServer> UpdateAsync(string id, ResourceServerUpdateRequest request)
         {
-            return Connection.SendAsync<ResourceServer>(new HttpMethod("PATCH"), BuildUri($"resource-servers/{id}"), request, DefaultHeaders);
+            return Connection.SendAsync<ResourceServer>(new HttpMethod("PATCH"), BuildUri($"resource-servers/{EncodePath(id)}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RolesClient.cs
@@ -45,7 +45,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{EncodePath(id)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Role"/> that was requested.</returns>
         public Task<Role> GetAsync(string id)
         {
-            return Connection.GetAsync<Role>(BuildUri($"roles/{id}"), DefaultHeaders);
+            return Connection.GetAsync<Role>(BuildUri($"roles/{EncodePath(id)}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="Role"/>.</returns>
         public Task<Role> UpdateAsync(string id, RoleUpdateRequest request)
         {
-            return Connection.SendAsync<Role>(new HttpMethod("PATCH"), BuildUri($"roles/{id}"), request, DefaultHeaders);
+            return Connection.SendAsync<Role>(new HttpMethod("PATCH"), BuildUri($"roles/{EncodePath(id)}"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>An <see cref="IPagedList{AssignedUser}"/> containing the assigned users.</returns>
         public Task<IPagedList<AssignedUser>> GetUsersAsync(string id)
         {
-            return Connection.GetAsync<IPagedList<AssignedUser>>(BuildUri($"roles/{id}/users"), DefaultHeaders, assignedUsersConverters);
+            return Connection.GetAsync<IPagedList<AssignedUser>>(BuildUri($"roles/{EncodePath(id)}/users"), DefaultHeaders, assignedUsersConverters);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>An <see cref="IPagedList{AssignedUser}"/> containing the assigned users.</returns>
         public Task<IPagedList<AssignedUser>> GetUsersAsync(string id, PaginationInfo pagination)
         {
-            return Connection.GetAsync<IPagedList<AssignedUser>>(BuildUri($"roles/{id}/users",
+            return Connection.GetAsync<IPagedList<AssignedUser>>(BuildUri($"roles/{EncodePath(id)}/users",
                 new Dictionary<string, string>
                 {
                     {"page", pagination.PageNo.ToString()},
@@ -143,7 +143,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assign operation.</returns>
         public Task AssignUsersAsync(string id, AssignUsersRequest request)
         {
-            return Connection.SendAsync<AssignUsersRequest>(HttpMethod.Post, BuildUri($"roles/{id}/users"), request, DefaultHeaders);
+            return Connection.SendAsync<AssignUsersRequest>(HttpMethod.Post, BuildUri($"roles/{EncodePath(id)}/users"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions for this role.</returns>
         public Task<IPagedList<Permission>> GetPermissionsAsync(string id, PaginationInfo pagination)
         {
-            return Connection.GetAsync<IPagedList<Permission>>(BuildUri($"roles/{id}/permissions",
+            return Connection.GetAsync<IPagedList<Permission>>(BuildUri($"roles/{EncodePath(id)}/permissions",
                 new Dictionary<string, string>
                 {
                     {"page", pagination.PageNo.ToString()},
@@ -171,7 +171,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assignment operation.</returns>
         public Task AssignPermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"roles/{id}/permissions"), request, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"roles/{EncodePath(id)}/permissions"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
         public Task RemovePermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{id}/permissions"), request, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"roles/{EncodePath(id)}/permissions"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/RulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RulesClient.cs
@@ -43,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"rules/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"rules/{EncodePath(id)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -87,7 +87,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="Rule" /> that was requested.</returns>
         public Task<Rule> GetAsync(string id, string fields = null, bool includeFields = true)
         {
-            return Connection.GetAsync<Rule>(BuildUri($"rules/{id}",
+            return Connection.GetAsync<Rule>(BuildUri($"rules/{EncodePath(id)}",
                 new Dictionary<string, string>
                 {
                     {"fields", fields},
@@ -103,7 +103,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="Rule"/>.</returns>
         public Task<Rule> UpdateAsync(string id, RuleUpdateRequest request)
         {
-            return Connection.SendAsync<Rule>(new HttpMethod("PATCH"), BuildUri($"rules/{id}"), request, DefaultHeaders);
+            return Connection.SendAsync<Rule>(new HttpMethod("PATCH"), BuildUri($"rules/{EncodePath(id)}"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/UserBlocksClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UserBlocksClient.cs
@@ -43,7 +43,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="UserBlocks"/> relating to the user requested.</returns>
         public Task<UserBlocks> GetByUserIdAsync(string id)
         {
-            return Connection.GetAsync<UserBlocks>(BuildUri($"user-blocks/{id}"), DefaultHeaders);
+            return Connection.GetAsync<UserBlocks>(BuildUri($"user-blocks/{EncodePath(id)}"), DefaultHeaders);
         }
 
         /// <summary>
@@ -64,7 +64,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous unblock operation.</returns>
         public Task UnblockByUserIdAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"user-blocks/{id}", 
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"user-blocks/{EncodePath(id)}", 
                 new Dictionary<string, string> { { "id", id } }), null, DefaultHeaders);
         }
     }

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -3,7 +3,6 @@ using Auth0.ManagementApi.Paging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -38,7 +37,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assign operation.</returns>
         public Task AssignRolesAsync(string id, AssignRolesRequest request)
         {
-            return Connection.SendAsync<AssignRolesRequest>(HttpMethod.Post, BuildUri($"users/{id}/roles"), request, DefaultHeaders);
+            return Connection.SendAsync<AssignRolesRequest>(HttpMethod.Post, BuildUri($"users/{EncodePath(id)}/roles"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -61,7 +60,7 @@ namespace Auth0.ManagementApi.Clients
             if (string.IsNullOrWhiteSpace(id))
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(id));
 
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{EncodePath(id)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -72,7 +71,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteMultifactorProviderAsync(string id, string provider)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/multifactor/{provider}"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{EncodePath(id)}/multifactor/{EncodePath(provider)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -118,7 +117,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The <see cref="User"/> that was requested.</returns>
         public Task<User> GetAsync(string id, string fields = null, bool includeFields = true)
         {
-            return Connection.GetAsync<User>(BuildUri($"users/{id}",
+            return Connection.GetAsync<User>(BuildUri($"users/{EncodePath(id)}",
                 new Dictionary<string, string>
                 {
                     {"fields", fields},
@@ -139,7 +138,7 @@ namespace Auth0.ManagementApi.Clients
             if (pagination == null)
                 throw new ArgumentNullException(nameof(pagination));
 
-            return Connection.GetAsync<IPagedList<LogEntry>>(BuildUri($"users/{request.UserId}/logs",
+            return Connection.GetAsync<IPagedList<LogEntry>>(BuildUri($"users/{EncodePath(request.UserId)}/logs",
                 new Dictionary<string, string>
                 {
                     {"sort", request.Sort},
@@ -160,7 +159,7 @@ namespace Auth0.ManagementApi.Clients
             if (pagination == null)
                 throw new ArgumentNullException(nameof(pagination));
 
-            return Connection.GetAsync<IPagedList<Role>>(BuildUri($"users/{userId}/roles",
+            return Connection.GetAsync<IPagedList<Role>>(BuildUri($"users/{EncodePath(userId)}/roles",
                 new Dictionary<string, string>
                 {
                     {"page", pagination.PageNo.ToString()},
@@ -194,7 +193,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A Task representing the operation and potential return value.</returns>
         public Task<IList<EnrollmentsResponse>> GetEnrollmentsAsync(string id)
         {
-            return Connection.GetAsync<IList<EnrollmentsResponse>>(BuildUri($"users/{id}/enrollments"), DefaultHeaders);
+            return Connection.GetAsync<IList<EnrollmentsResponse>>(BuildUri($"users/{EncodePath(id)}/enrollments"), DefaultHeaders);
         }
 
         /// <summary>
@@ -204,7 +203,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A Task representing the operation and potential return value.</returns>
         public Task InvalidateRememberBrowserAsync(string id)
         {
-            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{id}/multifactor/actions/invalidate-remember-browser"), null, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{EncodePath(id)}/multifactor/actions/invalidate-remember-browser"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -214,7 +213,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A Task representing the operation and potential return value.</returns>
         public Task<GenerateRecoveryCodeResponse> GenerateRecoveryCodeAsync(string id)
         {
-            return Connection.SendAsync<GenerateRecoveryCodeResponse>(HttpMethod.Post, BuildUri($"users/{id}/recovery-code-regeneration"), null, DefaultHeaders);
+            return Connection.SendAsync<GenerateRecoveryCodeResponse>(HttpMethod.Post, BuildUri($"users/{EncodePath(id)}/recovery-code-regeneration"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -225,7 +224,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="IList{AccountLinkResponse}"/> containing details about this account link.</returns>
         public Task<IList<AccountLinkResponse>> LinkAccountAsync(string id, UserAccountLinkRequest request)
         {
-            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Post, BuildUri($"users/{id}/identities"), request, DefaultHeaders);
+            return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Post, BuildUri($"users/{EncodePath(id)}/identities"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -243,7 +242,7 @@ namespace Auth0.ManagementApi.Clients
             };
 
             return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Post,
-                BuildUri($"users/{id}/identities"), request,
+                BuildUri($"users/{EncodePath(id)}/identities"), request,
                 new Dictionary<string, string>(DefaultHeaders)
                 {
                     ["Authorization"] = $"Bearer {primaryJwtToken}"
@@ -258,7 +257,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
         public Task RemoveRolesAsync(string id, AssignRolesRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/roles"), request, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{EncodePath(id)}/roles"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -271,7 +270,7 @@ namespace Auth0.ManagementApi.Clients
         public Task<IList<AccountLinkResponse>> UnlinkAccountAsync(string primaryUserId, string provider, string secondaryUserId)
         {
             return Connection.SendAsync<IList<AccountLinkResponse>>(HttpMethod.Delete,
-                BuildUri($"users/{primaryUserId}/identities/{provider}/{secondaryUserId}"), null, DefaultHeaders);
+                BuildUri($"users/{EncodePath(primaryUserId)}/identities/{EncodePath(provider)}/{EncodePath(secondaryUserId)}"), null, DefaultHeaders);
         }
 
         /// <summary>
@@ -282,7 +281,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>The newly updated <see cref="User"/>.</returns>
         public Task<User> UpdateAsync(string id, UserUpdateRequest request)
         {
-            return Connection.SendAsync<User>(new HttpMethod("PATCH"), BuildUri($"users/{id}"), request, DefaultHeaders);
+            return Connection.SendAsync<User>(new HttpMethod("PATCH"), BuildUri($"users/{EncodePath(id)}"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -293,7 +292,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions for this user.</returns>
         public Task<IPagedList<Permission>> GetPermissionsAsync(string id, PaginationInfo pagination)
         {
-            return Connection.GetAsync<IPagedList<Permission>>(BuildUri($"users/{id}/permissions",
+            return Connection.GetAsync<IPagedList<Permission>>(BuildUri($"users/{EncodePath(id)}/permissions",
                 new Dictionary<string, string>
                 {
                     {"page", pagination.PageNo.ToString()},
@@ -310,7 +309,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous assignment operation.</returns>
         public Task AssignPermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{id}/permissions"), request, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Post, BuildUri($"users/{EncodePath(id)}/permissions"), request, DefaultHeaders);
         }
 
         /// <summary>
@@ -321,7 +320,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>A <see cref="Task"/> that represents the asynchronous remove operation.</returns>
         public Task RemovePermissionsAsync(string id, AssignPermissionsRequest request)
         {
-            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{id}/permissions"), request, DefaultHeaders);
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"users/{EncodePath(id)}/permissions"), request, DefaultHeaders);
         }
     }
 }


### PR DESCRIPTION
Path parameters were not being encoded which was specifically causing problems with resource servers which can be referenced by URL.

Fixes #377 