### PR TITLE
Adds permission sources to User Response

### DIFF
--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -16,7 +16,7 @@ namespace Auth0.ManagementApi.Clients
         readonly JsonConverter[] usersConverters = new JsonConverter[] { new PagedListConverter<User>("users") };
         readonly JsonConverter[] logsConverters = new JsonConverter[] { new PagedListConverter<LogEntry>("logs", true) };
         readonly JsonConverter[] rolesConverters = new JsonConverter[] { new PagedListConverter<Role>("roles") };
-        readonly JsonConverter[] permissionsConverters = new JsonConverter[] { new PagedListConverter<Permission>("permissions") };
+        readonly JsonConverter[] permissionsConverters = new JsonConverter[] { new PagedListConverter<UserPermission>("permissions") };
 
         /// <summary>
         /// Initializes a new instance of <see cref="UsersClient"/>.
@@ -290,9 +290,9 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="id">The id of the user to obtain the permissions for.</param>
         /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
         /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions for this user.</returns>
-        public Task<IPagedList<Permission>> GetPermissionsAsync(string id, PaginationInfo pagination)
+        public Task<IPagedList<UserPermission>> GetPermissionsAsync(string id, PaginationInfo pagination)
         {
-            return Connection.GetAsync<IPagedList<Permission>>(BuildUri($"users/{EncodePath(id)}/permissions",
+            return Connection.GetAsync<IPagedList<UserPermission>>(BuildUri($"users/{EncodePath(id)}/permissions",
                 new Dictionary<string, string>
                 {
                     {"page", pagination.PageNo.ToString()},

--- a/src/Auth0.ManagementApi/Models/PermissionSource.cs
+++ b/src/Auth0.ManagementApi/Models/PermissionSource.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents the source of a permission assignment
+    /// </summary>
+    public class PermissionSource
+    {
+        /// <summary>
+        /// Gets or sets the ID of the source of the permission. Empty for direct assignment.
+        /// </summary>
+        [JsonProperty("source_id")]
+        public string ID { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the source of the permission. Empty for direct assignment.
+        /// </summary>
+        [JsonProperty("source_name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type of the permission source (direct assignment or role assignment)
+        /// </summary>
+        [JsonProperty("source_type")]
+        public PermissionSourceType Type { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/PermissionSourceType.cs
+++ b/src/Auth0.ManagementApi/Models/PermissionSourceType.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Types of permission sources
+    /// </summary>
+    public enum PermissionSourceType
+    {
+        /// <summary>
+        /// Permission assigned directly to user
+        /// </summary>
+        [EnumMember(Value = "direct")]
+        Direct,
+
+        /// <summary>
+        /// Permission assigned via role
+        /// </summary>
+        [EnumMember(Value = "role")]
+        Role
+    }
+}

--- a/src/Auth0.ManagementApi/Models/UserPermission.cs
+++ b/src/Auth0.ManagementApi/Models/UserPermission.cs
@@ -1,12 +1,12 @@
 ﻿namespace Auth0.ManagementApi.Models
 {
     /// <summary>
-    /// User-specific representation of a user, including permission sources
+    /// User-specific representation of a permission, including its source(s).
     /// </summary>
     public class UserPermission : Permission
     {
         /// <summary>
-        /// Gets or sets the source(s) of the permission
+        /// Gets or sets the source(s) of the permission.
         /// </summary>
         public PermissionSource[] Sources { get; set; }
     }

--- a/src/Auth0.ManagementApi/Models/UserPermission.cs
+++ b/src/Auth0.ManagementApi/Models/UserPermission.cs
@@ -1,0 +1,13 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// User-specific representation of a user, including permission sources
+    /// </summary>
+    public class UserPermission : Permission
+    {
+        /// <summary>
+        /// Gets or sets the source(s) of the permission
+        /// </summary>
+        public PermissionSource[] Sources { get; set; }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -395,6 +395,12 @@ namespace Auth0.ManagementApi.IntegrationTests
             associatedPermissions.First().Identifier.Should().Be(resourceServer.Identifier);
             associatedPermissions.First().Name.Should().Be(newScope.Value);
 
+            // check permission sources
+            associatedPermissions.First().Sources.Should().HaveCount(1);
+            associatedPermissions.First().Sources.First().ID.Should().Be(string.Empty);
+            associatedPermissions.First().Sources.First().Name.Should().Be(string.Empty);
+            associatedPermissions.First().Sources.First().Type.Should().Be(PermissionSourceType.Direct);
+
             // Unassociate a permission with the user
             await _apiClient.Users.RemovePermissionsAsync(user.UserId, assignPermissionsRequest);
 


### PR DESCRIPTION
### Changes

`UsersClient` now returns permissions along with the source of the permissions, according to apparent API specifications. This is done by simply updating the types to pass the permission sources from the http API to the client of this library.

Tests received a minor update to include this change.

### References

This is a response to issue #424.

### Testing

This minor change has only been included on the existing test that calls `UsersClient.GetPermissions`. As I don't believe I have access to the underlying definition of the API, please let me know if there are any differences between this implementation and the underlying API.

- [ ] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

> This reflects personal testing on the Management API through the portal, and has been tested in my local project, not sure what else I can do.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors

(I can't test this without merging [ref](https://github.com/auth0/auth0.net#testing))
