### PR TITLE
Sync Tenant Flags with API v2

### DIFF
--- a/src/Auth0.ManagementApi/Models/TenantFlags.cs
+++ b/src/Auth0.ManagementApi/Models/TenantFlags.cs
@@ -38,76 +38,91 @@ namespace Auth0.ManagementApi.Models
         public bool DisableClickjackProtectionHeaders { get; set; }
         
         /// <summary>
+        /// Whether third-party developers can dynamically register applications for your APIs (true) or not (false). This flag enables dynamic client registration.
         /// </summary>
         [JsonProperty("enable_dynamic_client_registration")]
         public bool EnableDynamicClientRegistration { get; set; }
         
         /// <summary>
+        /// Whether emails sent by Auth0 for change password, verification etc. should use your verified custom domain (true) or your auth0.com sub-domain (false). Affects all emails, links, and URLs. Email will fail if the custom domain is not verified.
         /// </summary>
         [JsonProperty("enable_custom_domain_in_emails")]
         public bool EnableCustomDomainInEmails { get; set; }
         
         /// <summary>
+        /// Whether the legacy /tokeninfo endpoint is enabled for your account (true) or unavailable (false).
         /// </summary>
         [JsonProperty("allow_legacy_tokeninfo_endpoint")]
         public bool AllowLegacyTokeninfoEndpoint { get; set; }
         
         /// <summary>
+        /// Whether ID tokens and the userinfo endpoint includes a complete user profile (true) or only OpenID Connect claims (false).
         /// </summary>
         [JsonProperty("enable_legacy_profile")]
         public bool EnableLegacyProfile { get; set; }
         
         /// <summary>
+        /// Whether ID tokens can be used to authorize some types of requests to API v2 (true) not not (false).
         /// </summary>
         [JsonProperty("enable_idtoken_api2")]
         public bool EnableIdTokenApi2 { get; set; }
         
         /// <summary>
+        /// Whether the public sign up process shows a user_exists error (true) or a generic error (false) if the user already exists.
         /// </summary>
         [JsonProperty("enable_public_signup_user_exists_error")]
         public bool EnablePublicSignupUserExistsError { get; set; }
         
         /// <summary>
+        /// Whether the legacy delegation endpoint will be enabled for your account (true) or not available (false).
         /// </summary>
         [JsonProperty("allow_legacy_delegation_grant_types")]
         public bool AllowLegacyDelegationGrantTypes { get; set; }
         
         /// <summary>
+        /// Whether the legacy auth/ro endpoint (used with resource owner password and passwordless features) will be enabled for your account (true) or not available (false).
         /// </summary>
         [JsonProperty("allow_legacy_ro_grant_types")]
         public bool AllowLegacyRoGrantTypes { get; set; }
         
         /// <summary>
+        /// Whether users are prompted to confirm log in before SSO redirection (false) or are not prompted (true).
         /// </summary>
         [JsonProperty("enable_sso")]
         public bool EnableSSO { get; set; }
         
         /// <summary>
+        /// Do not Publish Enterprise Connections Information with IdP domains on the lock configuration file.
         /// </summary>
         [JsonProperty("no_disclose_enterprise_connections")]
         public bool NoDiscloseEnterpriseConnections { get; set; }
         
         /// <summary>
+        /// If true, SMS phone numbers will not be obfuscated in Management API GET calls.
         /// </summary>
         [JsonProperty("disable_management_api_sms_obfuscation")]
         public bool DisableManagementApiSmsObfuscation { get; set; }
         
         /// <summary>
+        /// Enforce client authentication for passwordless start
         /// </summary>
         [JsonProperty("enforce_client_authentication_on_passwordless_start")]
         public bool EnforceClientAuthenticationOnPasswordlessStart { get; set; }
         
         /// <summary>
+        /// Changes email_verified behavior for Azure AD/ADFS connections when enabled. Sets email_verified to false otherwise.
         /// </summary>
         [JsonProperty("trust_azure_adfs_email_verified_connection_property")]
         public bool TrustAzureAdfsEmailVerifiedConnectionProperty { get; set; }
         
         /// <summary>
+        /// Enables the email verification flow during login for Azure AD and ADFS connections
         /// </summary>
         [JsonProperty("enable_adfs_waad_email_verification")]
         public bool EnabdleAdfsWaadEmailVerification { get; set; }
         
         /// <summary>
+        /// Delete underlying grant when a Refresh Token is revoked via the Authentication API.
         /// </summary>
         [JsonProperty("revoke_refresh_token_grant")]
         public bool RovokeRefreshTokenGrant { get; set; }

--- a/src/Auth0.ManagementApi/Models/TenantFlags.cs
+++ b/src/Auth0.ManagementApi/Models/TenantFlags.cs
@@ -36,95 +36,95 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("disable_clickjack_protection_headers")]
         public bool DisableClickjackProtectionHeaders { get; set; }
