### PR TITLE
[SDK-1822] Support new Email Verification Fields

### DIFF
--- a/src/Auth0.ManagementApi/Models/EmailVerificationIdentity.cs
+++ b/src/Auth0.ManagementApi/Models/EmailVerificationIdentity.cs
@@ -12,6 +12,7 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("provider")]
         public string Provider { get; set; }
+
         /// <summary>
         /// UserId of the identity to be verified.
         /// </summary>

--- a/src/Auth0.ManagementApi/Models/EmailVerificationIdentity.cs
+++ b/src/Auth0.ManagementApi/Models/EmailVerificationIdentity.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents the identity object that can be sent on requests to create an email verification ticket or job.
+    /// </summary>
+    public class EmailVerificationIdentity
+    {
+        /// <summary>
+        /// Identity provider name of the identity (e.g. google-oauth).
+        /// </summary>
+        [JsonProperty("provider")]
+        public string Provider { get; set; }
+        /// <summary>
+        /// UserId of the identity to be verified.
+        /// </summary>
+        [JsonProperty("user_id")]
+        public string UserId { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/EmailVerificationTicketRequest.cs
+++ b/src/Auth0.ManagementApi/Models/EmailVerificationTicketRequest.cs
@@ -27,6 +27,13 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("user_id")]
         public string UserId { get; set; }
+
+        /// <summary>
+        /// Sets the identity. Needed to verify primary identities when using social, enterprise, or passwordless connections.
+        /// It is also required to verify secondary identities.
+        /// </summary>
+        [JsonProperty("identity")]
+        public EmailVerificationIdentity Identity { get; set; }
     }
 
 }

--- a/src/Auth0.ManagementApi/Models/VerifyEmailJobRequest.cs
+++ b/src/Auth0.ManagementApi/Models/VerifyEmailJobRequest.cs
@@ -3,7 +3,7 @@
 namespace Auth0.ManagementApi.Models
 {
     /// <summary>
-    /// Specifies the user and client required in sending an email address verification link.
+    /// Contains details for sending an email address verification link.
     /// </summary>
     public class VerifyEmailJobRequest
     {
@@ -18,5 +18,12 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("client_id")]
         public string ClientId { get; set; }
+
+        /// <summary>
+        /// The primary identity to verify when using social, enterprise, or passwordless connections.
+        /// It is also required to verify secondary identities.
+        /// </summary>
+        [JsonProperty("identity")]
+        public EmailVerificationIdentity Identity { get; set; }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
@@ -10,8 +10,10 @@ namespace Auth0.ManagementApi.IntegrationTests
     public class JobsTest : TestBase, IAsyncLifetime
     {
         private ManagementApiClient _apiClient;
-        private Connection _connection;
-        private User _user;
+        private Connection _auth0Connection;
+        private Connection _emailConnection;
+        private User _auth0User;
+        private User _emailUser;
         private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
 
         public async Task InitializeAsync()
@@ -21,27 +23,44 @@ namespace Auth0.ManagementApi.IntegrationTests
             _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
 
             // Create a connection
-            _connection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            _auth0Connection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
                 Name = "Temp-Int-Test-" + MakeRandomName(),
                 Strategy = "auth0",
                 EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
             });
 
-            // Create a user
-            _user = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            _emailConnection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Connection = _connection.Name,
+                Name = "Temp-Int-Test-" + MakeRandomName(),
+                Strategy = "email",
+                EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
+            });
+
+            // Create a user
+            _auth0User = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            {
+                Connection = _auth0Connection.Name,
                 Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
                 EmailVerified = true,
                 Password = Password
+            });
+
+            _emailUser = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            {
+                Connection = _emailConnection.Name,
+                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                EmailVerified = true,
             });
         }
 
         public async Task DisposeAsync()
         {
-            await _apiClient.Users.DeleteAsync(_user.UserId);
-            await _apiClient.Connections.DeleteAsync(_connection.Id);
+            await _apiClient.Users.DeleteAsync(_auth0User.UserId);
+            await _apiClient.Connections.DeleteAsync(_auth0Connection.Id);
+
+            await _apiClient.Users.DeleteAsync(_emailUser.UserId);
+            await _apiClient.Connections.DeleteAsync(_emailConnection.Id);
             _apiClient.Dispose();
         }
 
