### PR TITLE
[SDK-2003] Support multiple Strategies in Connections.GetAllAsync

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -103,8 +103,12 @@ namespace Auth0.ManagementApi.Clients
 
             // Add each strategy as a separate querystring
             if (request.Strategy != null)
-                foreach (var s in request.Strategy)
-                    queryStrings.Add("strategy", s);
+            {
+                for (var i = 0; i < request.Strategy.Length; i++)
+                {
+                    queryStrings.Add($"strategy[{i}]", request.Strategy[i]);
+                }
+            }
 
             return Connection.GetAsync<IPagedList<Connection>>(BuildUri("connections", queryStrings), DefaultHeaders, converters);
         }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
@@ -142,13 +142,13 @@ namespace Auth0.ManagementApi.IntegrationTests
             Func<Task> getFunc = async () => await _apiClient.Connections.GetAsync(newConnectionResponse.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
         }
-        
+
         [Fact]
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
             var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo());
-            
+
             // Assert
             Assert.Null(connections.Paging);
         }
@@ -158,7 +158,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, false));
-            
+
             // Assert
             Assert.Null(connections.Paging);
         }
@@ -168,9 +168,22 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, true));
-            
+
             // Assert
             Assert.NotNull(connections.Paging);
+        }
+
+        [Fact]
+        public async Task Test_multiple_strategies()
+        {
+            // Act
+            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            {
+                Strategy = new[] { "google-oauth2", "auth0" }
+            }, new PaginationInfo());
+
+            // Assert
+            Assert.NotNull(connections);
         }
     }
 }


### PR DESCRIPTION
Closes #416

### Changes

Calling Connections.GetAllSync with multiple strategies at once results in an Exception being thrown because it is trying to add multiple items with the same key to the queryStrings dictionary.

This PR ensures this is supported by giving them the correct key (`Strategy[0]`, Strategy[1]`)

### References
https://github.com/auth0/auth0.net/issues/416

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