-        
+
         /// <summary>
         /// Whether third-party developers can dynamically register applications for your APIs (true) or not (false). This flag enables dynamic client registration.
         /// </summary>
         [JsonProperty("enable_dynamic_client_registration")]
-        public bool EnableDynamicClientRegistration { get; set; }
+        public bool? EnableDynamicClientRegistration { get; set; } = null;
         
         /// <summary>
         /// Whether emails sent by Auth0 for change password, verification etc. should use your verified custom domain (true) or your auth0.com sub-domain (false). Affects all emails, links, and URLs. Email will fail if the custom domain is not verified.
         /// </summary>
         [JsonProperty("enable_custom_domain_in_emails")]
-        public bool EnableCustomDomainInEmails { get; set; }
-        
+        public bool? EnableCustomDomainInEmails { get; set; } = null;
+
         /// <summary>
         /// Whether the legacy /tokeninfo endpoint is enabled for your account (true) or unavailable (false).
         /// </summary>
         [JsonProperty("allow_legacy_tokeninfo_endpoint")]
-        public bool AllowLegacyTokeninfoEndpoint { get; set; }
-        
+        public bool? AllowLegacyTokeninfoEndpoint { get; set; } = null;
+
         /// <summary>
         /// Whether ID tokens and the userinfo endpoint includes a complete user profile (true) or only OpenID Connect claims (false).
         /// </summary>
         [JsonProperty("enable_legacy_profile")]
-        public bool EnableLegacyProfile { get; set; }
-        
+        public bool? EnableLegacyProfile { get; set; } = null;
+
         /// <summary>
         /// Whether ID tokens can be used to authorize some types of requests to API v2 (true) not not (false).
         /// </summary>
         [JsonProperty("enable_idtoken_api2")]
-        public bool EnableIdTokenApi2 { get; set; }
-        
+        public bool? EnableIdTokenApi2 { get; set; } = null;
+
         /// <summary>
         /// Whether the public sign up process shows a user_exists error (true) or a generic error (false) if the user already exists.
         /// </summary>
         [JsonProperty("enable_public_signup_user_exists_error")]
-        public bool EnablePublicSignupUserExistsError { get; set; }
-        
+        public bool? EnablePublicSignupUserExistsError { get; set; } = null;
+
         /// <summary>
         /// Whether the legacy delegation endpoint will be enabled for your account (true) or not available (false).
         /// </summary>
         [JsonProperty("allow_legacy_delegation_grant_types")]
-        public bool AllowLegacyDelegationGrantTypes { get; set; }
-        
+        public bool? AllowLegacyDelegationGrantTypes { get; set; } = null;
+
         /// <summary>
         /// Whether the legacy auth/ro endpoint (used with resource owner password and passwordless features) will be enabled for your account (true) or not available (false).
         /// </summary>
         [JsonProperty("allow_legacy_ro_grant_types")]
-        public bool AllowLegacyRoGrantTypes { get; set; }
-        
+        public bool? AllowLegacyRoGrantTypes { get; set; } = null;
+
         /// <summary>
         /// Whether users are prompted to confirm log in before SSO redirection (false) or are not prompted (true).
         /// </summary>
         [JsonProperty("enable_sso")]
-        public bool EnableSSO { get; set; }
-        
+        public bool? EnableSSO { get; set; } = null;
+
         /// <summary>
         /// Do not Publish Enterprise Connections Information with IdP domains on the lock configuration file.
         /// </summary>
         [JsonProperty("no_disclose_enterprise_connections")]
-        public bool NoDiscloseEnterpriseConnections { get; set; }
-        
+        public bool? NoDiscloseEnterpriseConnections { get; set; } = null;
+
         /// <summary>
         /// If true, SMS phone numbers will not be obfuscated in Management API GET calls.
         /// </summary>
         [JsonProperty("disable_management_api_sms_obfuscation")]
-        public bool DisableManagementApiSmsObfuscation { get; set; }
-        
+        public bool? DisableManagementApiSmsObfuscation { get; set; } = null;
+
         /// <summary>
         /// Enforce client authentication for passwordless start
         /// </summary>
         [JsonProperty("enforce_client_authentication_on_passwordless_start")]
-        public bool EnforceClientAuthenticationOnPasswordlessStart { get; set; }
-        
+        public bool? EnforceClientAuthenticationOnPasswordlessStart { get; set; } = null;
+
         /// <summary>
         /// Changes email_verified behavior for Azure AD/ADFS connections when enabled. Sets email_verified to false otherwise.
         /// </summary>
         [JsonProperty("trust_azure_adfs_email_verified_connection_property")]
