### PR TITLE
Make GuardianFactor serialization a bit more resilient to new factor names

### DIFF
--- a/src/Auth0.ManagementApi/Models/GuardianFactor.cs
+++ b/src/Auth0.ManagementApi/Models/GuardianFactor.cs
@@ -1,5 +1,7 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Serialization;
 
 namespace Auth0.ManagementApi.Models
 {
@@ -23,5 +25,16 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("trial_expired")]
         public bool? IsTrialExpired { get; set; }
+
+        [OnError]
+        internal void OnError(StreamingContext context, ErrorContext errorContext)
+        {
+            // When the GuardianFactorName enum can not be serialized, set the value to null (as name is a nullable property)
+            // This ensures the code does not break when new factor names are added in Auth0 Server that are not part of the enum yet.
+            if (errorContext.Member != null && errorContext.Member.ToString() == "name")
+            {
+                errorContext.Handled = true;
+            }
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Models/GuardianFactorName.cs
+++ b/src/Auth0.ManagementApi/Models/GuardianFactorName.cs
@@ -23,6 +23,9 @@ namespace Auth0.ManagementApi.Models
         WebAuthnRoaming,
         
         [EnumMember(Value="webauthn-platform")]
-        WebAuthnPlatform
+        WebAuthnPlatform,
+
+        [EnumMember(Value= "recovery-code")]
+        RecoveryCode
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
@@ -30,7 +30,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var response = await _managementApiClient.Guardian.GetFactorsAsync();
 
-            response.Should().HaveCount(7);
+            response.Should().HaveCount(8);
         }
 
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
@@ -31,6 +31,11 @@ namespace Auth0.ManagementApi.IntegrationTests
             var response = await _managementApiClient.Guardian.GetFactorsAsync();
 
             response.Should().HaveCount(8);
+
+            foreach (var guardianFactor in response)
+            {
+                guardianFactor.Name.Should().NotBeNull();
+            }
         }
 
         [Fact]


### PR DESCRIPTION
Both our SDK (at least the `Guardian.GetFactorsAsync();` method) and our tests are broken as Auth0 Server supports another Factor Name that can not be mapped to our enum.

Ideally, we wouldn't use an enum here (but use a string instead) to be able to always map any new factor name, but that would be a breaking change.

This PR ensures the code doesn't break at run time, setting the `name` to `null` when it can not map it. 
It also fixes the tests for now, however, our tests would still fail when a new one gets added so we should catch this ourselves rather fast and update our enum.