### PR TITLE
Include WebAuthn Guardian Factory names

### DIFF
--- a/docs/api/Auth0.ManagementApi.Models.GuardianFactorName.html
+++ b/docs/api/Auth0.ManagementApi.Models.GuardianFactorName.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum GuardianFactorName
    ">
-    <meta name="generator" content="docfx 2.48.0.0">
+    <meta name="generator" content="docfx 2.56.4.0">
     
     <link rel="shortcut icon" href="../images/logo.png">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -111,6 +111,14 @@
         <td id="Auth0_ManagementApi_Models_GuardianFactorName_Sms">Sms</td>
         <td></td>
       </tr>
+      <tr>
+        <td id="Auth0_ManagementApi_Models_GuardianFactorName_WebAuthnPlatform">WebAuthnPlatform</td>
+        <td></td>
+      </tr>
+      <tr>
+        <td id="Auth0_ManagementApi_Models_GuardianFactorName_WebAuthnRoaming">WebAuthnRoaming</td>
+        <td></td>
+      </tr>
     </tbody>
   </thead></thead></table>
 </article>
@@ -119,7 +127,8 @@
           <div class="hidden-sm col-md-2" role="complementary">
             <div class="sideaffix">
               <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
-              <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
+                <h5>In This Article</h5>
+                <div></div>
               </nav>
             </div>
           </div>

--- a/docs/api/Auth0.ManagementApi.Models.GuardianFactorName.html
+++ b/docs/api/Auth0.ManagementApi.Models.GuardianFactorName.html
@@ -10,7 +10,7 @@
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum GuardianFactorName
    ">
-    <meta name="generator" content="docfx 2.56.4.0">
+    <meta name="generator" content="docfx 2.48.0.0">
     
     <link rel="shortcut icon" href="../images/logo.png">
     <link rel="stylesheet" href="../styles/docfx.vendor.css">
@@ -127,8 +127,7 @@
           <div class="hidden-sm col-md-2" role="complementary">
             <div class="sideaffix">
               <nav class="bs-docs-sidebar hidden-print hidden-xs hidden-sm affix" id="affix">
-                <h5>In This Article</h5>
-                <div></div>
+                <!-- <p><a class="back-to-top" href="#top">Back to top</a><p> -->
               </nav>
             </div>
           </div>

--- a/src/Auth0.ManagementApi/Models/GuardianFactorName.cs
+++ b/src/Auth0.ManagementApi/Models/GuardianFactorName.cs
@@ -17,12 +17,12 @@ namespace Auth0.ManagementApi.Models
         Otp,
 
         [EnumMember(Value = "duo")]
-        Duo
+        Duo,
         
         [EnumMember(Value="webauthn-roaming")]
         WebAuthnRoaming,
         
         [EnumMember(Value="webauthn-platform")]
-        WebAuthnPlatform,
+        WebAuthnPlatform
     }
 }

--- a/src/Auth0.ManagementApi/Models/GuardianFactorName.cs
+++ b/src/Auth0.ManagementApi/Models/GuardianFactorName.cs
@@ -18,5 +18,11 @@ namespace Auth0.ManagementApi.Models
 
         [EnumMember(Value = "duo")]
         Duo
+        
+        [EnumMember(Value="webauthn-roaming")]
+        WebAuthnRoaming,
+        
+        [EnumMember(Value="webauthn-platform")]
+        WebAuthnPlatform,
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
@@ -30,7 +30,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var response = await _managementApiClient.Guardian.GetFactorsAsync();
 
-            response.Should().HaveCount(5);
+            response.Should().HaveCount(6);
         }
 
         [Fact]


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:
- Added missing factor name's: https://auth0.com/docs/api/management/v2#!/Guardian/get_factors
- fixed a test that is currently broken on master since an update to Auth0's available factories.

### References
#445

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
