### PR TITLE
Remove obsolete methods from docs

### DIFF
--- a/docs-source/docfx.json
+++ b/docs-source/docfx.json
@@ -8,7 +8,8 @@
           "cwd": "../src"
         }
       ],
-      "dest": "obj/api"
+      "dest": "obj/api",
+      "filter": "filterConfig.yml"
     }
   ],
   "build": {

--- a/docs-source/filterConfig.yml
+++ b/docs-source/filterConfig.yml
@@ -1,0 +1,5 @@
+apiRules:
+- exclude:
+    hasAttribute:
+      uid: System.ObsoleteAttribute
+    type: Member


### PR DESCRIPTION
This PR ensures Obsolete methods are not added to the docs output.

It looks like DocFx doesnt have a proper way to visualize obsolete methods, so I figured it's not a bad idea to remove them from the docs while keeping them in the SDK but marked as obsolete.