### PR TITLE
Add client secret to passwordless

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -261,6 +261,7 @@ namespace Auth0.AuthenticationApi
             var body = new
             {
                 client_id = request.ClientId,
+                client_secret = request.ClientSecret,
                 connection = "email",
                 email = request.Email,
                 send = request.Type.ToString().ToLower(),
@@ -282,6 +283,7 @@ namespace Auth0.AuthenticationApi
             var body = new
             {
                 client_id = request.ClientId,
+                client_secret = request.ClientSecret,
                 connection = "sms",
                 phone_number = request.PhoneNumber
             };

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessEmailRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessEmailRequest.cs
@@ -15,6 +15,12 @@ namespace Auth0.AuthenticationApi.Models
         public string ClientId { get; set; }
 
         /// <summary>
+        /// Client Secret of the application.
+        /// </summary>
+        [JsonProperty("client_secret")]
+        public string ClientSecret { get; set; }
+
+        /// <summary>
         /// Email to which the link or code must be sent.
         /// </summary>
         [JsonProperty("email")]

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessEmailResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessEmailResponse.cs
@@ -10,7 +10,7 @@ namespace Auth0.AuthenticationApi.Models
         /// <summary>
         /// Identifier of this request.
         /// </summary>
-        [JsonProperty("id")]
+        [JsonProperty("_id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -18,5 +18,11 @@ namespace Auth0.AuthenticationApi.Models
         /// </summary>
         [JsonProperty("email")]
         public string Email { get; set; }
+
+        /// <summary>
+        /// Whether the email address has been verified (true) or has not been verified (false).
+        /// </summary>
+        [JsonProperty("email_verified")]
+        public bool? EmailVerified { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessSmsRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessSmsRequest.cs
@@ -14,6 +14,12 @@ namespace Auth0.AuthenticationApi.Models
         public string ClientId { get; set; }
 
         /// <summary>
+        /// Client Secret of the application.
+        /// </summary>
+        [JsonProperty("client_secret")]
+        public string ClientSecret { get; set; }
+
+        /// <summary>
         /// Phone number to which the code must be sent.
         /// </summary>
         [JsonProperty("phone_number")]

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -17,6 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/PasswordlessTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/PasswordlessTests.cs
@@ -9,72 +9,88 @@ namespace Auth0.AuthenticationApi.IntegrationTests
 {
     public class PasswordlessTests : TestBase
     {
-        [Fact(Skip = "Run manually")]
+        private AuthenticationApiClient authenticationApiClient;
+        private string email;
+        private string phone;
+
+        public PasswordlessTests()
+        {
+            authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+            email = GetVariable("AUTH0_PASSWORDLESSDEMO_EMAIL", false);
+            phone = GetVariable("AUTH0_PASSWORDLESSDEMO_PHONE", false);
+        }
+
+        [SkippableFact]
         public async Task Can_launch_email_link_flow()
         {
-            // Arrange
-            using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))
-            {
-                // Act
-                var request = new PasswordlessEmailRequest
-                {
-                    ClientId = GetVariable("AUTH0_CLIENT_ID"),
-                    Email = "your email",
-                    Type = PasswordlessEmailRequestType.Link
-                };
-                var response = await authenticationApiClient.StartPasswordlessEmailFlowAsync(request);
-                response.Should().NotBeNull();
-                response.Email.Should().Be(request.Email);
-            }
-        }
+            Skip.If(string.IsNullOrEmpty(email), "AUTH0_PASSWORDLESSDEMO_EMAIL not set");
 
-        [Fact(Skip = "Run manually")]
-        public async Task Can_launch_email_link_flow_with_auth_parameters()
-        {
-            // Arrange 
-            using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))
-            {
-                // Act
-                var request = new PasswordlessEmailRequest
-                {
-                    ClientId = GetVariable("AUTH0_CLIENT_ID"),
-                    Email = "your email",
-                    Type = PasswordlessEmailRequestType.Link,
-                    AuthenticationParameters = new Dictionary<string, object>()
-                {
-                    { "response_type","code" },
-                    { "scope" , "openid" },
-                    {  "nonce" , "mynonce" },
-                    { "redirect_uri", "http://localhost:5000/signin-auth0" }
-                }
-                };
-                var response = await authenticationApiClient.StartPasswordlessEmailFlowAsync(request);
-                response.Should().NotBeNull();
-                response.Email.Should().Be(request.Email);
-            }
-        }
-
-        [Fact(Skip = "Run manually")]
-        public async Task Can_launch_email_code_flow()
-        {
-            // Arrange
-            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
-
-            // Act
             var request = new PasswordlessEmailRequest
             {
                 ClientId = GetVariable("AUTH0_CLIENT_ID"),
-                Email = "your email",
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                Email = email,
+                Type = PasswordlessEmailRequestType.Link
+            };
+
+            var response = await authenticationApiClient.StartPasswordlessEmailFlowAsync(request);
+            response.Should().NotBeNull();
+            response.Email.Should().Be(request.Email);
+            response.Id.Should().NotBeNullOrEmpty();
+            response.EmailVerified.Should().NotBeNull();
+        }
+
+        [SkippableFact]
+        public async Task Can_launch_email_link_flow_with_auth_parameters()
+        {
+            Skip.If(string.IsNullOrEmpty(email), "AUTH0_PASSWORDLESSDEMO_EMAIL not set");
+
+            var request = new PasswordlessEmailRequest
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                Email = email,
+                Type = PasswordlessEmailRequestType.Link,
+                AuthenticationParameters = new Dictionary<string, object>()
+                {
+                    { "response_type", "code" },
+                    { "scope" , "openid" },
+                    { "nonce" , "mynonce" },
+                    { "redirect_uri", "http://localhost:5000/signin-auth0" }
+                }
+            };
+
+            var response = await authenticationApiClient.StartPasswordlessEmailFlowAsync(request);
+            response.Should().NotBeNull();
+            response.Email.Should().Be(request.Email);
+            response.Id.Should().NotBeNullOrEmpty();
+            response.EmailVerified.Should().NotBeNull();
+        }
+
+        [SkippableFact]
+        public async Task Can_launch_email_code_flow()
+        {
+            Skip.If(string.IsNullOrEmpty(email), "AUTH0_PASSWORDLESSDEMO_EMAIL not set");
+
+            var request = new PasswordlessEmailRequest
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                Email = email,
                 Type = PasswordlessEmailRequestType.Code
             };
             var response = await authenticationApiClient.StartPasswordlessEmailFlowAsync(request);
             response.Should().NotBeNull();
             response.Email.Should().Be(request.Email);
+            response.Id.Should().NotBeNullOrEmpty();
+            response.EmailVerified.Should().NotBeNull();
         }
 
