### PR TITLE
Add connection property to OrganizationConnection

### DIFF
--- a/src/Auth0.ManagementApi/Models/OrganizationConnection.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnection.cs
@@ -16,5 +16,10 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("assign_membership_on_login")]
         public bool AssignMembershipOnLogin { get; set; }
 
+        /// <summary>
+        /// Information on the enabled connection
+        /// </summary>
+        [JsonProperty("connection")]
+        public OrganizationConnectionInfo Connection { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/OrganizationConnectionInfo.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnectionInfo.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Information on the enabled connection for an Organization
+    /// </summary>
+    public class OrganizationConnectionInfo
+    {
+        /// <summary>
+        /// The name of the enabled connection.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The strategy of the enabled connection.
+        /// </summary>
+        [JsonProperty("strategy")]
+        public string Strategy { get; set; }
+    }
+}


### PR DESCRIPTION
### Changes

The `Connection` property was missing on the `OrganizationConnection`, but it is returned with the following responses:

- https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections
- https://auth0.com/docs/api/management/v2#!/Organizations/post_enabled_connections
- https://auth0.com/docs/api/management/v2#!/Organizations/get_enabled_connections_by_connectionId
- https://auth0.com/docs/api/management/v2#!/Organizations/patch_enabled_connections_by_connectionId

### References
Closes #502