@@ -50,8 +69,33 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var sendVerification = await _apiClient.Jobs.SendVerificationEmailAsync(new VerifyEmailJobRequest
             {
-                UserId = _user.UserId,
+                UserId = _auth0User.UserId,
                 ClientId = GetVariable("AUTH0_CLIENT_ID")
+            });
+            sendVerification.Should().NotBeNull();
+            sendVerification.Id.Should().NotBeNull();
+
+            // Check to see whether we can get the same job again
+            var job = await _apiClient.Jobs.GetAsync(sendVerification.Id);
+            job.Should().NotBeNull();
+            job.Id.Should().Be(sendVerification.Id);
+            job.Type.Should().Be("verification_email");
+            job.Status.Should().Be("pending");
+            job.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
+        }
+
+        [Fact]
+        public async Task Can_send_verification_email_with_identity()
+        {
+            var sendVerification = await _apiClient.Jobs.SendVerificationEmailAsync(new VerifyEmailJobRequest
+            {
+                UserId = _emailUser.UserId,
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                Identity = new EmailVerificationIdentity
+                {
+                    Provider = "email",
+                    UserId = _emailUser.UserId.Replace("email|", "")
+                }
             });
             sendVerification.Should().NotBeNull();
             sendVerification.Id.Should().NotBeNull();
@@ -71,14 +115,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Send a user import request
             using (var stream = GetType().Assembly.GetManifestResourceStream("Auth0.ManagementApi.IntegrationTests.user-import-test.json"))
             {
-                var importUsers = await _apiClient.Jobs.ImportUsersAsync(_connection.Id, "user-import-test.json", stream, sendCompletionEmail: false);
+                var importUsers = await _apiClient.Jobs.ImportUsersAsync(_auth0Connection.Id, "user-import-test.json", stream, sendCompletionEmail: false);
                 importUsers.Should().NotBeNull();
                 importUsers.Id.Should().NotBeNull();
                 importUsers.Type.Should().Be("users_import");
                 importUsers.Status.Should().Be("pending");
                 importUsers.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
-                importUsers.ConnectionId.Should().Be(_connection.Id);
-                importUsers.Connection.Should().Be(_connection.Name);
+                importUsers.ConnectionId.Should().Be(_auth0Connection.Id);
+                importUsers.Connection.Should().Be(_auth0Connection.Name);
             }
         }
     }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
@@ -10,8 +10,10 @@ namespace Auth0.ManagementApi.IntegrationTests
     public class TicketsTests : TestBase, IAsyncLifetime
     {
         private ManagementApiClient _apiClient;
-        private Connection _connection;
-        private User _user;
+        private Connection _authConnection;
+        private Connection _emailConnection;
+        private User _auth0User;
+        private User _emailUser;
         private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
 
         public async Task InitializeAsync()
@@ -20,28 +22,43 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
 
-            // Create a connection
-            _connection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            _authConnection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
                 Name = "Temp-Int-Test-" + MakeRandomName(),
                 Strategy = "auth0",
                 EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
             });
 
-            // Create a user
-            _user = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            _emailConnection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Connection = _connection.Name,
+                Name = "Temp-Int-Test-" + MakeRandomName(),
+                Strategy = "email",
+                EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
+            });
+
+            _auth0User = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            {
+                Connection = _authConnection.Name,
                 Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
                 EmailVerified = true,
                 Password = Password
+            });
+
+            _emailUser = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            {
+                Connection = _emailConnection.Name,
+                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                EmailVerified = true,
             });
         }
 
         public async Task DisposeAsync()
         {
-            await _apiClient.Users.DeleteAsync(_user.UserId);
-            await _apiClient.Connections.DeleteAsync(_connection.Id);
+            await _apiClient.Users.DeleteAsync(_auth0User.UserId);
+            await _apiClient.Connections.DeleteAsync(_authConnection.Id);
+
+            await _apiClient.Users.DeleteAsync(_emailUser.UserId);
+            await _apiClient.Connections.DeleteAsync(_emailConnection.Id);
             _apiClient.Dispose();
         }
 
@@ -51,7 +68,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Send email verification ticket
             var verificationTicketRequest = new EmailVerificationTicketRequest
             {
-                UserId = _user.UserId,
+                UserId = _auth0User.UserId,
                 ResultUrl = "http://www.nonexistingdomain.aaa/success"
             };
             var verificationTicketResponse = await _apiClient.Tickets.CreateEmailVerificationTicketAsync(verificationTicketRequest);
@@ -61,7 +78,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Send password change ticket
             var changeTicketRequest = new PasswordChangeTicketRequest
             {
-                UserId = _user.UserId,
+                UserId = _auth0User.UserId,
                 ResultUrl = "http://www.nonexistingdomain.aaa/success",
                 MarkEmailAsVerified = true,
                 IncludeEmailInRedirect = true
@@ -69,6 +86,23 @@ namespace Auth0.ManagementApi.IntegrationTests
             var changeTicketRsponse = await _apiClient.Tickets.CreatePasswordChangeTicketAsync(changeTicketRequest);
             changeTicketRsponse.Should().NotBeNull();
             changeTicketRsponse.Value.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task Can_send_verification_email_with_identity()
+        {
+            var verificationTicketResponse = await _apiClient.Tickets.CreateEmailVerificationTicketAsync(new EmailVerificationTicketRequest
+            {
+                UserId = _emailUser.UserId,
+                ResultUrl = "http://www.nonexistingdomain.aaa/success",
+                Identity = new EmailVerificationIdentity
+                {
+                    Provider = "email",
+                    UserId = _emailUser.UserId.Replace("email|", "")
+                }
+            });
+            verificationTicketResponse.Should().NotBeNull();
+            verificationTicketResponse.Value.Should().NotBeNull();
         }
     }
 }


### PR DESCRIPTION
### Changes

Add support for specifying the identity property when calling `jobs/verification-email` and `tickets/email-verification`.

### References

- https://auth0.com/docs/api/management/v2#!/Tickets/post_email_verification
- https://auth0.com/docs/api/management/v2#!/Jobs/post_verification_email

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
