### PR TITLE
Ensure Checkpoint Pagination works when no next is returned

### DIFF
--- a/src/Auth0.ManagementApi/Paging/CheckpointPagedListConverter.cs
+++ b/src/Auth0.ManagementApi/Paging/CheckpointPagedListConverter.cs
@@ -37,10 +37,7 @@ namespace Auth0.ManagementApi.Paging
                 {
                     var collection = item[_collectionFieldName].ToObject<IList<T>>(serializer);
 
-                    if (item["next"] != null)
-                    {
-                        return new CheckpointPagedList<T>(collection, new CheckpointPagingInformation(item["next"].Value<string>()));
-                    }
+                    return new CheckpointPagedList<T>(collection, new CheckpointPagingInformation(item["next"]?.Value<string>()));
                 }
                 else if (_collectionInDictionary) // Special case to handle User Logs which is returned as a dictionary and not an array
                 {

--- a/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
@@ -326,15 +326,19 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             });
 
-
             var firstCheckPointPaginationRequest = await _apiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(1));
             var secondCheckPointPaginationRequest = await _apiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(1, firstCheckPointPaginationRequest.Paging.Next));
 
             secondCheckPointPaginationRequest.Count.Should().Be(1);
             secondCheckPointPaginationRequest.Paging.Next.Should().NotBeNullOrEmpty();
 
+            var checkpointPagingationRequestWithoutNext = await _apiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(50));
+            checkpointPagingationRequestWithoutNext.Count.Should().Be(2);
+            checkpointPagingationRequestWithoutNext.Paging.Next.Should().BeNullOrEmpty();
+
             await _apiClient.Users.DeleteAsync(user1.UserId);
             await _apiClient.Users.DeleteAsync(user2.UserId);
+            await _apiClient.Roles.DeleteAsync(role.Id);
         }
 
         [Fact]


### PR DESCRIPTION
Checkpoint pagination calls weren't returning the results when no `next` property is returned in the response, breaking all last pages.

This PR ensures it returns the data as expected.