### PR TITLE
Set ClientSecret if defined when using PKCE

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -152,6 +152,11 @@ namespace Auth0.AuthenticationApi
                 { "code_verifier", request.CodeVerifier },
                 { "redirect_uri", request.RedirectUri } };
 
+            if (!string.IsNullOrEmpty(request.ClientSecret))
+            {
+                body.Add("client_secret", request.ClientSecret);
+            }
+
             var response = await connection.SendAsync<AccessTokenResponse>(
                 HttpMethod.Post,
                 tokenUri,


### PR DESCRIPTION
ClientSecret is not set when using PKCE, however this is required when using PKCE from a Web Application such as ASP.NET MVC.