### PR TITLE
[SDK-1871] Add Management API support for Log Streams

### DIFF
--- a/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
@@ -66,6 +66,20 @@ namespace Auth0.ManagementApi.Clients
 
             return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"log-streams/{EncodePath(id)}"), null, DefaultHeaders);
         }
+
+        /// <summary>
+        /// Updates a log stream
+        /// </summary>
+        /// <param name="id">The id of the log stream to update</param>
+        /// <param name="request">The information required to update the log stream</param>
+        /// <returns>The updated <see cref="LogStream"/> object</returns>
+        public Task<LogStream> UpdateAsync(string id, LogStreamUpdateRequest request)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(id));
+
+            return Connection.SendAsync<LogStream>(new HttpMethod("PATCH"), BuildUri($"log-streams/{EncodePath(id)}"), request, DefaultHeaders);
+        }
     }
 }
 

--- a/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
@@ -1,6 +1,7 @@
 ﻿using Auth0.ManagementApi.Models;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Auth0.ManagementApi.Clients
@@ -28,6 +29,16 @@ namespace Auth0.ManagementApi.Clients
         public Task<IList<LogStream>> GetAllAsync()
         {
             return Connection.GetAsync<IList<LogStream>>(BuildUri("log-streams"), DefaultHeaders);
+        }
+
+        /// <summary>
+        /// Creates a new log stream
+        /// </summary>
+        /// <param name="request">The <see cref="LogStreamCreateRequest"/> containing the information needed to create the log stream</param>
+        /// <returns>A <see cref="Task"/> that represents the  asynchronous create operation.</returns>
+        public Task CreateAsync(LogStreamCreateRequest request)
+        {
+            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri("log-streams"), request, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
@@ -32,13 +32,39 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <summary>
+        /// Gets a log stream
+        /// </summary>
+        /// <param name="id">The id of the log stream to get</param>
+        /// <returns>A <see cref="LogStream"/> object</returns>
+        public Task<LogStream> GetAsync(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(id));
+
+            return Connection.GetAsync<LogStream>(BuildUri($"log-streams/{EncodePath(id)}"), DefaultHeaders);
+        }
+
+        /// <summary>
         /// Creates a new log stream
         /// </summary>
         /// <param name="request">The <see cref="LogStreamCreateRequest"/> containing the information needed to create the log stream</param>
         /// <returns>A <see cref="Task"/> that represents the  asynchronous create operation.</returns>
-        public Task CreateAsync(LogStreamCreateRequest request)
+        public Task<LogStream> CreateAsync(LogStreamCreateRequest request)
         {
-            return Connection.SendAsync<Client>(HttpMethod.Post, BuildUri("log-streams"), request, DefaultHeaders);
+            return Connection.SendAsync<LogStream>(HttpMethod.Post, BuildUri("log-streams"), request, DefaultHeaders);
+        }
+
+        /// <summary>
+        /// Deletes a log stream
+        /// </summary>
+        /// <param name="id">The id of the log stream to delete</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
+        public Task DeleteAsync(string id)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(id));
+
+            return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"log-streams/{EncodePath(id)}"), null, DefaultHeaders);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogStreamsClient.cs
@@ -1,0 +1,34 @@
+﻿using Auth0.ManagementApi.Models;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Auth0.ManagementApi.Clients
+{
+    /// <summary>
+    /// Contains methods to access the /log-streams endpoint
+    /// </summary>
+    public class LogStreamsClient : BaseClient
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="LogStreamsClient"/>
+        /// </summary>
+        /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
+        /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>
+        /// <param name="defaultHeaders">Dictionary containing default headers included with every request this client makes.</param>
+        public LogStreamsClient(IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders)
+            : base(connection, baseUri, defaultHeaders)
+        {
+        }
+
+        /// <summary>
+        /// Gets all of the log streams
+        /// </summary>
+        /// <returns>A list of <see cref="LogStream"/> objects</returns>
+        public Task<IList<LogStream>> GetAllAsync()
+        {
+            return Connection.GetAsync<IList<LogStream>>(BuildUri("log-streams"), DefaultHeaders);
+        }
+    }
+}
+

--- a/src/Auth0.ManagementApi/Clients/LogsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogsClient.cs
@@ -15,7 +15,7 @@ namespace Auth0.ManagementApi.Clients
         readonly JsonConverter[] converters = new JsonConverter[] { new PagedListConverter<LogEntry>("logs") };
 
         /// <summary>
-        /// Initializes a new instance on <see cref="LogsClient"/>
+        /// Initializes a new instance of <see cref="LogsClient"/>
         /// </summary>
         /// <param name="connection"><see cref="IManagementConnection"/> used to make all API calls.</param>
         /// <param name="baseUri"><see cref="Uri"/> of the endpoint to use in making API calls.</param>

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -71,6 +71,11 @@ namespace Auth0.ManagementApi
         public LogsClient Logs { get; }
 
         /// <summary>
