### PR TITLE
Ensure CustomDomainVerification.Methods can be serialized

### DIFF
--- a/src/Auth0.ManagementApi/Models/CustomDomainVerification.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainVerification.cs
@@ -11,6 +11,6 @@ namespace Auth0.ManagementApi.Models
         /// The custom domain verification methods.
         /// </summary>
         [JsonProperty("methods")]
-        public string[] Methods { get; set; }
+        public CustomDomainVerificationMethod[] Methods { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/CustomDomainVerificationMethod.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomainVerificationMethod.cs
@@ -1,0 +1,28 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The custom domain verification method.
+    /// </summary>
+    public class CustomDomainVerificationMethod
+    {
+        /// <summary>
+        /// Domain verification method. ("cname" or "txt")
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Value used to verify the domain.
+        /// </summary>
+        [JsonProperty("record")]
+        public string Record { get; set; }
+
+        /// <summary>
+        /// The name of the txt record for verification.
+        /// </summary>
+        [JsonProperty("domain")]
+        public string Domain { get; set; }
+    }
+}


### PR DESCRIPTION
The Methods property on the CustomDomainVerification type was defined as an array of strings, while its actually an array of objects, see https://auth0.com/docs/api/management/v2#!/Custom_Domains/get_custom_domains.

This PR doesn't add tests as we already have a test in place for this, but its configured to only run manually. I manually run the test to verify it works as expected now.

Fixes #508