### PR TITLE
Preserve URL path for auth

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -1,5 +1,6 @@
 ﻿using Auth0.AuthenticationApi.Models;
 using Auth0.AuthenticationApi.Tokens;
+using Auth0.Core.Http;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
@@ -324,7 +325,7 @@ namespace Auth0.AuthenticationApi
 
         private Uri BuildUri(string path)
         {
-            return new UriBuilder(BaseUri) { Path = path }.Uri;
+            return Utils.BuildUri(BaseUri.AbsoluteUri, path, null, null);
         }
 
         private IDictionary<string, string> BuildHeaders(string accessToken)

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
@@ -10,6 +10,22 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Builders
     public class UriBuildersTests : TestBase
     {
         [Fact]
+        public void Preserves_Uri_Path()
+        {
+            var authenticationApiClient = new AuthenticationApiClient(new Uri("https://localhost:2000/something/here"));
+
+            var authorizationUrl = authenticationApiClient.BuildAuthorizationUrl()
+                .WithResponseType(AuthorizationResponseType.Code)
+                .WithClient("rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW")
+                .WithConnection("google-oauth2")
+                .Build();
+
+            authorizationUrl.Should()
+                .Be(
+                    new Uri("https://localhost:2000/something/here/authorize?response_type=code&client_id=rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW&connection=google-oauth2"));
+        }
+
+        [Fact]
         public void Can_build_authorization_uri()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));


### PR DESCRIPTION
Right now if you pass a URL to AuthenticationApiClient the path portion is ignored.

While this is never an issue in real-world usage it does prevent some development and testing scenarios from being able to mock out the server-side.

This is a potentially breaking change if a customer today was accidentally passing a URL that incorrectly contained a path parameter but that is an unlikely scenario so not treating this as a breaking change under the "semver is an intent" philosophy.