### PR TITLE
Change Guardian Factors test to expect 7 instead of 6 factors

### DIFF
--- a/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
@@ -30,7 +30,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var response = await _managementApiClient.Guardian.GetFactorsAsync();
 
-            response.Should().HaveCount(6);
+            response.Should().HaveCount(7);
         }
 
         [Fact]


### PR DESCRIPTION
Our CI has been failing for a while because of a misconfigured test that tests the Guardian Factors where it expected 6 factors while it should be 7.