-        [Fact(Skip = "Run manually")]
+        [SkippableFact]
         public async Task Can_launch_sms_flow()
         {
+            Skip.If(string.IsNullOrEmpty(phone), "AUTH0_PASSWORDLESSDEMO_PHONE not set");
+
             // Arrange
             using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_PASSWORDLESSDEMO_AUTHENTICATION_API_URL")))
             {
@@ -82,7 +98,8 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 var request = new PasswordlessSmsRequest
                 {
                     ClientId = GetVariable("AUTH0_PASSWORDLESSDEMO_CLIENT_ID"),
-                    PhoneNumber = "your phone number"
+                    ClientSecret = GetVariable("AUTH0_PASSWORDLESSDEMO_CLIENT_SECRET"),
+                    PhoneNumber = phone
                 };
                 var response = await authenticationApiClient.StartPasswordlessSmsFlowAsync(request);
                 response.Should().NotBeNull();

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
@@ -48,10 +48,10 @@ namespace Auth0.Tests.Shared
             }
         }
 
-        protected static string GetVariable(string variableName)
+        protected static string GetVariable(string variableName, bool throwIfMissing = true)
         {
             var value = _config[variableName];
-            if (String.IsNullOrEmpty(value))
+            if (String.IsNullOrEmpty(value) && throwIfMissing)
                 throw new ArgumentOutOfRangeException($"Configuration value '{variableName}' has not been set.");
             return value;
         }


### PR DESCRIPTION
Adds support for `client_secret` being sent as a new parameter to `passwordless/start`

https://community.auth0.com/t/passwordless-connection-not-working-for-tenants-created-after-jan-2-2020/36415

Basic change is very simple but also fixed return `id` and added `email_verified` on the response.

Tests are now conditionally skippable depending on whether the environment variables are set.