### PR TITLE
Update Docs for GetUsersRequest regarding Connection and SearchEngine

### DIFF
--- a/src/Auth0.ManagementApi/Models/GetUsersRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetUsersRequest.cs
@@ -6,7 +6,8 @@
     public class GetUsersRequest
     {
         /// <summary>
-        /// The connection to filter on.
+        /// Connection filter. Only applies when <see cref="SearchEngine"/> is set to v1. 
+        /// To filter by connection with <see cref="SearchEngine"/> set to v2 or v3, set <see cref="Query"/> to identities.connection:"connection_name" instead.
         /// </summary>
         public string Connection { get; set; } = null;
 


### PR DESCRIPTION
According to the docs of API v2 (https://auth0.com/docs/api/management/v2#!/Users/get_users), Connection is only taken into account when using SearchEngine v1, this was not reflected in our API docs.

![image](https://user-images.githubusercontent.com/2146903/106433049-f042f700-646f-11eb-857b-27b4250ac3be.png)


Closes #466