-        public bool TrustAzureAdfsEmailVerifiedConnectionProperty { get; set; }
-        
+        public bool? TrustAzureAdfsEmailVerifiedConnectionProperty { get; set; } = null;
+
         /// <summary>
         /// Enables the email verification flow during login for Azure AD and ADFS connections
         /// </summary>
         [JsonProperty("enable_adfs_waad_email_verification")]
-        public bool EnabdleAdfsWaadEmailVerification { get; set; }
-        
+        public bool? EnabdleAdfsWaadEmailVerification { get; set; } = null;
+
         /// <summary>
         /// Delete underlying grant when a Refresh Token is revoked via the Authentication API.
         /// </summary>
         [JsonProperty("revoke_refresh_token_grant")]
-        public bool RovokeRefreshTokenGrant { get; set; }
+        public bool? RevokeRefreshTokenGrant { get; set; } = null;
     }
 }

--- a/src/Auth0.ManagementApi/Models/TenantFlags.cs
+++ b/src/Auth0.ManagementApi/Models/TenantFlags.cs
@@ -119,7 +119,7 @@ namespace Auth0.ManagementApi.Models
         /// Enables the email verification flow during login for Azure AD and ADFS connections
         /// </summary>
         [JsonProperty("enable_adfs_waad_email_verification")]
-        public bool? EnabdleAdfsWaadEmailVerification { get; set; } = null;
+        public bool? EnableAdfsWaadEmailVerification { get; set; } = null;
 
         /// <summary>
         /// Delete underlying grant when a Refresh Token is revoked via the Authentication API.

--- a/src/Auth0.ManagementApi/Models/TenantFlags.cs
+++ b/src/Auth0.ManagementApi/Models/TenantFlags.cs
@@ -36,5 +36,80 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("disable_clickjack_protection_headers")]
         public bool DisableClickjackProtectionHeaders { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enable_dynamic_client_registration")]
+        public bool EnableDynamicClientRegistration { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enable_custom_domain_in_emails")]
+        public bool EnableCustomDomainInEmails { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("allow_legacy_tokeninfo_endpoint")]
+        public bool AllowLegacyTokeninfoEndpoint { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enable_legacy_profile")]
+        public bool EnableLegacyProfile { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enable_idtoken_api2")]
+        public bool EnableIdTokenApi2 { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enable_public_signup_user_exists_error")]
+        public bool EnablePublicSignupUserExistsError { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("allow_legacy_delegation_grant_types")]
+        public bool AllowLegacyDelegationGrantTypes { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("allow_legacy_ro_grant_types")]
+        public bool AllowLegacyRoGrantTypes { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enable_sso")]
+        public bool EnableSSO { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("no_disclose_enterprise_connections")]
+        public bool NoDiscloseEnterpriseConnections { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("disable_management_api_sms_obfuscation")]
+        public bool DisableManagementApiSmsObfuscation { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enforce_client_authentication_on_passwordless_start")]
+        public bool EnforceClientAuthenticationOnPasswordlessStart { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("trust_azure_adfs_email_verified_connection_property")]
+        public bool TrustAzureAdfsEmailVerifiedConnectionProperty { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("enable_adfs_waad_email_verification")]
+        public bool EnabdleAdfsWaadEmailVerification { get; set; }
+        
+        /// <summary>
+        /// </summary>
+        [JsonProperty("revoke_refresh_token_grant")]
+        public bool RovokeRefreshTokenGrant { get; set; }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
@@ -63,7 +63,18 @@ namespace Auth0.ManagementApi.IntegrationTests
                 };
 
                 var settingsUpdateResponse = await apiClient.TenantSettings.UpdateAsync(settingsUpdateRequest);
-                settingsUpdateResponse.Should().BeEquivalentTo(settingsUpdateRequest, options => options.Excluding(p => p.SandboxVersion).Excluding(p => p.SandboxVersionsAvailable));
+
+                settingsUpdateResponse.Should().BeEquivalentTo(settingsUpdateRequest, options => options
+                    .Excluding(p => p.Flags)
+                    .Excluding(p => p.SandboxVersion)
+                    .Excluding(p => p.SandboxVersionsAvailable)
+                );
+
+                settingsUpdateResponse.Flags.ChangePwdFlowV1.Should().BeFalse();
+                settingsUpdateResponse.Flags.DisableClickjackProtectionHeaders.Should().BeTrue();
+                settingsUpdateResponse.Flags.EnableAPIsSection.Should().BeTrue();
+                settingsUpdateResponse.Flags.EnableClientConnections.Should().BeFalse();
+                settingsUpdateResponse.Flags.EnablePipeline2.Should().BeTrue();
 
                 var resetUpdateRequest = new TenantSettingsUpdateRequest
                 {


### PR DESCRIPTION
The PR syncs the TenantFlags class with the available flags on the API v2 based on https://auth0.com/docs/api/management/v2#!/Tenants/get_settings

Closes #465