### PR TITLE
Do not use JSON.NET's default serializer settings

### DIFF
--- a/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
+++ b/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
@@ -89,7 +89,7 @@ namespace Auth0.AuthenticationApi
 
                 return typeof(T) == typeof(string)
                     ? (T)(object)content
-                    : JsonConvert.DeserializeObject<T>(content);
+                    : JsonConvert.DeserializeObject<T>(content, jsonSerializerSettings);
             }
         }
 

--- a/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
+++ b/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
@@ -16,6 +16,7 @@ namespace Auth0.ManagementApi
     public class HttpClientManagementConnection : IManagementConnection, IDisposable
     {
         static readonly JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+
         readonly HttpClient httpClient;
         bool ownHttpClient;
 
@@ -94,7 +95,8 @@ namespace Auth0.ManagementApi
 
                 return typeof(T) == typeof(string)
                     ? (T)(object)content
-                    : JsonConvert.DeserializeObject<T>(content, converters);
+                    : JsonConvert.DeserializeObject<T>(content,
+                        converters == null ? jsonSerializerSettings : new JsonSerializerSettings() { Converters = converters });
             }
         }
 


### PR DESCRIPTION
It is possible to change the default settings for JSON.NET at a global level. We want to ensure we do not pick up any global settings to ensure deserialization works as we expect.

Fixes #390 