### PR TITLE
Ensure await is using ConfigureAwait

### DIFF
--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
@@ -16,7 +16,7 @@ namespace Auth0.AuthenticationApi
             if (string.IsNullOrWhiteSpace(idToken))
                 throw new IdTokenValidationException("ID token is required but missing.");
 
-            var verifiedToken = await DecodeSignedToken(requirements, idToken, clientSecret);
+            var verifiedToken = await DecodeSignedToken(requirements, idToken, clientSecret).ConfigureAwait(false);
             IdTokenClaimValidator.AssertClaimsMeetRequirements(requirements, verifiedToken, pointInTime ?? DateTime.Now);
         }
 

--- a/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
@@ -11,7 +11,7 @@ namespace Auth0.AuthenticationApi.Tokens
         public static async Task<JsonWebKeySet> GetForIssuer(string issuer)
         {
             var metadataAddress = new UriBuilder(issuer) { Path = "/.well-known/openid-configuration" }.Uri.OriginalString;
-            var openIdConfiguration = await GetOpenIdConfiguration(metadataAddress);
+            var openIdConfiguration = await GetOpenIdConfiguration(metadataAddress).ConfigureAwait(false);
             return openIdConfiguration.JsonWebKeySet;
         }
 

--- a/src/Auth0.Core/Exceptions/ApiException.cs
+++ b/src/Auth0.Core/Exceptions/ApiException.cs
@@ -58,7 +58,7 @@ namespace Auth0.Core.Exceptions
                 case 429:
                     return RateLimitApiException.Create(response);
                 default:
-                    return await ErrorApiException.CreateAsync(response);
+                    return await ErrorApiException.CreateAsync(response).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Our SDK is using `ConfigureAwait(false)` on all `await` calls except for these 3.

Normally, when using async code, the next code is executed on the calling thread. However, in a library that shouldn't be required, so avoiding that has some improvements in terms of performance and deadlocks. Avoiding that can be done by using `ConfigureAwait(false)`.

Adding some text from https://devblogs.microsoft.com/dotnet/configureawait-faq/

> ConfigureAwait(continueOnCapturedContext: false) is used to avoid forcing the callback to be invoked on the original context or scheduler. This has a few benefits:
> 
> **Improving performance**. There is a cost to queueing the callback rather than just invoking it, both because there’s extra work (and typically extra allocation) involved, but also because it means certain optimizations we’d otherwise like to employ in the runtime can’t be used (we can do more optimization when we know exactly how the callback will be invoked, but if it’s handed off to an arbitrary implementation of an abstraction, we can sometimes be limited). For very hot paths, even the extra costs of checking for the current SynchronizationContext and the current TaskScheduler (both of which involve accessing thread statics) can add measurable overhead. If the code after an await doesn’t actually require running in the original context, using ConfigureAwait(false) can avoid all these costs: it won’t need to queue unnecessarily, it can utilize all the optimizations it can muster, and it can avoid the unnecessary thread static accesses.
> 
> **Avoiding deadlocks**. Consider a library method that uses await on the result of some network download. You invoke this method and synchronously block waiting for it to complete, such as by using .Wait() or .Result or .GetAwaiter().GetResult() off of the returned Task object. Now consider what happens if your invocation of it happens when the current SynchronizationContext is one that limits the number of operations that can be running on it to 1, whether explicitly via something like the MaxConcurrencySynchronizationContext shown earlier, or implicitly by this being a context that only has one thread that can be used, e.g. a UI thread. So you invoke the method on that one thread and then block it waiting for the operation to complete. The operation kicks off the network download and awaits it. Since by default awaiting a Task will capture the current SynchronizationContext, it does so, and when the network download completes, it queues back to the SynchronizationContext the callback that will invoke the remainder of the operation. But the only thread that can process the queued callback is currently blocked by your code blocking waiting on the operation to complete. And that operation won’t complete until the callback is processed. Deadlock! This can apply even when the context doesn’t limit the concurrency to just 1, but when the resources are limited in any fashion. Imagine the same situation, except using the MaxConcurrencySynchronizationContext with a limit of 4. And instead of making just one call to the operation, we queue to that context 4 invocations, each of which makes the call and blocks waiting for it to complete. We’ve now still blocked all of the resources while waiting for the async methods to complete, and the only thing that will allow those async methods to complete is if their callbacks can be processed by this context that’s already entirely consumed. Again, deadlock! If instead the library method had used ConfigureAwait(false), it would not queue the callback back to the original context, avoiding the deadlock scenarios. 