+        /// Contains all the methods to all the /log-streams endpoints.
+        /// </summary>
+        public LogStreamsClient LogStreams { get; }
+
+        /// <summary>
         /// Contains all the methods to call the /resource-servers endpoints.
         /// </summary>
         public ResourceServersClient ResourceServers { get; }
@@ -139,6 +144,7 @@ namespace Auth0.ManagementApi
             Guardian = new GuardianClient(managementConnection, baseUri, defaultHeaders);
             Jobs = new JobsClient(managementConnection, baseUri, defaultHeaders);
             Logs = new LogsClient(managementConnection, baseUri, defaultHeaders);
+            LogStreams = new LogStreamsClient(managementConnection, baseUri, defaultHeaders);
             ResourceServers = new ResourceServersClient(managementConnection, baseUri, defaultHeaders);
             Roles = new RolesClient(managementConnection, baseUri, defaultHeaders);
             Rules = new RulesClient(managementConnection, baseUri, defaultHeaders);

--- a/src/Auth0.ManagementApi/Models/LogStream.cs
+++ b/src/Auth0.ManagementApi/Models/LogStream.cs
@@ -1,0 +1,43 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Information about a log stream
+    /// </summary>
+    public class LogStream
+    {
+        /// <summary>
+        /// The identifier of the log stream
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The name of the log stream
+        /// </summary>
+        [JsonProperty("name")] 
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The status of the log stream
+        /// </summary>
+        [JsonProperty("status")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LogStreamStatus Status { get; set; }
+
+        /// <summary>
+        /// The type of the log stream
+        /// </summary>
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LogStreamType Type { get; set; }
+
+        /// <summary>
+        /// Information about the log stream sink
+        /// </summary>
+        [JsonProperty("sink")]
+        public dynamic Sink { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/LogStream.cs
+++ b/src/Auth0.ManagementApi/Models/LogStream.cs
@@ -6,7 +6,7 @@ namespace Auth0.ManagementApi.Models
     /// <summary>
     /// Information about a log stream
     /// </summary>
-    public class LogStream
+    public class LogStream : LogStreamBase
     {
         /// <summary>
         /// The identifier of the log stream
@@ -15,29 +15,10 @@ namespace Auth0.ManagementApi.Models
         public string Id { get; set; }
 
         /// <summary>
-        /// The name of the log stream
-        /// </summary>
-        [JsonProperty("name")] 
-        public string Name { get; set; }
-
-        /// <summary>
         /// The status of the log stream
         /// </summary>
         [JsonProperty("status")]
         [JsonConverter(typeof(StringEnumConverter))]
         public LogStreamStatus Status { get; set; }
-
-        /// <summary>
-        /// The type of the log stream
-        /// </summary>
-        [JsonProperty("type")]
-        [JsonConverter(typeof(StringEnumConverter))]
-        public LogStreamType Type { get; set; }
-
-        /// <summary>
-        /// Information about the log stream sink
-        /// </summary>
-        [JsonProperty("sink")]
-        public dynamic Sink { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/LogStreamBase.cs
+++ b/src/Auth0.ManagementApi/Models/LogStreamBase.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class LogStreamBase
+    {
+        /// <summary>
+        /// The name of the log stream
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The type of the log stream
+        /// </summary>
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LogStreamType Type { get; set; }
+
+        /// <summary>
+        /// Information about the log stream sink
+        /// </summary>
+        [JsonProperty("sink")]
+        public dynamic Sink { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/LogStreamBase.cs
+++ b/src/Auth0.ManagementApi/Models/LogStreamBase.cs
@@ -1,8 +1,5 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Auth0.ManagementApi.Models
 {

--- a/src/Auth0.ManagementApi/Models/LogStreamCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/LogStreamCreateRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// A request for creating log streams
+    /// </summary>
+    public class LogStreamCreateRequest : LogStreamBase
+    {
+    }
+}

--- a/src/Auth0.ManagementApi/Models/LogStreamStatus.cs
+++ b/src/Auth0.ManagementApi/Models/LogStreamStatus.cs
@@ -1,0 +1,28 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The possible statuses of the log stream
+    /// </summary>
+    public enum LogStreamStatus
+    {
+        /// <summary>
+        /// The log stream is active
+        /// </summary>
+        [EnumMember(Value = "active")]
+        Active,
+
+        /// <summary>
+        /// The log stream is paused
+        /// </summary>
+        [EnumMember(Value = "paused")]
+        Paused,
+
+        /// <summary>
+        /// The log stream is suspended
+        /// </summary>
+        [EnumMember(Value = "suspended")]
+        Suspended
+    }
+}

--- a/src/Auth0.ManagementApi/Models/LogStreamType.cs
+++ b/src/Auth0.ManagementApi/Models/LogStreamType.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The possible types of log stream
+    /// </summary>
+    public enum LogStreamType
+    {
+        [EnumMember(Value = "http")]
+        Http,
+
+        [EnumMember(Value = "eventbridge")]
+        EventBridge
+    }
+}

--- a/src/Auth0.ManagementApi/Models/LogStreamUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/LogStreamUpdateRequest.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Information required to update a log stream
+    /// </summary>
+    public class LogStreamUpdateRequest
+    { 
+        /// <summary>
+        /// The name of the log stream
+        /// </summary>
+        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The new status of the log stream
+        /// </summary>
+        [JsonProperty("status", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public LogStreamUpdateStatus? Status { get; set; }
+
+        /// <summary>
+        /// The new collection of properties describing the log stream sink
+        /// </summary>
+        [JsonProperty("sink", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public dynamic Sink { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/LogStreamUpdateStatus.cs
+++ b/src/Auth0.ManagementApi/Models/LogStreamUpdateStatus.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The possible statuses to update a log strem with
+    /// </summary>
+    public enum LogStreamUpdateStatus
+    {
+        /// <summary>
+        /// Activate the log stream
+        /// </summary>
+        [EnumMember(Value = "active")]
+        Active,
+
+        /// <summary>
+        /// Pause the log stream
+        /// </summary>
+        [EnumMember(Value = "paused")]
+        Paused
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
@@ -2,9 +2,8 @@
 using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using FluentAssertions;
-using FluentAssertions.Common;
-using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
@@ -2,6 +2,7 @@
 using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using FluentAssertions;
+using FluentAssertions.Common;
 using Newtonsoft.Json;
 using System;
 using System.Threading.Tasks;
@@ -77,6 +78,50 @@ namespace Auth0.ManagementApi.IntegrationTests
             await _apiClient.LogStreams.DeleteAsync(createdLogStream.Id);
             Func<Task> getFunc = async () => await _apiClient.LogStreams.GetAsync(createdLogStream.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.Error.Should().Be("Not Found");
+        }
+        
+        [Fact]
+        public async Task Test_log_stream_get_all()
+        {
+            // Arrange
+            var request1 = new LogStreamCreateRequest
+            {
+                Name = "Auth0.net Stream 1",
+                Type = LogStreamType.Http,
+                Sink = new
+                {
+                    httpEndpoint = "https://my-stream.com",
+                    httpContentType = "application/json",
+                    httpContentFormat = "JSONOBJECT",
+                    httpAuthorization = "http-auth"
+                }
+            };
+
+            var request2 = new LogStreamCreateRequest
+            {
+                Name = "Auth0.net Stream 2",
+                Type = LogStreamType.Http,
+                Sink = new
+                {
+                    httpEndpoint = "https://my-stream.com",
+                    httpContentType = "application/json",
+                    httpContentFormat = "JSONOBJECT",
+                    httpAuthorization = "http-auth"
+                }
+            };
+
+            var stream1 = await _apiClient.LogStreams.CreateAsync(request1);
+            var stream2 = await _apiClient.LogStreams.CreateAsync(request2);
+
+            // Act
+            var streams = await _apiClient.LogStreams.GetAllAsync();
+
+            // Assert
+            streams.Count.Should().Be(2);
+
+            // Cleanup
+            await _apiClient.LogStreams.DeleteAsync(stream1.Id);
+            await _apiClient.LogStreams.DeleteAsync(stream2.Id);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
@@ -58,6 +58,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             var updateRequest = new LogStreamUpdateRequest
             {
                 Name = "Auth0.net Test Updated Stream",
+                Status = LogStreamUpdateStatus.Paused,
                 Sink = new
                 {
                     httpEndpoint = "https://new-stream.com"
@@ -66,7 +67,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             var updatedLogStream = await _apiClient.LogStreams.UpdateAsync(fetchedLogStream.Id, updateRequest);
             updatedLogStream.Name.Should().Be(updateRequest.Name);
-            updatedLogStream.Status.Should().Be(LogStreamStatus.Active);
+            updatedLogStream.Status.Should().Be(LogStreamStatus.Paused);
             updatedLogStream.Id.Should().Be(fetchedLogStream.Id);
             
             // show that sink properties are merged

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
@@ -38,13 +38,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             {
                 Name = name,
                 Type = LogStreamType.Http,
-                Sink = new ExpandoObject()
+                Sink = new
+                {
+                    httpEndpoint = "https://my-stream.com",
+                    httpContentType = "application/json",
+                    httpContentFormat = "JSONOBJECT",
+                    httpAuthorization = "http-auth"
+                }
             };
-
-            request.Sink.httpEndpoint = "https://my-stream.com";
-            request.Sink.httpContentType = "application/json";
-            request.Sink.httpContentFormat = "JSONOBJECT";
-            request.Sink.httpAuthorization = "http-auth";
 
             var json = JsonConvert.SerializeObject(request);
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
@@ -1,0 +1,67 @@
+﻿using Auth0.Core.Exceptions;
+using Auth0.ManagementApi.Models;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Dynamic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Auth0.ManagementApi.IntegrationTests
+{
+    public class LogStreamsTests : TestBase, IAsyncLifetime
+    {
+        private ManagementApiClient _apiClient;
+
+        public async Task InitializeAsync()
+        {
+            string token = await GenerateBruckeManagementApiToken();
+            _apiClient = new ManagementApiClient(token, GetVariable("BRUCKE_MANAGEMENT_API_URL"));
+        }
+
+        public Task DisposeAsync()
+        {
+            _apiClient.Dispose();
+            return Task.CompletedTask;
+        }
+
+        [Fact]
+        public async Task Test_log_stream_crud_sequence()
+        {
+            // Create a new entity
+            var name = "Auth0.net Test Log Stream";
+
+            var request = new LogStreamCreateRequest
+            {
+                Name = name,
+                Type = LogStreamType.Http,
+                Sink = new ExpandoObject()
+            };
+
+            request.Sink.httpEndpoint = "https://my-stream.com";
+            request.Sink.httpContentType = "application/json";
+            request.Sink.httpContentFormat = "JSONOBJECT";
+            request.Sink.httpAuthorization = "http-auth";
+
+            var json = JsonConvert.SerializeObject(request);
+
+            var createdLogStream = await _apiClient.LogStreams.CreateAsync(request);
+            createdLogStream.Should().NotBeNull();
+            createdLogStream.Name.Should().Be(name);
+
+            // Get an entity
+            var fetchedLogStream = await _apiClient.LogStreams.GetAsync(createdLogStream.Id);
+            fetchedLogStream.Should().NotBeNull();
+            fetchedLogStream.Name.Should().Be(name);
+            fetchedLogStream.Id.Should().Be(createdLogStream.Id);
+
+            // Delete the entity
+            await _apiClient.LogStreams.DeleteAsync(createdLogStream.Id);
+            Func<Task> getFunc = async () => await _apiClient.LogStreams.GetAsync(createdLogStream.Id);
+            getFunc.Should().Throw<ErrorApiException>().And.ApiError.Error.Should().Be("Not Found");
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/Readme.md
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Readme.md
@@ -75,3 +75,10 @@ delete:connections
 
 read:tenant_settings
 update:tenant_settings
+
+## AUTH0_TOKEN_LOG_STREAMS
+
+read:log_streams
+create:log_streams
+delete:log_streams
+update:log_streams

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
@@ -32,6 +32,22 @@ namespace Auth0.Tests.Shared
             return _alphaNumeric.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "");
         }
 
+        protected async Task<string> GenerateBruckeManagementApiToken()
+        {
+            using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("BRUCKE_AUTHENTICATION_API_URL")))
+            {
+                // Get the access token
+                var token = await authenticationApiClient.GetTokenAsync(new ClientCredentialsTokenRequest
+                {
+                    ClientId = GetVariable("BRUCKE_MANAGEMENT_API_CLIENT_ID"),
+                    ClientSecret = GetVariable("BRUCKE_MANAGEMENT_API_CLIENT_SECRET"),
+                    Audience = GetVariable("BRUCKE_MANAGEMENT_API_AUDIENCE")
+                });
+
+                return token.AccessToken;
+            }
+        }
+
         protected async Task<string> GenerateManagementApiToken()
         {
             using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))


### PR DESCRIPTION
### Changes

This PR adds support for the [Auth0 Log Streams API](https://auth0.com/docs/api/management/v2#!/Log_Streams/get_log_streams).

API:

```csharp
// Create a new stream
var createdLogStream = await client.LogStreams.CreateAsync(new LogStreamCreateRequest
{
    Name = "My Log Stream",
    Type = LogStreamType.Http,
    Sink = new
    {
        httpEndpoint = "https://my-stream.com",
        httpContentType = "application/json",
        httpContentFormat = "JSONOBJECT",
        httpAuthorization = "http-auth"
    }
});

// Get a stream by ID
var stream = await client.LogStreams.GetAsync(createdLogStream.Id);

// Update it
var updatedStream = await client.LogStreams.UpdateAsync(new LogStreamUpdateRequest
{
    Name = "New stream name",
    Status = LogStreamStatus.Paused,
    Sink = new
    {
        httpEndpoint = "https://new-stream-endpoint.com"
    }
};

// Delete a stream
await client.LogStreams.DeleteAsync(updatedStream.Id);

// Get all the streams
var streams  = await client.LogStreams.GetAllAsync();

```

### Testing

All testing is done through the existing integration test suite.

- [ ] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
