### PR TITLE
[SDK-1980] Add openid scope requirement to migrating to v7

### DIFF
--- a/docs-source/migrating-to-v7.md
+++ b/docs-source/migrating-to-v7.md
@@ -4,6 +4,10 @@
 
 There are a number of important changes in v7 including some that may be breaking depending on your scenarios. They are as follows:
 
+### ID Token
+
+As part of our on-going efforts to be OpenID Compliant, the authentication SDK expects an ID Token to always be present. Therefor `openid` should always be passed as a `Scope` when calling `GetTokenAsync` for the `Refresh Token` or `Resource Owner Password` grants as well as when using `AuthenticationApiClient.BuildAuthorizationUrl`. Only the `Client Credentials` grant doesn't require the existence of an ID Token as there is no user involved in the process of getting a token in that case.
+
 ### ID Token Validation
 
 The authentication SDK now includes all-new ID Token validation capable of validating both RS256 and HS256 signed tokens.

--- a/docs-source/migrating-to-v7.md
+++ b/docs-source/migrating-to-v7.md
@@ -6,7 +6,7 @@ There are a number of important changes in v7 including some that may be breakin
 
 ### ID Token
 
-As part of our on-going efforts to be OpenID Compliant, the authentication SDK expects an ID Token to always be present. Therefor `openid` should always be passed as a `Scope` when calling `GetTokenAsync` for the `Refresh Token` or `Resource Owner Password` grants as well as when using `AuthenticationApiClient.BuildAuthorizationUrl`. Only the `Client Credentials` grant doesn't require the existence of an ID Token as there is no user involved in the process of getting a token in that case.
+As part of our on-going efforts to be OpenID Compliant, the authentication SDK expects an ID Token to always be present. Therefore, `openid` should always be passed as a `Scope` when calling `GetTokenAsync` for the `Refresh Token` or `Resource Owner Password` grants, as well as when using `AuthenticationApiClient.BuildAuthorizationUrl`. Only the [Client Credentials](https://auth0.com/docs/flows/client-credentials-flow) grant doesn't require the existence of an ID Token, as there is no user involved in the process of getting a token in that case.
 
 ### ID Token Validation
 

--- a/docs/migrating-to-v7.html
+++ b/docs/migrating-to-v7.html
@@ -65,7 +65,7 @@
 <h2 id="migrating-from-v6-to-v7">Migrating From v6 to v7</h2>
 <p>There are a number of important changes in v7 including some that may be breaking depending on your scenarios. They are as follows:</p>
 <h3 id="id-token">ID Token</h3>
-<p>As part of our on-going efforts to be OpenID Compliant, the authentication SDK expects an ID Token to always be present. Therefor <code>openid</code> should always be passed as a <code>Scope</code> when calling <code>GetTokenAsync</code> for the <code>Refresh Token</code> or <code>Resource Owner Password</code> grants as well as when using <code>AuthenticationApiClient.BuildAuthorizationUrl</code>. Only the <code>Client Credentials</code> grant doesn&#39;t require the existence of an ID Token as there is no user involved in the process of getting a token in that case.</p>
+<p>As part of our on-going efforts to be OpenID Compliant, the authentication SDK expects an ID Token to always be present. Therefore, <code>openid</code> should always be passed as a <code>Scope</code> when calling <code>GetTokenAsync</code> for the <code>Refresh Token</code> or <code>Resource Owner Password</code> grants, as well as when using <code>AuthenticationApiClient.BuildAuthorizationUrl</code>. Only the <a href="https://auth0.com/docs/flows/client-credentials-flow">Client Credentials</a> grant doesn&#39;t require the existence of an ID Token, as there is no user involved in the process of getting a token in that case.</p>
 <h3 id="id-token-validation">ID Token Validation</h3>
 <p>The authentication SDK now includes all-new ID Token validation capable of validating both RS256 and HS256 signed tokens.</p>
 <p>If your app is configured for:</p>

--- a/docs/migrating-to-v7.html
+++ b/docs/migrating-to-v7.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <!--[if IE]><![endif]-->
 <html>
   
@@ -64,6 +64,8 @@
 
 <h2 id="migrating-from-v6-to-v7">Migrating From v6 to v7</h2>
 <p>There are a number of important changes in v7 including some that may be breaking depending on your scenarios. They are as follows:</p>
+<h3 id="id-token">ID Token</h3>
+<p>As part of our on-going efforts to be OpenID Compliant, the authentication SDK expects an ID Token to always be present. Therefor <code>openid</code> should always be passed as a <code>Scope</code> when calling <code>GetTokenAsync</code> for the <code>Refresh Token</code> or <code>Resource Owner Password</code> grants as well as when using <code>AuthenticationApiClient.BuildAuthorizationUrl</code>. Only the <code>Client Credentials</code> grant doesn&#39;t require the existence of an ID Token as there is no user involved in the process of getting a token in that case.</p>
 <h3 id="id-token-validation">ID Token Validation</h3>
 <p>The authentication SDK now includes all-new ID Token validation capable of validating both RS256 and HS256 signed tokens.</p>
 <p>If your app is configured for:</p>


### PR DESCRIPTION
### Changes

V7 requires the use of openid scope but it is not listed as part of the migration page.

### References

https://github.com/auth0/auth0.net/issues/372

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
