### PR TITLE
Allow creating and updating RefreshToken settings for Clients

### DIFF
--- a/src/Auth0.ManagementApi/Models/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientBase.cs
@@ -163,6 +163,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("sso")]
         public bool? Sso { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("refresh_token")]
+        public RefreshToken RefreshToken { get; set; }
     }
 }
 

--- a/src/Auth0.ManagementApi/Models/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientBase.cs
@@ -163,8 +163,9 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("sso")]
         public bool? Sso { get; set; }
-        
+
         /// <summary>
+        /// Configuration of refresh tokens for a client
         /// </summary>
         [JsonProperty("refresh_token")]
         public RefreshToken RefreshToken { get; set; }

--- a/src/Auth0.ManagementApi/Models/RefreshToken.cs
+++ b/src/Auth0.ManagementApi/Models/RefreshToken.cs
@@ -13,14 +13,14 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("rotation_type")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public RefreshTokenRotationType RotationType { get; set; } = RefreshTokenRotationType.NonRotating;
+        public RefreshTokenRotationType RotationType { get; set; }
 
         /// <summary>
         /// Refresh token expiration type
         /// </summary>
         [JsonProperty("expiration_type")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public RefreshTokenExpirationType ExpirationType { get; set; } = RefreshTokenExpirationType.NonExpiring;
+        public RefreshTokenExpirationType ExpirationType { get; set; }
 
         /// <summary>
         /// Period in seconds where the previous refresh token can be exchanged without triggering breach detection

--- a/src/Auth0.ManagementApi/Models/RefreshToken.cs
+++ b/src/Auth0.ManagementApi/Models/RefreshToken.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Represents configuration of refresh tokens for a client.
+    /// </summary>
+    public class RefreshToken
+    {
+        /// <summary>
+        /// Refresh token rotation type
+        /// </summary>
+        [JsonProperty("rotation_type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RefreshTokenRotationType RotationType { get; set; } = RefreshTokenRotationType.NonRotating;
+
+        /// <summary>
+        /// Refresh token expiration type
+        /// </summary>
+        [JsonProperty("expiration_type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public RefreshTokenExpirationType ExpirationType { get; set; } = RefreshTokenExpirationType.NonExpiring;
+
+        /// <summary>
+        /// Period in seconds where the previous refresh token can be exchanged without triggering breach detection
+        /// </summary>
+        [JsonProperty("leeway")]
+        public int? Leeway { get; set; }
+
+        /// <summary>
+        /// Period (in seconds) for which refresh tokens will remain valid
+        /// </summary>
+        [JsonProperty("token_lifetime")]
+        public int? TokenLifetime { get; set; }
+
+        /// <summary>
+        /// Prevents tokens from having a set lifetime when true (takes precedence over token_lifetime values)
+        /// </summary>
+        [JsonProperty("infinite_token_lifetime")]
+        public bool? InfiniteTokenLifetime { get; set; }
+
+        /// <summary>
+        /// Period (in seconds) for which refresh tokens will remain valid without use
+        /// </summary>
+        [JsonProperty("idle_token_lifetime")]
+        public int? IdleTokenLifetime { get; set; }
+
+        /// <summary>
+        /// Prevents tokens from expiring without use when true (takes precedence over idle_token_lifetime values)
+        /// </summary>
+        [JsonProperty("infinite_idle_token_lifetime")]
+        public bool? InfiniteIdleTokenLifetime { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/RefreshTokenExpirationType.cs
+++ b/src/Auth0.ManagementApi/Models/RefreshTokenExpirationType.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{ 
+    /// <summary>
+    /// The type of expiration for a <see cref="RefreshToken"/>
+    /// </summary>
+    public enum RefreshTokenExpirationType
+    {
+        /// <summary>
+        /// Expiring
+        /// </summary>
+        [EnumMember(Value = "expiring")]
+        Expiring,
+
+        /// <summary>
+        /// Non-Expiring
+        /// </summary>
+        [EnumMember(Value = "non-expiring")]
+        NonExpiring,
+    }
+}

--- a/src/Auth0.ManagementApi/Models/RefreshTokenRotationType.cs
+++ b/src/Auth0.ManagementApi/Models/RefreshTokenRotationType.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The type of rotation for a <see cref="RefreshToken"/>
+    /// </summary>
+    public enum RefreshTokenRotationType
+    {        
+        /// <summary>
+        /// Rotating
+        /// </summary>
+        [EnumMember(Value = "rotating")]
+        Rotating,
+
+        /// <summary>
+        /// Non-Rotating
+        /// </summary>
+        [EnumMember(Value = "non-rotating")]
+        NonRotating,
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -28,7 +28,6 @@ namespace Auth0.ManagementApi.IntegrationTests
         [Fact]
         public async Task Test_client_crud_sequence()
         {
-
             // Add a new client
             var newClientRequest = new ClientCreateRequest
             {
@@ -40,7 +39,14 @@ namespace Auth0.ManagementApi.IntegrationTests
                     Prop1 = "1",
                     Prop2 = "2"
                 },
-                InitiateLoginUri = "https://create.com/login"
+                InitiateLoginUri = "https://create.com/login",
+                RefreshToken = new RefreshToken
+                {
+                    ExpirationType = RefreshTokenExpirationType.NonExpiring,
+                    RotationType = RefreshTokenRotationType.NonRotating
+                },
+                OidcConformant = true,
+                GrantTypes = new[] { "refresh_token" }
             };
             var newClientResponse = await _apiClient.Clients.CreateAsync(newClientRequest);
             newClientResponse.Should().NotBeNull();
@@ -48,11 +54,15 @@ namespace Auth0.ManagementApi.IntegrationTests
             newClientResponse.TokenEndpointAuthMethod.Should().Be(TokenEndpointAuthMethod.ClientSecretPost);
             newClientResponse.ApplicationType.Should().Be(ClientApplicationType.Native);
             newClientResponse.IsFirstParty.Should().BeTrue();
+            newClientResponse.RefreshToken.Should().NotBeNull();
+            newClientResponse.RefreshToken.ExpirationType.Should().Be(newClientRequest.RefreshToken.ExpirationType);
+            newClientResponse.RefreshToken.RotationType.Should().Be(newClientRequest.RefreshToken.RotationType);
+
             string prop1 = newClientResponse.ClientMetaData.Prop1;
             prop1.Should().Be("1");
             string prop2 = newClientResponse.ClientMetaData.Prop2;
             prop2.Should().Be("2");
-            newClientResponse.GrantTypes.Should().HaveCount(i => i > 0);
+            newClientResponse.GrantTypes.Should().HaveCount(1);
             newClientResponse.InitiateLoginUri.Should().Be("https://create.com/login");
 
             // Update the client
@@ -61,16 +71,28 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"Integration testing {Guid.NewGuid():N}",
                 TokenEndpointAuthMethod = TokenEndpointAuthMethod.ClientSecretPost,
                 ApplicationType = ClientApplicationType.Spa,
-                GrantTypes = Array.Empty<string>(),
-                InitiateLoginUri = "https://update.com/login"
+                GrantTypes = new[] { "refresh_token", "authorization_code" },
+                InitiateLoginUri = "https://update.com/login",
+                RefreshToken = new RefreshToken
+                {
+                    ExpirationType = RefreshTokenExpirationType.Expiring,
+                    RotationType = RefreshTokenRotationType.Rotating,
+                    TokenLifetime = 3600,
+                    Leeway = 1800
+                }
             };
             var updateClientResponse = await _apiClient.Clients.UpdateAsync(newClientResponse.ClientId, updateClientRequest);
             updateClientResponse.Should().NotBeNull();
             updateClientResponse.Name.Should().Be(updateClientRequest.Name);
             updateClientResponse.TokenEndpointAuthMethod.Should().Be(TokenEndpointAuthMethod.ClientSecretPost);
             updateClientResponse.ApplicationType.Should().Be(ClientApplicationType.Spa);
-            updateClientResponse.GrantTypes.Should().HaveCount(0);
+            updateClientResponse.GrantTypes.Should().HaveCount(2);
             updateClientResponse.InitiateLoginUri.Should().Be("https://update.com/login");
+            updateClientResponse.RefreshToken.Should().NotBeNull();
+            updateClientResponse.RefreshToken.RotationType.Should().Be(updateClientRequest.RefreshToken.RotationType);
+            updateClientResponse.RefreshToken.ExpirationType.Should().Be(updateClientRequest.RefreshToken.ExpirationType);
+            updateClientResponse.RefreshToken.TokenLifetime.Should().Be(updateClientRequest.RefreshToken.TokenLifetime);
+            updateClientResponse.RefreshToken.Leeway.Should().Be(updateClientRequest.RefreshToken.Leeway);
 
             // Get a single client
             var client = await _apiClient.Clients.GetAsync(newClientResponse.ClientId);
@@ -170,64 +192,6 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Delete the client, and ensure we get exception when trying to fetch client again
             await _apiClient.Clients.DeleteAsync(newClientResponse.ClientId);
-        }
-
-        [Fact]
-        public async Task Test_client_crud_sequence_with_refresh_token()
-        {
-
-            // Add a new client
-            var newClientRequest = new ClientCreateRequest
-            {
-                Name = $"Integration testing {MakeRandomName()}",
-                RefreshToken = new RefreshToken
-                {
-                    ExpirationType = RefreshTokenExpirationType.NonExpiring,
-                    RotationType = RefreshTokenRotationType.NonRotating
-                },
-                OidcConformant = true,
-                GrantTypes = new []{"refresh_token"}
-            };
-            var newClientResponse = await _apiClient.Clients.CreateAsync(newClientRequest);
-            newClientResponse.Should().NotBeNull();
-            newClientResponse.Name.Should().Be(newClientRequest.Name);
-            newClientResponse.RefreshToken.Should().NotBeNull();
-            newClientResponse.RefreshToken.ExpirationType.Should().Be(newClientRequest.RefreshToken.ExpirationType);
-            newClientResponse.RefreshToken.RotationType.Should().Be(newClientRequest.RefreshToken.RotationType);
-
-            // Update the client
-            var updateClientRequest = new ClientUpdateRequest
-            {
-                Name = $"Integration testing {Guid.NewGuid():N}",
-                RefreshToken = new RefreshToken
-                {
-                    ExpirationType = RefreshTokenExpirationType.Expiring,
-                    RotationType = RefreshTokenRotationType.Rotating,
-                    TokenLifetime = 3600,
-                    Leeway = 1800
-                }
-            };
-            var updateClientResponse = await _apiClient.Clients.UpdateAsync(newClientResponse.ClientId, updateClientRequest);
-            updateClientResponse.Should().NotBeNull();
-            updateClientResponse.Name.Should().Be(updateClientRequest.Name);
-            updateClientResponse.RefreshToken.Should().NotBeNull();
-            updateClientResponse.RefreshToken.RotationType.Should().Be(updateClientRequest.RefreshToken.RotationType);
-            updateClientResponse.RefreshToken.ExpirationType.Should().Be(updateClientRequest.RefreshToken.ExpirationType);
-            updateClientResponse.RefreshToken.TokenLifetime.Should().Be(updateClientRequest.RefreshToken.TokenLifetime);
-            updateClientResponse.RefreshToken.Leeway.Should().Be(updateClientRequest.RefreshToken.Leeway);
-
-            // Get a single client
-            var client = await _apiClient.Clients.GetAsync(newClientResponse.ClientId);
-            client.Should().NotBeNull();
-            client.Name.Should().Be(updateClientResponse.Name);
-            client.RefreshToken.Should().NotBeNull();
-            client.RefreshToken.ExpirationType.Should().Be(updateClientResponse.RefreshToken.ExpirationType);
-            client.RefreshToken.RotationType.Should().Be(updateClientResponse.RefreshToken.RotationType);
-
-            // Delete the client, and ensure we get exception when trying to fetch client again
-            await _apiClient.Clients.DeleteAsync(client.ClientId);
-            Func<Task> getFunc = async () => await _apiClient.Clients.GetAsync(client.ClientId);
-            getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_client");
         }
     }
 }


### PR DESCRIPTION
### Changes

I added new models for the refresh token rotation. With the changes it should be possible to configure
refresh token settings on create and update of clients.

This is important, because at the moment it is impossible to configure a client for refresh token rotation.

### References

I added the properties as described in the api documentation: https://auth0.com/docs/api/management/v2?utm_source=emea-google-dg&utm_medium=cpc&utm_campaign=Branded&utm_content=dynamicRT2&utm_term=&gclid=Cj0KCQiA-rj9BRCAARIsANB_4ADez090wM_osbvalReSynvXe2yRi80CsGig9CxckDToVUFjizzbPukaAnZ3EALw_wcB#!/Clients/post_clients

### Testing

I was not able to run integration tests, because i do not have a tenant to use.

- [ ] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
