### PR TITLE
Only label "waiting for customer" is marked stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -6,8 +6,9 @@ daysUntilStale: 90
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 daysUntilClose: 7
 
-# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
-exemptLabels: []
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  - 'waiting for customer'
 
 # Set to true to ignore issues with an assignee (defaults to false)
 exemptAssignees: true


### PR DESCRIPTION
Ensure only issues that are waiting for customers are marked as stale