### PR TITLE
Add missing constructor Argument to AuthenticationApiClient docs

### DIFF
--- a/docs/api/Auth0.AuthenticationApi.AuthenticationApiClient.html
+++ b/docs/api/Auth0.AuthenticationApi.AuthenticationApiClient.html
@@ -158,8 +158,8 @@ Defaults to a freshly created <a class="xref" href="Auth0.AuthenticationApi.Http
   <h5 id="Auth0_AuthenticationApi_AuthenticationApiClient__ctor_System_String_Auth0_AuthenticationApi_IAuthenticationConnection__remarks">Remarks</h5>
   <div class="markdown level1 remarks"><p>To use a custom <span class="xref">System.Net.Http.HttpClient</span> or <span class="xref">System.Net.Http.HttpMessageHandler</span> create a 
 <a class="xref" href="Auth0.AuthenticationApi.HttpClientAuthenticationConnection.html">HttpClientAuthenticationConnection</a> passing that into the constructor. e.g.</p>
-<pre><code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpClient));</code></pre> or
-<pre><code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpMessageHandler));</code></pre> or
+<pre><code>var client = new AuthenticationApiClient(domain, new HttpClientAuthenticationConnection(myHttpClient));</code></pre> or
+<pre><code>var client = new AuthenticationApiClient(domain, new HttpClientAuthenticationConnection(myHttpMessageHandler));</code></pre> or
 </div>
   <a id="Auth0_AuthenticationApi_AuthenticationApiClient__ctor_" data-uid="Auth0.AuthenticationApi.AuthenticationApiClient.#ctor*"></a>
   <h4 id="Auth0_AuthenticationApi_AuthenticationApiClient__ctor_System_Uri_Auth0_AuthenticationApi_IAuthenticationConnection_" data-uid="Auth0.AuthenticationApi.AuthenticationApiClient.#ctor(System.Uri,Auth0.AuthenticationApi.IAuthenticationConnection)">AuthenticationApiClient(Uri, IAuthenticationConnection)</h4>
@@ -198,8 +198,8 @@ Defaults to a freshly created <a class="xref" href="Auth0.AuthenticationApi.Http
   <h5 id="Auth0_AuthenticationApi_AuthenticationApiClient__ctor_System_Uri_Auth0_AuthenticationApi_IAuthenticationConnection__remarks">Remarks</h5>
   <div class="markdown level1 remarks"><p>To use a custom <span class="xref">System.Net.Http.HttpClient</span> or <span class="xref">System.Net.Http.HttpMessageHandler</span> create a 
 <a class="xref" href="Auth0.AuthenticationApi.HttpClientAuthenticationConnection.html">HttpClientAuthenticationConnection</a> passing that into the constructor. e.g.</p>
-<pre><code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpClient));</code></pre> or
-<pre><code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpMessageHandler));</code></pre> or
+<pre><code>var client = new AuthenticationApiClient(baseUri, new HttpClientAuthenticationConnection(myHttpClient));</code></pre> or
+<pre><code>var client = new AuthenticationApiClient(baseUri, new HttpClientAuthenticationConnection(myHttpMessageHandler));</code></pre> or
 </div>
   <h3 id="fields">Fields
   </h3>

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -34,8 +34,8 @@ namespace Auth0.AuthenticationApi
         /// Defaults to a freshly created <see cref="HttpClientAuthenticationConnection"/> that uses a single <see cref="HttpClient"/>.</param>
         /// <remarks>To use a custom <see cref="HttpClient"/> or <see cref="HttpMessageHandler"/> create a 
         /// <see cref="HttpClientAuthenticationConnection"/> passing that into the constructor. e.g.
-        /// <code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpClient));</code> or
-        /// <code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpMessageHandler));</code> or
+        /// <code>var client = new AuthenticationApiClient(baseUri, new HttpClientAuthenticationConnection(myHttpClient));</code> or
+        /// <code>var client = new AuthenticationApiClient(baseUri, new HttpClientAuthenticationConnection(myHttpMessageHandler));</code> or
         /// </remarks>
         public AuthenticationApiClient(Uri baseUri, IAuthenticationConnection connection = null)
         {
@@ -62,8 +62,8 @@ namespace Auth0.AuthenticationApi
         /// Defaults to a freshly created <see cref="HttpClientAuthenticationConnection"/> that uses a single <see cref="HttpClient"/>.</param>
         /// <remarks>To use a custom <see cref="HttpClient"/> or <see cref="HttpMessageHandler"/> create a 
         /// <see cref="HttpClientAuthenticationConnection"/> passing that into the constructor. e.g.
-        /// <code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpClient));</code> or
-        /// <code>var client = new AuthenticationApiClient(new HttpClientAuthenticationConnection(myHttpMessageHandler));</code> or
+        /// <code>var client = new AuthenticationApiClient(domain, new HttpClientAuthenticationConnection(myHttpClient));</code> or
+        /// <code>var client = new AuthenticationApiClient(domain, new HttpClientAuthenticationConnection(myHttpMessageHandler));</code> or
         /// </remarks>
         public AuthenticationApiClient(string domain, IAuthenticationConnection connection = null)
             : this(new Uri($"https://{domain}"), connection)


### PR DESCRIPTION
The generated docs for AuthenticationApiClient has an incorrect code snippet, as it is missing a constructor argument.

Closes #523
