### PR TITLE
[SDK-2548] Support unpaginated requests for some endpoints

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
@@ -56,22 +56,25 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A <see cref="IPagedList{ClientGrant}"/> containing the client grants requested.</returns>
-        public Task<IPagedList<ClientGrant>> GetAllAsync(GetClientGrantsRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<ClientGrant>> GetAllAsync(GetClientGrantsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
-            return Connection.GetAsync<IPagedList<ClientGrant>>(BuildUri("client-grants",
-                new Dictionary<string, string>
-                {
-                    {"audience", request.Audience},
-                    {"client_id", request.ClientId},
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, converters, cancellationToken);
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"audience", request.Audience},
+                {"client_id", request.ClientId},
+            };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<ClientGrant>>(BuildUri("client-grants", queryStrings), DefaultHeaders, converters, cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -57,23 +57,25 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{Client}"/> containing the clients.</returns>
-        public Task<IPagedList<Client>> GetAllAsync(GetClientsRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<Client>> GetAllAsync(GetClientsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
             var queryStrings = new Dictionary<string, string>
             {
                 {"fields", request.Fields},
                 {"include_fields", request.IncludeFields?.ToString().ToLower()},
                 {"is_global", request.IsGlobal?.ToString().ToLower()},
-                {"is_first_party", request.IsFirstParty?.ToString().ToLower()},
-                {"page", pagination.PageNo.ToString()},
-                {"per_page", pagination.PerPage.ToString()},
-                {"include_totals", pagination.IncludeTotals.ToString().ToLower()},
+                {"is_first_party", request.IsFirstParty?.ToString().ToLower()}
             };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
 
             if (request.AppType != null)
                 queryStrings.Add("app_type", string.Join(",", request.AppType.Select(ExtensionMethods.ToEnumString)));

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -90,22 +90,24 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{Connection}"/> containing the list of connections.</returns>
-        public Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
             var queryStrings = new Dictionary<string, string>
             {
                 {"fields", request.Fields},
                 {"include_fields", request.IncludeFields?.ToString().ToLower()},
                 {"name", request.Name},
-                {"page", pagination.PageNo.ToString()},
-                {"per_page", pagination.PerPage.ToString()},
-                {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
             };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
 
             // Add each strategy as a separate querystring
             if (request.Strategy != null)

--- a/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
@@ -58,13 +58,10 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A list of <see cref="DeviceCredential"/> which conforms to the criteria specified.</returns>
-        public Task<IPagedList<DeviceCredential>> GetAllAsync(GetDeviceCredentialsRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<DeviceCredential>> GetAllAsync(GetDeviceCredentialsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
             var queryStrings = new Dictionary<string, string>
                 {
@@ -73,10 +70,14 @@ namespace Auth0.ManagementApi.Clients
                     {"user_id", request.UserId},
                     {"client_id", request.ClientId},
                     {"type", request.Type},
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
                 };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
 
             return Connection.GetAsync<IPagedList<DeviceCredential>>(BuildUri("device-credentials", queryStrings), DefaultHeaders, converters, cancellationToken);
         }

--- a/src/Auth0.ManagementApi/Clients/HooksClient.cs
+++ b/src/Auth0.ManagementApi/Clients/HooksClient.cs
@@ -56,23 +56,27 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{T}"/> containing the hooks requested.</returns>
-        public Task<IPagedList<Hook>> GetAllAsync(GetHooksRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<Hook>> GetAllAsync(GetHooksRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
+
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"enabled", request.Enabled?.ToString().ToLower()},
+                {"fields", request.Fields},
+                {"triggerId", request.TriggerId},
+            };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
 
             return Connection.GetAsync<IPagedList<Hook>>(BuildUri("hooks",
-                new Dictionary<string, string>
-                {
-                    {"enabled", request.Enabled?.ToString().ToLower()},
-                    {"fields", request.Fields},
-                    {"triggerId", request.TriggerId },
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, hooksConverters, cancellationToken);
+                queryStrings), DefaultHeaders, hooksConverters, cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/LogsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/LogsClient.cs
@@ -33,26 +33,29 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{LogEntry}"/> containing the list of log entries.</returns>
-        public Task<IPagedList<LogEntry>> GetAllAsync(GetLogsRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<LogEntry>> GetAllAsync(GetLogsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
-            return Connection.GetAsync<IPagedList<LogEntry>>(BuildUri("logs",
-                new Dictionary<string, string>
-                {
-                    {"sort", request.Sort},
-                    {"fields", request.Fields},
-                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
-                    {"from", request.From},
-                    {"take", request.Take?.ToString().ToLower()},
-                    {"q", request.Query},
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, converters, cancellationToken);
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"sort", request.Sort},
+                {"fields", request.Fields},
+                {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                {"from", request.From},
+                {"take", request.Take?.ToString().ToLower()},
+                {"q", request.Query},
+            };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<LogEntry>>(BuildUri("logs", queryStrings), DefaultHeaders, converters, cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
@@ -66,15 +66,15 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A <see cref="IPagedList{ResourceServer}"/> containing the list of resource servers.</returns>
-        public Task<IPagedList<ResourceServer>> GetAllAsync(PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<ResourceServer>> GetAllAsync(PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             return Connection.GetAsync<IPagedList<ResourceServer>>(BuildUri("resource-servers",
-                new Dictionary<string, string>
+                pagination != null ? new Dictionary<string, string>
                 {
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, converters, cancellationToken);
+                } : null), DefaultHeaders, converters, cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/RulesClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RulesClient.cs
@@ -56,24 +56,27 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{Rule}"/> containing the rules requested.</returns>
-        public Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<Rule>> GetAllAsync(GetRulesRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
-            return Connection.GetAsync<IPagedList<Rule>>(BuildUri("rules",
-                new Dictionary<string, string>
-                {
-                    {"enabled", request.Enabled?.ToString().ToLower()},
-                    {"fields", request.Fields},
-                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
-                    {"stage", request.Stage},
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, rulesConverters, cancellationToken);
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"enabled", request.Enabled?.ToString().ToLower()},
+                {"fields", request.Fields},
+                {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                {"stage", request.Stage}
+            };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<Rule>>(BuildUri("rules", queryStrings), DefaultHeaders, rulesConverters, cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -86,26 +86,29 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{GetUsersRequest}"/> containing the list of users.</returns>
-        public Task<IPagedList<User>> GetAllAsync(GetUsersRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<User>> GetAllAsync(GetUsersRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
-            return Connection.GetAsync<IPagedList<User>>(BuildUri($"users",
-                new Dictionary<string, string>
-                {
-                    {"sort", request.Sort},
-                    {"connection", request.Connection},
-                    {"fields", request.Fields},
-                    {"include_fields", request.IncludeFields?.ToString().ToLower()},
-                    {"q", request.Query},
-                    {"search_engine", request.SearchEngine},
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()},
-                }), DefaultHeaders, usersConverters, cancellationToken);
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"sort", request.Sort},
+                {"connection", request.Connection},
+                {"fields", request.Fields},
+                {"include_fields", request.IncludeFields?.ToString().ToLower()},
+                {"q", request.Query},
+                {"search_engine", request.SearchEngine},
+            };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<User>>(BuildUri($"users", queryStrings), DefaultHeaders, usersConverters, cancellationToken);
         }
 
         /// <summary>
@@ -139,21 +142,24 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{LogEntry}"/> containing the log entries for the user.</returns>
-        public Task<IPagedList<LogEntry>> GetLogsAsync(GetUserLogsRequest request, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<LogEntry>> GetLogsAsync(GetUserLogsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
 
-            return Connection.GetAsync<IPagedList<LogEntry>>(BuildUri($"users/{EncodePath(request.UserId)}/logs",
-                new Dictionary<string, string>
-                {
-                    {"sort", request.Sort},
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, logsConverters, cancellationToken);
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"sort", request.Sort}
+            };
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<LogEntry>>(BuildUri($"users/{EncodePath(request.UserId)}/logs", queryStrings), DefaultHeaders, logsConverters, cancellationToken);
         }
 
         /// <summary>
@@ -163,18 +169,18 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{Role}"/> containing the roles for the user.</returns>
-        public Task<IPagedList<Role>> GetRolesAsync(string userId, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<Role>> GetRolesAsync(string userId, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
-            if (pagination == null)
-                throw new ArgumentNullException(nameof(pagination));
+            var queryStrings = new Dictionary<string, string>();
 
-            return Connection.GetAsync<IPagedList<Role>>(BuildUri($"users/{EncodePath(userId)}/roles",
-                new Dictionary<string, string>
-                {
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, rolesConverters, cancellationToken);
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<Role>>(BuildUri($"users/{EncodePath(userId)}/roles", queryStrings), DefaultHeaders, rolesConverters, cancellationToken);
         }
 
         /// <summary>
@@ -309,15 +315,18 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{Permission}"/> containing the assigned permissions for this user.</returns>
-        public Task<IPagedList<UserPermission>> GetPermissionsAsync(string id, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        public Task<IPagedList<UserPermission>> GetPermissionsAsync(string id, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
-            return Connection.GetAsync<IPagedList<UserPermission>>(BuildUri($"users/{EncodePath(id)}/permissions",
-                new Dictionary<string, string>
-                {
-                    {"page", pagination.PageNo.ToString()},
-                    {"per_page", pagination.PerPage.ToString()},
-                    {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
-                }), DefaultHeaders, permissionsConverters, cancellationToken);
+            var queryStrings = new Dictionary<string, string>();
+
+            if (pagination != null)
+            {
+                queryStrings["page"] = pagination.PageNo.ToString();
+                queryStrings["per_page"] = pagination.PerPage.ToString();
+                queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<UserPermission>>(BuildUri($"users/{EncodePath(id)}/permissions", queryStrings), DefaultHeaders, permissionsConverters, cancellationToken);
         }
 
         /// <summary>

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
@@ -140,5 +140,17 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Assert
             Assert.NotNull(grants.Paging);
         }
+
+        [Fact]
+        public async Task Test_without_paging()
+        {
+            // Act
+            var grants = await _apiClient.ClientGrants.GetAllAsync(new GetClientGrantsRequest());
+
+            // Assert
+            Assert.True(grants.Count > 0);
+            Assert.Null(grants.Paging);
+        }
+
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -170,6 +170,17 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
+        public async Task Test_without_paging()
+        {
+            // Act
+            var clients = await _apiClient.Clients.GetAllAsync(new GetClientsRequest());
+
+            // Assert
+            Assert.Null(clients.Paging);
+            Assert.True(clients.Count > 0);
+        }
+
+        [Fact]
         public async Task Test_app_type_works_correctly()
         {
             // Add a new client

--- a/tests/Auth0.ManagementApi.IntegrationTests/HooksTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/HooksTests.cs
@@ -105,5 +105,31 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Assert
             Assert.NotNull(hooks.Paging);
         }
+
+        [Fact]
+        public async Task Test_without_paging()
+        {
+            // Add a new hook
+            var newHook = await _apiClient.Hooks.CreateAsync(new HookCreateRequest()
+            {
+                Name = $"integration-test-hook-{Guid.NewGuid():N}",
+                Script = @"module.exports = function(client, scope, audience, context, callback) { {
+                              // TODO: implement your hook
+                              callback(null, context);
+                            }",
+                Dependencies = JObject.Parse("{ \"auth0\": \"2.32.0\"}"),
+                TriggerId = "credentials-exchange"
+            });
+
+            newHook.Should().NotBeNull();
+            
+            // Act
+            var hooks = await _apiClient.Hooks.GetAllAsync(new GetHooksRequest());
+
+            hooks.Paging.Should().BeNull();
+            hooks.Count.Should().BeGreaterThan(0);
+
+            await _apiClient.Hooks.DeleteAsync(newHook.Id);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
@@ -69,5 +69,16 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Assert
             Assert.NotNull(logs.Paging);
         }
+
+        [Fact]
+        public async Task Test_without_paging()
+        {
+            // Act
+            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest());
+
+            // Assert
+            logs.Paging.Should().BeNull();
+            logs.Count.Should().BeGreaterThan(0);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
@@ -124,5 +124,16 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Assert
             Assert.NotNull(resourceServers.Paging);
         }
+
+        [Fact]
+        public async Task Test_without_paging()
+        {
+            // Act
+            var resourceServers = await _apiClient.ResourceServers.GetAllAsync();
+
+            // Assert
+            resourceServers.Paging.Should().BeNull();
+            resourceServers.Count.Should().BeGreaterThan(0);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
@@ -97,5 +97,30 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Assert
             Assert.NotNull(rules.Paging);
         }
+
+        [Fact]
+        public async Task Test_without_paging()
+        {
+            // Add a new rule
+            var newRule = await _apiClient.Rules.CreateAsync(new RuleCreateRequest
+            {
+                Name = $"integration-test-rule-{Guid.NewGuid():N}",
+                Script = @"function (user, context, callback) {
+                              // TODO: implement your rule
+                              callback(null, user, context);
+                            }"
+            });
+
+            newRule.Should().NotBeNull();
+
+            // Act
+            var rules = await _apiClient.Rules.GetAllAsync(new GetRulesRequest());
+
+            // Assert
+            rules.Paging.Should().BeNull();
+            rules.Count.Should().BeGreaterThan(0);
+
+            await _apiClient.Rules.DeleteAsync(newRule.Id);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -201,6 +201,18 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
+        public async Task Test_without_paging()
+        {
+            // Act
+            var users = await _apiClient.Users.GetAllAsync(new GetUsersRequest());
+
+            // Assert
+            users.Paging.Should().BeNull();
+            users.Count.Should().BeGreaterThan(0);
+        }
+
+
+        [Fact]
         public async Task Can_update_user_metadata()
         {
             // Add a new user with metadata


### PR DESCRIPTION
### Changes

Some of the endpoints on API v2 have support for requests without pagination. This PR ensures those methods are callable without specifying an instance of `PaginationInfo`. 

https://auth0.com/docs/api/management/v2

### References

Closes #495

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
