### PR TITLE
[SDK-2400] Add support for Organizations

### DIFF
--- a/docs-source/index.md
+++ b/docs-source/index.md
@@ -155,7 +155,7 @@ var authorizationUrl = client.BuildAuthorizationUrl()
     .WithClient("abcdef")
     .WithRedirectUrl("https://www.myapp.com/redirect")
     .WithOrganization("YOUR_ORGANIZATION_ID")
-    .WithOrganization("YOUR_INVITATION_ID")
+    .WithInvitation("YOUR_INVITATION_ID")
     .Build();
 ```
 

--- a/docs-source/index.md
+++ b/docs-source/index.md
@@ -107,6 +107,58 @@ public ActionResult Login() {
 > [!IMPORTANT]
 > If you choose to use the @Auth0.AuthenticationApi.Builders.AuthorizationUrlBuilder to construct the authorization URL and implement a login flow callback yourself, it is important to generate and store a state value using @Auth0.AuthenticationApi.Builders.AuthorizationUrlBuilder.WithState(System.String) and validate it in your callback URL before calling exchanging the authorization code for the tokens.
 
+### Organizations (Closed Beta)
+
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+
+Using Organizations, you can:
+
+- Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
+
+- Manage their membership in a variety of ways, including user invitation.
+
+- Configure branded, federated login flows for each organization.
+
+- Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
+
+- Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
+
+Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
+
+#### Log in to an organization
+
+Log in to an organization by using `WithOrganization()` when building the Authorization URL:
+
+```
+var client = new AuthenticationApiClient("YOUR_AUTH0_DOMAIN");
+
+var authorizationUrl = client.BuildAuthorizationUrl()
+    .WithResponseType(AuthorizationResponseType.Code)
+    .WithClient("abcdef")
+    .WithRedirectUrl("https://www.myapp.com/redirect")
+    .WithOrganization("YOUR_ORGANIZATION_ID")
+    .Build();
+```
+
+> [!NOTE]
+> When logging in to an Organization it is important to ensure the `org_id` claim in the ID Token is validated by providing **the exact same** `organization` value when retrieving a token using @Auth0.AuthenticationApi.Models.AuthorizationCodePkceTokenRequest, @Auth0.AuthenticationApi.Models.AuthorizationCodeTokenRequest or @Auth0.AuthenticationApi.Models.RefreshTokenRequest.
+
+### Accept user invitations
+
+Accept a user invitation by using `WithInvitation()` when building the Authorization URL:
+
+```
+var client = new AuthenticationApiClient("YOUR_AUTH0_DOMAIN");
+
+var authorizationUrl = client.BuildAuthorizationUrl()
+    .WithResponseType(AuthorizationResponseType.Code)
+    .WithClient("abcdef")
+    .WithRedirectUrl("https://www.myapp.com/redirect")
+    .WithOrganization("YOUR_ORGANIZATION_ID")
+    .WithOrganization("YOUR_INVITATION_ID")
+    .Build();
+```
+
 ## Using the Management API
 
 This section will take your through the basics of using the Management API.

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -134,7 +134,7 @@ namespace Auth0.AuthenticationApi
                 body
             ).ConfigureAwait(false);
 
-            await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret).ConfigureAwait(false);
+            await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization).ConfigureAwait(false);
 
             return response;
         }
@@ -158,7 +158,7 @@ namespace Auth0.AuthenticationApi
                 body
             ).ConfigureAwait(false);
 
-            await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret).ConfigureAwait(false);
+            await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization).ConfigureAwait(false);
 
             return response;
         }
@@ -203,7 +203,7 @@ namespace Auth0.AuthenticationApi
                 body
             ).ConfigureAwait(false);
 
-            await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret).ConfigureAwait(false);
+            await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization).ConfigureAwait(false);
 
             return response;
         }
@@ -400,9 +400,9 @@ namespace Auth0.AuthenticationApi
             GC.SuppressFinalize(this);
         }
 
-        private Task AssertIdTokenValid(string idToken, string audience, JwtSignatureAlgorithm algorithm, string clientSecret)
+        private Task AssertIdTokenValid(string idToken, string audience, JwtSignatureAlgorithm algorithm, string clientSecret, string organization = null)
         {
-            var requirements = new IdTokenRequirements(algorithm, BaseUri.AbsoluteUri, audience, idTokenValidationLeeway);
+            var requirements = new IdTokenRequirements(algorithm, BaseUri.AbsoluteUri, audience, idTokenValidationLeeway, null, organization);
             return idTokenValidator.Assert(requirements, idToken, clientSecret);
         }
 

--- a/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
@@ -176,5 +176,15 @@ namespace Auth0.AuthenticationApi.Builders
         {
             return WithConnectionScope(String.Join(" ", connectionScope));
         }
+
+        /// <summary>
+        /// Adds the `organization` query string parameter.
+        /// </summary>
+        /// <param name="organization">The ID of the organization to which the user wants to authenticate.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        public AuthorizationUrlBuilder WithOrganization(string organization)
+        {
+            return WithValue("organization", organization);
+        }
     }
 }

--- a/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
@@ -180,7 +180,7 @@ namespace Auth0.AuthenticationApi.Builders
         /// <summary>
         /// Adds the `organization` query string parameter.
         /// </summary>
-        /// <param name="organization">The ID of the organization to which the user wants to authenticate.</param>
+        /// <param name="organization">The ID of the organization to log the user in to</param>
         /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
         public AuthorizationUrlBuilder WithOrganization(string organization)
         {

--- a/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
@@ -186,5 +186,15 @@ namespace Auth0.AuthenticationApi.Builders
         {
             return WithValue("organization", organization);
         }
+
+        /// <summary>
+        /// Adds the `invitation` query string parameter.
+        /// </summary>
+        /// <param name="invitation">The Id of an invitation to accept. This is available from the URL that is given when participating in a user invitation flow.</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        public AuthorizationUrlBuilder WithInvitation(string invitation)
+        {
+            return WithValue("invitation", invitation);
+        }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
@@ -33,5 +33,13 @@
         /// Optional except when using <see cref="AuthorizationCodeRequestBase"/>.
         /// </remarks>
         public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// Organization for Id Token verification.
+        /// </summary>
+        /// <remarks>
+        /// Optional except when using <see cref="AuthorizationCodeRequestBase"/>.
+        /// </remarks>
+        public string Organization { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
@@ -37,9 +37,6 @@
         /// <summary>
         /// Organization for Id Token verification.
         /// </summary>
-        /// <remarks>
-        /// Optional except when using <see cref="AuthorizationCodeRequestBase"/>.
-        /// </remarks>
         public string Organization { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
@@ -40,5 +40,10 @@
         /// of Id Tokens.
         /// </summary>
         public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+
+        /// <summary>
+        /// Organization for Id Token verification.
+        /// </summary>
+        public string Organization { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Tokens/Auth0ClaimNames.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/Auth0ClaimNames.cs
@@ -1,0 +1,10 @@
+﻿namespace Auth0.AuthenticationApi.Tokens
+{
+    /// <summary>
+    /// List of Auth0 specific claims
+    /// </summary>
+    internal static class Auth0ClaimNames
+    {
+        internal static string Organization = "org_id"; 
+    }
+}

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
@@ -91,13 +91,13 @@ namespace Auth0.AuthenticationApi.Tokens
             }
 
             // Organization
-            if (required.Organization != null)
+            if (!string.IsNullOrWhiteSpace(required.Organization))
             {
-                var organizationClaimValue = token.Claims.SingleOrDefault(c => c.Type == "org_id")?.Value;
-                if (string.IsNullOrWhiteSpace(organizationClaimValue))
+                var organization = GetClaimValue(token.Claims, Auth0ClaimNames.Organization);
+                if (string.IsNullOrWhiteSpace(organization))
                     throw new IdTokenValidationException("Organization claim must be a string present in the ID token.");
-                if (organizationClaimValue != required.Organization)
-                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organizationClaimValue}\".");
+                if (organization != required.Organization)
+                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organization}\".");
             }
 
         }
@@ -114,6 +114,20 @@ namespace Auth0.AuthenticationApi.Tokens
             if (claim == null) return null;
 
             return (long)Convert.ToDouble(claim.Value, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Get the value for a given claim.
+        /// </summary>
+        /// <param name="claims"><see cref="IEnumerable{Claim}"/>Claims to search the <paramref name="claimType"/> for.</param>
+        /// <param name="claimType">Type of claim to search the <paramref name="claims"/> for. See <see cref="JwtRegisteredClaimNames"/> or <see cref="Auth0ClaimNames"/> for possible names.</param>
+        /// <returns><see cref="string"/> containing the value or <see langword="null"/> if no matching value was found.</returns>
+        private static string GetClaimValue(IEnumerable<Claim> claims, string claimType)
+        {
+            var claim = claims.SingleOrDefault(t => t.Type == claimType);
+            if (claim == null) return null;
+
+            return claim.Value;
         }
     }
 }

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
@@ -89,6 +89,17 @@ namespace Auth0.AuthenticationApi.Tokens
                 if (epochNow > authValidUntil)
                     throw new IdTokenValidationException($"Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time ({epochNow}) is after last auth at {authValidUntil}.");
             }
+
+            // Organization
+            if (required.Organization != null)
+            {
+                var organizationClaimValue = token.Claims.SingleOrDefault(c => c.Type == "org_id")?.Value;
+                if (string.IsNullOrWhiteSpace(organizationClaimValue))
+                    throw new IdTokenValidationException("Organization claim must be a string present in the ID token.");
+                if (organizationClaimValue != required.Organization)
+                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organizationClaimValue}\".");
+            }
+
         }
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
@@ -39,6 +39,11 @@ namespace Auth0.AuthenticationApi.Tokens
         public TimeSpan Leeway;
 
         /// <summary>
+        /// Optional organization the token must be for.
+        /// </summary>
+        public string Organization;
+
+        /// <summary>
         /// Create a new instance of <see cref="IdTokenRequirements"/> with specified parameters.
         /// </summary>
         /// <param name="signatureAlgorithm"><see cref="JwtSignatureAlgorithm"/> the id token must be signed with.</param>
@@ -47,13 +52,14 @@ namespace Auth0.AuthenticationApi.Tokens
         /// <param name="leeway">Amount of leeway in validating date and time claims to allow some clock variance
         /// between the issuer and the application.</param>
         /// <param name="maxAge">Optional maximum time since the user last authenticated.</param>
-        public IdTokenRequirements(JwtSignatureAlgorithm signatureAlgorithm, string issuer, string audience, TimeSpan leeway, TimeSpan? maxAge = null)
+        public IdTokenRequirements(JwtSignatureAlgorithm signatureAlgorithm, string issuer, string audience, TimeSpan leeway, TimeSpan? maxAge = null, string organization = null)
         {
             SignatureAlgorithm = signatureAlgorithm;
             Issuer = issuer;
             Audience = audience;
             Leeway = leeway;
             MaxAge = maxAge;
+            Organization = organization;
         }
     }
 }

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
@@ -39,7 +39,7 @@ namespace Auth0.AuthenticationApi.Tokens
         public TimeSpan Leeway;
 
         /// <summary>
-        /// Optional organization the token must be for.
+        /// Optional organization (org_id) the token must be for.
         /// </summary>
         public string Organization;
 

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
@@ -65,6 +65,29 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Builders
         }
 
         [Fact]
+        public void Can_build_authorization_uri_with_organization()
+        {
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            var authorizationUrl = authenticationApiClient.BuildAuthorizationUrl()
+                .WithResponseType(AuthorizationResponseType.Code)
+                .WithClient("rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW")
+                .WithConnection("google-oauth2")
+                .WithRedirectUrl("http://www.jerriepelser.com/test")
+                .WithScope("openid offline_access")
+                .WithAudience("https://myapi.com/v2")
+                .WithNonce("MyNonce")
+                .WithState("MyState")
+                .WithConnectionScope("ConnectionScope")
+                .WithOrganization("123")
+                .Build();
+
+            authorizationUrl.Should()
+                .Be(
+                    new Uri("https://dx-sdks-testing.us.auth0.com/authorize?response_type=code&client_id=rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW&connection=google-oauth2&redirect_uri=http%3A%2F%2Fwww.jerriepelser.com%2Ftest&scope=openid%20offline_access&audience=https%3A%2F%2Fmyapi.com%2Fv2&nonce=MyNonce&state=MyState&connection_scope=ConnectionScope&organization=123"));
+        }
+
+        [Fact]
         public void Can_provide_multiple_response_type()
         {
             var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
@@ -72,19 +72,37 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Builders
             var authorizationUrl = authenticationApiClient.BuildAuthorizationUrl()
                 .WithResponseType(AuthorizationResponseType.Code)
                 .WithClient("rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW")
-                .WithConnection("google-oauth2")
                 .WithRedirectUrl("http://www.jerriepelser.com/test")
                 .WithScope("openid offline_access")
-                .WithAudience("https://myapi.com/v2")
                 .WithNonce("MyNonce")
                 .WithState("MyState")
-                .WithConnectionScope("ConnectionScope")
                 .WithOrganization("123")
                 .Build();
 
             authorizationUrl.Should()
                 .Be(
-                    new Uri("https://dx-sdks-testing.us.auth0.com/authorize?response_type=code&client_id=rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW&connection=google-oauth2&redirect_uri=http%3A%2F%2Fwww.jerriepelser.com%2Ftest&scope=openid%20offline_access&audience=https%3A%2F%2Fmyapi.com%2Fv2&nonce=MyNonce&state=MyState&connection_scope=ConnectionScope&organization=123"));
+                    new Uri("https://dx-sdks-testing.us.auth0.com/authorize?response_type=code&client_id=rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW&redirect_uri=http%3A%2F%2Fwww.jerriepelser.com%2Ftest&scope=openid%20offline_access&nonce=MyNonce&state=MyState&organization=123"));
+        }
+
+        [Fact]
+        public void Can_build_authorization_uri_with_invitation()
+        {
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            var authorizationUrl = authenticationApiClient.BuildAuthorizationUrl()
+                .WithResponseType(AuthorizationResponseType.Code)
+                .WithClient("rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW")
+                .WithRedirectUrl("http://www.jerriepelser.com/test")
+                .WithScope("openid offline_access")
+                .WithNonce("MyNonce")
+                .WithState("MyState")
+                .WithOrganization("123")
+                .WithInvitation("456")
+                .Build();
+
+            authorizationUrl.Should()
+                .Be(
+                    new Uri("https://dx-sdks-testing.us.auth0.com/authorize?response_type=code&client_id=rLNKKMORlaDzrMTqGtSL9ZSXiBBksCQW&redirect_uri=http%3A%2F%2Fwww.jerriepelser.com%2Ftest&scope=openid%20offline_access&nonce=MyNonce&state=MyState&organization=123&invitation=456"));
         }
 
         [Fact]


### PR DESCRIPTION
This PR adds support for Organizations and user invitation:

- Allow to specify `organization` and `invitation` parameters when building the Authorize URL
- Allow to pass the `organization` to `GetTokenAsync` when called for either `AuthorizationCodePkceTokenRequest`, `AuthorizationCodeTokenRequest` or `RefreshTokenRequest`. Doing so will ensure the `org_id` claim in the retrieved ID Token is validated against the provided `organization` value.
- Update the docs to show how `organization` and `invitation` can be configured when using the AuthorizeUrlBuilder
- Adds a note on the fact that the exact same `organization` value should be configured when using either `AuthorizationCodePkceTokenRequest`, `AuthorizationCodeTokenRequest` or `RefreshTokenRequest`