### PR TITLE
Prepare Release 7.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,202 @@
+# Change Log
+
+## [release-7.2.0](https://github.com/auth0/auth0.net/tree/release-7.2.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.1.0...release-7.2.0)
+
+- Support passing the Identity property to the payload sent to JobsClient.SendVerificationEmailAsync 
+and TicketClient.CreateEmailVerificationTicketAsync in Auth0.ManagementApi
+- Fix ConnectionsClient.GetAllAsync when trying to use multiple strategies in Auth0.ManagementApi
+- Add Sources to the User's Permissions when using UserClient.GetPermissionsAsync in Auth0.ManagementApi.
+The return type of the UserClient.GetPermissionsAsync method has been changed, 
+so there might be use-cases where this is breaking your existing code base.
+In case you are inheriting the UserClient and overriding the GetPermissionsAsync method, you will need to update your code
+to ensure the return type matches the return type of the updated UserClient.GetPermissionsAsync method.
+
+## [release-7.1.0](https://github.com/auth0/auth0.net/tree/release-7.1.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.9...release-7.1.0)
+
+- Add support for Log Streams API in Auth0.ManagementApi
+
+## [release-7.0.9](https://github.com/auth0/auth0.net/tree/release-7.0.9)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.8...release-7.0.9)
+
+- Fix boolean casing on form post operations such as ImportUsersAsync so that upsert and sendCompletionEmail work.
+
+## [release-7.0.8](https://github.com/auth0/auth0.net/tree/release-7.0.8)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.7...release-7.0.8)
+
+- Add missing "connections" property on UserBlock class
+
+## [release-7.0.7](https://github.com/auth0/auth0.net/tree/release-7.0.7)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.6...release-7.0.7)
+
+- AuthenticationApiClient now respects path portions of the URI passed to the constructor.
+
+## [release-7.0.6](https://github.com/auth0/auth0.net/tree/release-7.0.6)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.5...release-7.0.6)
+
+- Force DateParseHandling of DateTime in JSON.NET serialization to avoid global setting.
+
+## [release-7.0.5](https://github.com/auth0/auth0.net/tree/release-7.0.5)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.4...release-7.0.5)
+
+- Use own JSON.NET serialization settings (avoids conflicts with changes to global)
+- Fix Jobs ImportUsersAsync function, add new SendVerificationEmail setting.
+- Add missing properties to Jobs class.
+- Add client_secret support to passwordless authentication.
+
+## [release-7.0.4](https://github.com/auth0/auth0.net/tree/release-7.0.4)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.3...release-7.0.4)
+
+- Ensure JWKS keys are cached for the correct period.
+- Raise RateLimitApiException on 429/TooManyRequests status code response.
+
+## [release-7.0.3](https://github.com/auth0/auth0.net/tree/release-7.0.3)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.2...release-7.0.3)
+
+- Fixed path encoding allowing ResourceServers.GetAsync to work with HTTP URLs #377
+- Add support for extra error properties to faciliate mfa_required etc. #376
+
+## [release-7.0.2](https://github.com/auth0/auth0.net/tree/release-7.0.2)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.1...release-7.0.2)
+
+- Fixed a concurrency issue - missing ConfigureAwait(false) in HttpClient*Connections.
+
+## [release-7.0.1](https://github.com/auth0/auth0.net/tree/release-7.0.1)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.0.0...release-7.0.1)
+
+- Fixes request message disposal issue in HttpClient*Connection.GetAsync on .NET Framework 4.x
+
+## [release-7.0.0](https://github.com/auth0/auth0.net/tree/release-7.0.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.5.6...release-7.0.0)
+
+There are many breaking changes in this release. Please see our Migration Guide for v7 at
+https://auth0.github.io/auth0.net/migrating.html
+
+The summary of changes is:
+
+- Authentication SDK includes new ID Token Validation. If your application uses HS256
+signing you should set either SigningAlgorithm to SigningAlgorithm.HS256 on requests
+you make to AuthenticationApiClient or switch to RS256 if your application is not confidential.
+
+- Improved testing and mocking support. You can now mock `IAuthenticationConnection` /
+`IManagementConnection` classes to provide local unit-testing functionality for
+`AuthenticationApiClient` and `ManagementApiClient` respectively.
+
+- Many classes moved namespace and assembly primarily ones in `Core` that were around paging.
+Visual Studio should be able to suggest where classes you were using now reside.
+
+- Disposal is now consistent. If `AuthenticationApiClient` or `ManagementApiClient` create a
+connection for you they will manage its lifecycle. If you pass in a connection then it will be your
+responsibility to manage it. This also applies to how `HttpClientAuthenticationConnection` and
+`HttpClientManagementConnection` will only dispose of a `HttpClient` they create and not ones they
+are given.
+
+- Rate Limiting information is now only available on the `RateLimitApiException` which is raised when
+the rate limit is exceeded.
+
+- `ApiException` is now `ErrorApiException`. If you use the status code or error message on exception
+you will need to switch to catching the later. The former is now a base class that does not have
+this information but ensures any old catch `ApiException` will continue to catch rate limit
+exceptions which also now inherit from this class.
+
+- Microsoft recommends `HttpClient` is reused as much as possible.  Therefore you should use
+dependency injection or inversion of control to ensure that either a single instance of
+`AuthenticationApiClient` / `ManagementApiClient` or its connections `HttpClientXConnection` are
+created to ensure sharing.  These classes are now thread-safe. You can additionally share
+`HttpClient` objects between them if you wish by injecting it into the `HttpClientXConnection`
+constructor.
+
+- Connections now have DisplayName, Realms and IsDomainConnection properties.
+
+## [release-6.5.6](https://github.com/auth0/auth0.net/tree/release-6.5.6)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.5.5...release-6.5.6)
+
+- Fix sharing of ApiConnection objects (would keep expanding default Auth0-Client header)
+
+## [release-6.5.5](https://github.com/auth0/auth0.net/tree/release-6.5.5)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.5.4...release-6.5.5)
+
+- Signup API result now handles custom databases returning variations of "id" name
+- Fix EnrollmentAuthMethod.Authenticator enum name
+- ClientBase now has property for `initiate_login_uri`
+
+## [release-6.5.4](https://github.com/auth0/auth0.net/tree/release-6.5.4)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.5.3...release-6.5.4)
+
+SECURITY FIX for CVE-2019-16929. See https://github.com/auth0/auth0.net/blob/master/SECURITY-NOTICE.md#idtokenvalidator-public for more details.
+
+## [release-6.5.3](https://github.com/auth0/auth0.net/tree/release-6.5.3)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.5.2...release-6.5.3)
+
+WARNING: If you generate tokens in your project via System.IdentityModel.Tokens.Jwt
+please read the important notice at https://github.com/auth0/auth0.net/issues/300
+
+- Upgraded System.IdentityModel.Tokens.Jwt to 5.5 to fix incompatible kid
+- Upgraded Microsoft.IdentityModel.Protocols.OpenIdConnect to 5.5
+- Add ClientId to VerifyEmailJobRequest
+- Updated all test dependencies (xunit, FluentAssertions, .NET Test SDK)
+- Removed unused Console Workbench project
+
+## [release-6.5.2](https://github.com/auth0/auth0.net/tree/release-6.5.2)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.5.1...release-6.5.2)
+
+- UserClient.GetEnrollments now correctly passes user id.
+
+## [release-6.5.1](https://github.com/auth0/auth0.net/tree/release-6.5.1)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.5.0...release-6.5.1)
+
+- User and role permissions endpoints in UsersClient and RolesClient paging fix.
+
+## [release-6.5.0](https://github.com/auth0/auth0.net/tree/release-6.5.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.4.0...release-6.5.0)
+
+- Assembly is now strong-name-signed so it can be used by other strong-name-signed packages.
+- NOTE: This is code signing only using a non-secret key. It is not authenticode or tamper protection.
+- User and role permissions endpoints in UsersClient and RolesClient now correctly honoring paging.
+- User model optional fields (CreatedAt, UpdatedAt, LastLogin) are now nullable.
+
+## [release-6.4.0](https://github.com/auth0/auth0.net/tree/release-6.4.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.3.0...release-6.4.0)
+
+- TenantSettings lifetimes are now double not integer.
+- Added various Guardian-related endpoints on UserClient.
+
+## [release-6.3.0](https://github.com/auth0/auth0.net/tree/release-6.3.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.2.0...release-6.3.0)
+
+- Missing Tenant settings now available (device flow, Guardian MFA, Change Password, flags etc.
+
+## [release-6.2.0](https://github.com/auth0/auth0.net/tree/release-6.2.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.1.0...release-6.2.0)
+
+- Added client_id to GetDeviceCredentials response
+- Added various user properties to UserUpdateRequest
+
+## [release-6.1.0](https://github.com/auth0/auth0.net/tree/release-6.1.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.0.0...release-6.1.0)
+
+- New user permission endpoints added to UsersClient
+- New role permission endpoints added to RolesClient
+- AuthenticationApiClient now implements IDisposable to dispose ApiConnection and HttpClient
+- Added various new and missing properties to Resource Servers (ResourceServerBase)
+
+## [release-6.0.0](https://github.com/auth0/auth0.net/tree/release-6.0.0)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-6.0.0...release-5.11.0)
+
+- New GuardianClient for managing /guardian endpoints
+- New RolesClient for managing /roles endpoints
+- PasswordChangeTicket now has IncludeEmailInRedirect and MailEmailAsVerified
+- ApiConnection now has Dispose to dispose the HttpClient it creates
+- ManagementApiClient now has Dispose to dispose the ApiConnection it creates
+- XML documentation tweaks
+- Dependencies updated
+
+BREAKING CHANGES
+See our migration guide at https://github.com/auth0/auth0.net/blob/master/docs-source/migrating-to-v6.md
+
+- All I*Client interfaces have been removed so adding endpoints is no longer breaking
+- IManagementApi interface was removed so adding new clients is no longer breaking
+- All non-paging GetAll methods have been removed
+- DiagnosticsHeader/DiagnosticsComponent are no longer available
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [release-7.3.0](https://github.com/auth0/auth0.net/tree/release-7.3.0) (2020-10-23)
+[Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.2.0...release-7.3.0)
+
+**Added**
+- Complete passwordless API [\#438](https://github.com/auth0/auth0.net/pull/438) ([frederikprijck](https://github.com/frederikprijck))
+- Implement the POST Job Users Export endpoint [\#436](https://github.com/auth0/auth0.net/pull/436) ([frederikprijck](https://github.com/frederikprijck))
+
 ## [release-7.2.0](https://github.com/auth0/auth0.net/tree/release-7.2.0)
 [Full Changelog](https://github.com/auth0/auth0.net/compare/release-7.1.0...release-7.2.0)
 

--- a/build/common.props
+++ b/build/common.props
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <LangVersion>7.1</LangVersion>
     <Major>7</Major>
-    <Minor>2</Minor>
+    <Minor>3</Minor>
     <Revision>0</Revision>
     <Suffix/>
   </PropertyGroup>

--- a/build/common.props
+++ b/build/common.props
@@ -13,156 +13,7 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/auth0/auth0.net</RepositoryUrl>
     <PackageReleaseNotes>
-      Version 7.2.0
-      - Support passing the Identity property to the payload sent to JobsClient.SendVerificationEmailAsync 
-        and TicketClient.CreateEmailVerificationTicketAsync in Auth0.ManagementApi
-      - Fix ConnectionsClient.GetAllAsync when trying to use multiple strategies in Auth0.ManagementApi
-      - Add Sources to the User's Permissions when using UserClient.GetPermissionsAsync in Auth0.ManagementApi.
-        The return type of the UserClient.GetPermissionsAsync method has been changed, 
-        so there might be use-cases where this is breaking your existing code base.
-        In case you are inheriting the UserClient and overriding the GetPermissionsAsync method, you will need to update your code
-        to ensure the return type matches the return type of the updated UserClient.GetPermissionsAsync method.
-
-      Version 7.1.0
-      - Add support for Log Streams API in Auth0.ManagementApi
-      
-      Version 7.0.9
-      - Fix boolean casing on form post operations such as ImportUsersAsync so that upsert and sendCompletionEmail work.
-	  
-      Version 7.0.8
-      - Add missing "connections" property on UserBlock class
-
-      Version 7.0.7
-      - AuthenticationApiClient now respects path portions of the URI passed to the constructor.
-
-      Version 7.0.6
-      - Force DateParseHandling of DateTime in JSON.NET serialization to avoid global setting.
-
-      Version 7.0.5
-      - Use own JSON.NET serialization settings (avoids conflicts with changes to global)
-      - Fix Jobs ImportUsersAsync function, add new SendVerificationEmail setting.
-      - Add missing properties to Jobs class.
-      - Add client_secret support to passwordless authentication.
-
-      Version 7.0.4
-      - Ensure JWKS keys are cached for the correct period.
-      - Raise RateLimitApiException on 429/TooManyRequests status code response.
-
-      Version 7.0.3
-      - Fixed path encoding allowing ResourceServers.GetAsync to work with HTTP URLs #377
-      - Add support for extra error properties to faciliate mfa_required etc. #376
-
-      Version 7.0.2
-      - Fixed a concurrency issue - missing ConfigureAwait(false) in HttpClient*Connections.
-
-      Version 7.0.1
-      - Fixes request message disposal issue in HttpClient*Connection.GetAsync on .NET Framework 4.x
-
-      Version 7.0.0
-
-      There are many breaking changes in this release. Please see our Migration Guide for v7 at
-      https://auth0.github.io/auth0.net/migrating.html
-
-      The summary of changes is:
-
-      - Authentication SDK includes new ID Token Validation. If your application uses HS256
-        signing you should set either SigningAlgorithm to SigningAlgorithm.HS256 on requests
-        you make to AuthenticationApiClient or switch to RS256 if your application is not confidential.
-
-      - Improved testing and mocking support. You can now mock `IAuthenticationConnection` /
-        `IManagementConnection` classes to provide local unit-testing functionality for
-        `AuthenticationApiClient` and `ManagementApiClient` respectively.
-
-      - Many classes moved namespace and assembly primarily ones in `Core` that were around paging.
-        Visual Studio should be able to suggest where classes you were using now reside.
-
-      - Disposal is now consistent. If `AuthenticationApiClient` or `ManagementApiClient` create a
-        connection for you they will manage its lifecycle. If you pass in a connection then it will be your
-        responsibility to manage it. This also applies to how `HttpClientAuthenticationConnection` and
-        `HttpClientManagementConnection` will only dispose of a `HttpClient` they create and not ones they
-        are given.
-
-      - Rate Limiting information is now only available on the `RateLimitApiException` which is raised when
-        the rate limit is exceeded.
-
-      - `ApiException` is now `ErrorApiException`. If you use the status code or error message on exception
-        you will need to switch to catching the later. The former is now a base class that does not have
-        this information but ensures any old catch `ApiException` will continue to catch rate limit
-        exceptions which also now inherit from this class.
-
-      - Microsoft recommends `HttpClient` is reused as much as possible.  Therefore you should use
-        dependency injection or inversion of control to ensure that either a single instance of
-        `AuthenticationApiClient` / `ManagementApiClient` or its connections `HttpClientXConnection` are
-        created to ensure sharing.  These classes are now thread-safe. You can additionally share
-        `HttpClient` objects between them if you wish by injecting it into the `HttpClientXConnection`
-        constructor.
-
-      - Connections now have DisplayName, Realms and IsDomainConnection properties.
-
-      Version 6.5.5
-      - Signup API result now handles custom databases returning variations of "id" name
-      - Fix EnrollmentAuthMethod.Authenticator enum name
-      - ClientBase now has property for `initiate_login_uri`
-
-      Version 6.5.4
-      - SECURITY FIX for CVE-2019-16929. See
-        https://github.com/auth0/auth0.net/blob/master/SECURITY-NOTICE.md#idtokenvalidator-public for more details.
-
-      Version 6.5.3
-      WARNING: If you generate tokens in your project via System.IdentityModel.Tokens.Jwt
-      please read the important notice at https://github.com/auth0/auth0.net/issues/300
-
-      - Upgraded System.IdentityModel.Tokens.Jwt to 5.5 to fix incompatible kid
-      - Upgraded Microsoft.IdentityModel.Protocols.OpenIdConnect to 5.5
-      - Add ClientId to VerifyEmailJobRequest
-      - Updated all test dependencies (xunit, FluentAssertions, .NET Test SDK)
-      - Removed unused Console Workbench project
-
-      Version 6.5.2
-      - UserClient.GetEnrollments now correctly passes user id.
-
-      Version 6.5.1
-      - User and role permissions endpoints in UsersClient and RolesClient paging fix.
-
-      Version 6.5.0
-      - Assembly is now strong-name-signed so it can be used by other strong-name-signed packages.
-      - NOTE: This is code signing only using a non-secret key. It is not authenticode or tamper protection.
-      - User and role permissions endpoints in UsersClient and RolesClient now correctly honoring paging.
-      - User model optional fields (CreatedAt, UpdatedAt, LastLogin) are now nullable.
-
-      Version 6.4.0
-      - TenantSettings lifetimes are now double not integer.
-      - Added various Guardian-related endpoints on UserClient.
-
-      Version 6.3.0
-      - Missing Tenant settings now available (device flow, Guardian MFA, Change Password, flags etc.
-
-      Version 6.2.0
-      - Added client_id to GetDeviceCredentials response
-      - Added various user properties to UserUpdateRequest
-
-      Version 6.1.0
-      - New user permission endpoints added to UsersClient
-      - New role permission endpoints added to RolesClient
-      - AuthenticationApiClient now implements IDisposable to dispose ApiConnection and HttpClient
-      - Added various new and missing properties to Resource Servers (ResourceServerBase)
-
-      Version 6.0.0
-      - New GuardianClient for managing /guardian endpoints
-      - New RolesClient for managing /roles endpoints
-      - PasswordChangeTicket now has IncludeEmailInRedirect and MailEmailAsVerified
-      - ApiConnection now has Dispose to dispose the HttpClient it creates
-      - ManagementApiClient now has Dispose to dispose the ApiConnection it creates
-      - XML documentation tweaks
-      - Dependencies updated
-
-      BREAKING CHANGES
-      See our migration guide at https://github.com/auth0/auth0.net/blob/prepare-6.0.0/docs-source/migrating.md
-
-      - All I*Client interfaces have been removed so adding endpoints is no longer breaking
-      - IManagementApi interface was removed so adding new clients is no longer breaking
-      - All non-paging GetAll methods have been removed
-      - DiagnosticsHeader/DiagnosticsComponent are no longer available
+      https://github.com/auth0/auth0.net/blob/master/CHANGELOG.md
     </PackageReleaseNotes>
     <CLSCompliant>true</CLSCompliant>
     <ComVisible>false</ComVisible>
@@ -172,7 +23,7 @@
     <Major>7</Major>
     <Minor>2</Minor>
     <Revision>0</Revision>
-    <Suffix></Suffix>
+    <Suffix/>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyVersion>$(Major).$(Minor).$(Revision)</AssemblyVersion>
@@ -184,6 +35,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="../../build/Auth0Icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="../../build/Auth0Icon.png" Pack="true" Visible="false" PackagePath=""/>
   </ItemGroup>
 </Project>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,36 @@
+{
+  "name": "auth0.net",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "dev": true
+    },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "auth0.net",
   "version": "0.0.1",
-  "description": "[![Build status](https://dev.azure.com/Auth0SDK/Auth0.Net/_apis/build/status/Auth0.Net)](https://dev.azure.com/Auth0SDK/Auth0.Net/_build/latest?definitionId=6) [![NuGet version](https://img.shields.io/nuget/v/auth0.core.svg?style=flat)](https://www.nuget.org/packages/Auth0.Core/) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2Fauth0.net.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2Fauth0.net?ref=badge_shield)",
+  "description": ".NET client library for Auth0",
   "scripts": {
     "release": "node ./scripts/release",
     "release:clean": "node ./scripts/cleanup"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "auth0.net",
+  "version": "0.0.1",
+  "description": "[![Build status](https://dev.azure.com/Auth0SDK/Auth0.Net/_apis/build/status/Auth0.Net)](https://dev.azure.com/Auth0SDK/Auth0.Net/_build/latest?definitionId=6) [![NuGet version](https://img.shields.io/nuget/v/auth0.core.svg?style=flat)](https://www.nuget.org/packages/Auth0.Core/) [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2Fauth0.net.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2Fauth0.net?ref=badge_shield)",
+  "scripts": {
+    "release": "node ./scripts/release",
+    "release:clean": "node ./scripts/cleanup"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/auth0/auth0.net.git"
+  },
+  "author": "Auth0",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/auth0/auth0.net/issues"
+  },
+  "homepage": "https://github.com/auth0/auth0.net#readme",
+  "devDependencies": {
+    "moment": "^2.29.1",
+    "xml2js": "^0.4.23"
+  }
+}

--- a/scripts/changelog.js
+++ b/scripts/changelog.js
@@ -1,0 +1,61 @@
+if (process.platform === 'win32') {
+    console.error('Must be run on a Unix OS');
+    process.exit(1);
+  }
+  
+  const repo = 'auth0.net';
+  const fs = require('fs');
+  const path = require('path');
+  const execSync = require('child_process').execSync;
+  const moment = require('moment');
+  
+  module.exports = function (newVersion) {
+    return new Promise((resolve, reject) => {
+      const tmp = fs.readFileSync('.release', 'utf-8');
+  
+      const currentVersion = fs.readFileSync(
+        path.resolve(tmp, 'current-version'),
+        'utf-8'
+      );
+  
+      const changelogPath = path.resolve(tmp, 'CHANGELOG.md');
+      const stream = fs.createWriteStream(changelogPath);
+      const webtask = `https://webtask.it.auth0.com/api/run/wt-hernan-auth0_com-0/oss-changelog.js?webtask_no_cache=1&repo=${repo}&milestone=${newVersion}`;
+      const command = `curl -f -s -H "Accept: text/markdown" "${webtask}"`;
+      const changes = execSync(command, { encoding: 'utf-8' });
+  
+      const previous = execSync(
+        'sed "s/# Change Log//" CHANGELOG.md | sed \'1,2d\''
+      );
+  
+      stream.once('open', function (fd) {
+        stream.write('# Change Log');
+        stream.write('\n');
+        stream.write('\n');
+  
+        stream.write(
+          `## [release-${newVersion}](https://github.com/auth0/${repo}/tree/release-${newVersion}) (${moment().format(
+            'YYYY-MM-DD'
+          )})`
+        );
+  
+        stream.write('\n');
+  
+        stream.write(
+          `[Full Changelog](https://github.com/auth0/${repo}/compare/release-${currentVersion}...release-${newVersion})`
+        );
+  
+        stream.write('\n');
+        stream.write(changes);
+        stream.write('\n');
+        stream.write(previous);
+        stream.end();
+      });
+  
+      stream.once('close', function (fd) {
+        execSync(`mv ${changelogPath} CHANGELOG.md`, { stdio: 'inherit' });
+        execSync('git add CHANGELOG.md', { stdio: 'inherit' });
+        resolve();
+      });
+    });
+  };

--- a/scripts/cleanup.js
+++ b/scripts/cleanup.js
@@ -1,0 +1,15 @@
+const execSync = require('child_process').execSync;
+const fs = require('fs');
+
+if (!fs.existsSync('.release')) {
+  console.log('No in progress release found');
+  process.exit(0);
+}
+
+const tmp = fs.readFileSync('.release');
+
+if (fs.existsSync(tmp)) {
+  execSync(`rm -r ${tmp}`, { stdio: 'inherit' });
+}
+
+execSync(`rm -r .release`, { stdio: 'inherit' });

--- a/scripts/exec.js
+++ b/scripts/exec.js
@@ -1,0 +1,12 @@
+const exec = require('child_process').exec;
+
+module.exports = cmd => {
+  return new Promise((resolve, reject) => {
+    exec(cmd, (error, stdout, stderr) => {
+      if (error) {
+        reject(error);
+      }
+      resolve(stdout ? stdout : stderr);
+    });
+  });
+};

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,42 @@
+const fs = require("fs");
+const exec = require("./exec");
+const writeChangelog = require("./changelog");
+const { getVersion, setVersion } = require("./version");
+const path = require("path");
+const tmp = fs.mkdtempSync(`.release-tmp-`);
+
+const newVersion = process.argv[2];
+if (!newVersion) {
+  throw new Error("usage: `release new_version [branch]`");
+}
+
+const branch = process.argv[3];
+
+(async () => {
+  if (!fs.existsSync(".release")) {
+    fs.writeFileSync(".release", tmp);
+  } else {
+    console.error(
+      "Found a pending release. Please run `npm run release:clean`"
+    );
+    process.exit(1);
+  }
+
+  const lastVersionFile = path.resolve(tmp, "current-version");
+  const version = await getVersion();
+
+  fs.writeFileSync(lastVersionFile, version);
+
+  if (branch) {
+    await exec(`git checkout ${branch}`);
+  }
+
+  await exec("git pull");
+  await exec(`git checkout -b prepare/${newVersion}`);
+
+  await setVersion(newVersion);
+
+  await writeChangelog(newVersion);
+
+  await exec("npm run release:clean");
+})();

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -1,0 +1,54 @@
+const fs = require("fs").promises;
+const xml2js = require("xml2js");
+
+async function loadXMLDoc(filePath) {
+  const fileData = await fs.readFile(filePath, "utf-8");
+  const parser = new xml2js.Parser();
+  return parser.parseStringPromise(fileData.substring(0, fileData.length));
+}
+
+async function saveXMLDoc(filePath, content) {
+  const builder = new xml2js.Builder({ headless: true });
+  const xml = builder.buildObject(content);
+
+  return fs.writeFile(filePath, xml, "utf-8");
+}
+
+let commonPropsJson = null;
+async function loadCommonProps() {
+  const XMLPath = "./build/common.props";
+  commonPropsJson = commonPropsJson || (await loadXMLDoc(XMLPath));
+  return commonPropsJson;
+}
+
+async function saveCommonProps(content) {
+  const XMLPath = "./build/common.props";
+  return saveXMLDoc(XMLPath, content);
+}
+
+module.exports = {
+  getVersion: async () => {
+    const commonProps = await loadCommonProps();
+    const {
+      Major,
+      Minor,
+      Revision,
+    } = commonProps.Project.PropertyGroup.find((propertyGroup) =>
+      Object.keys(propertyGroup).includes("Major")
+    );
+    return `${Major}.${Minor}.${Revision}`;
+  },
+  setVersion: async (version) => {
+    const commonProps = await loadCommonProps();
+    const propertyGroupWithVersion = commonProps.Project.PropertyGroup.find(
+      (propertyGroup) => Object.keys(propertyGroup).includes("Major")
+    );
+    const [major, minor, revision] = version.split(".");
+
+    propertyGroupWithVersion.Major = major;
+    propertyGroupWithVersion.Minor = minor;
+    propertyGroupWithVersion.Revision = revision;
+
+    saveCommonProps(commonProps);
+  },
+};


### PR DESCRIPTION
This also fixes SDK-2091 to change the way we handle changelogs

As of this PR, the changelog is automatically generated using node scripts.
Even thought it might be a bit weird to be adding package.json and a bunch of node scripts to the .NET repository, it does ensure change log generation is close to identical to how it is done within our JavaScript SDKs.