### PR TITLE
[SDK-2005]: Complete passwordless API

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -242,6 +242,50 @@ namespace Auth0.AuthenticationApi
         }
 
         /// <inheritdoc/>
+        public Task<AccessTokenResponse> GetTokenAsync(PasswordlessEmailTokenRequest request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var body = new Dictionary<string, string> {
+                { "grant_type", "http://auth0.com/oauth/grant-type/passwordless/otp" },
+                { "client_id", request.ClientId },
+                { "client_secret", request.ClientSecret },
+                { "username", request.Email },
+                { "realm", "email" },
+                { "otp", request.Code },
+                { "audience", request.Audience },
+                { "scope", request.Scope } };
+
+            return connection.SendAsync<AccessTokenResponse>(
+                HttpMethod.Post,
+                tokenUri,
+                body);
+        }
+
+        /// <inheritdoc/>
+        public Task<AccessTokenResponse> GetTokenAsync(PasswordlessSmsTokenRequest request)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var body = new Dictionary<string, string> {
+                { "grant_type", "http://auth0.com/oauth/grant-type/passwordless/otp" },
+                { "client_id", request.ClientId },
+                { "client_secret", request.ClientSecret },
+                { "username", request.PhoneNumber },
+                { "realm", "sms" },
+                { "otp", request.Code },
+                { "audience", request.Audience },
+                { "scope", request.Scope } };
+
+            return connection.SendAsync<AccessTokenResponse>(
+                HttpMethod.Post,
+                tokenUri,
+                body);
+        }
+
+        /// <inheritdoc/>
         public Task<SignupUserResponse> SignupUserAsync(SignupUserRequest request)
         {
             if (request == null)

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -87,6 +87,22 @@ namespace Auth0.AuthenticationApi
         Task<AccessTokenResponse> GetTokenAsync(ResourceOwnerTokenRequest request);
 
         /// <summary>
+        /// Requests an Access Token using the Passwordless flow.
+        /// </summary>
+        /// <param name="request"><see cref="PasswordlessEmailTokenRequest"/> containing request details to exchange a one time password received through email.</param>
+        /// <returns><see cref="Task"/> representing the async operation containing 
+        /// a <see cref="AccessTokenResponse" /> with the requested tokens.</returns>
+        Task<AccessTokenResponse> GetTokenAsync(PasswordlessEmailTokenRequest request);
+
+        /// <summary>
+        /// Requests an Access Token using the Passwordless flow.
+        /// </summary>
+        /// <param name="request"><see cref="PasswordlessSmsTokenRequest"/> containing request details to exchange a one time password received through SMS.</param>
+        /// <returns><see cref="Task"/> representing the async operation containing 
+        /// a <see cref="AccessTokenResponse" /> with the requested tokens.</returns>
+        Task<AccessTokenResponse> GetTokenAsync(PasswordlessSmsTokenRequest request);
+
+        /// <summary>
         /// Creates a new user given the user details specified.
         /// </summary>
         /// <param name="request"><see cref="SignupUserRequest" /> containing information of the user to sign up.</param>

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -87,7 +87,7 @@ namespace Auth0.AuthenticationApi
         Task<AccessTokenResponse> GetTokenAsync(ResourceOwnerTokenRequest request);
 
         /// <summary>
-        /// Requests an Access Token using the Passwordless flow.
+        /// Requests an Access Token using the Passwordless flow through email.
         /// </summary>
         /// <param name="request"><see cref="PasswordlessEmailTokenRequest"/> containing request details to exchange a one time password received through email.</param>
         /// <returns><see cref="Task"/> representing the async operation containing 
@@ -95,7 +95,7 @@ namespace Auth0.AuthenticationApi
         Task<AccessTokenResponse> GetTokenAsync(PasswordlessEmailTokenRequest request);
 
         /// <summary>
-        /// Requests an Access Token using the Passwordless flow.
+        /// Requests an Access Token using the Passwordless flow through SMS.
         /// </summary>
         /// <param name="request"><see cref="PasswordlessSmsTokenRequest"/> containing request details to exchange a one time password received through SMS.</param>
         /// <returns><see cref="Task"/> representing the async operation containing 

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessEmailTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessEmailTokenRequest.cs
@@ -1,0 +1,15 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    /// <summary>
+    /// Represents a request to exchange a one time password, received through email, for an access token using the Passwordless flow.
+    /// </summary>
+    public class PasswordlessEmailTokenRequest : PasswordlessTokenRequestBase
+    {
+        /// <summary>
+        /// Email used for the Passwordless flow
+        /// </summary>
+        public string Email { get; set; }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessSmsTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessSmsTokenRequest.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    /// <summary>
+    /// Represents a request to exchange a one time password, received through SMS, for an access token using the Passwordless flow.
+    /// </summary>
+    public class PasswordlessSmsTokenRequest : PasswordlessTokenRequestBase
+    {
+        /// <summary>
+        /// Phonenumber used for the Passwordless flow
+        /// </summary>
+        public string PhoneNumber { get; set; }
+        
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessTokenRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessTokenRequestBase.cs
@@ -1,0 +1,41 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    /// <summary>
+    /// Base class for all types of Passwordless requests.
+    /// </summary>
+    public abstract class PasswordlessTokenRequestBase
+    {
+        /// <summary>
+        /// Client ID of the application.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Client Secret of the application.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// The user's verification code
+        /// </summary>
+        public string Code { get; set; }
+
+        /// <summary>
+        /// Unique identifier of the target API to access.
+        /// </summary>
+        /// <remarks>
+        /// Optional except when requesting a token to call an API.
+        /// </remarks>
+        public string Audience { get; set; }
+
+        /// <summary>
+        /// Scopes to be requested. Separate multiple values with a space.
+        /// </summary>
+        /// <remarks>
+        /// Optional, use `openid` to get an ID Token, or `openid profile email` to also include user profile information in the ID Token.
+        /// </remarks>
+        public string Scope { get; set; }
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Moq" Version="4.14.7" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Changes

Currently, the API allows to start the passwordless flow to retrieve a OTP. However, the API does not allow for anyone to exchange that OTP for Token(s). 

This PR adds this possibility by adding an overload for the GetTokenAsync method for both Passwordless With Email and SMS.

### References

https://github.com/auth0/auth0.net/issues/419

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

Adding integration tests for this wasn't possible, so I added a unit test to verify the correct request is being sent.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
