### PR TITLE
Add auth0-forwarded-for header to passwordless sms authentication for…

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -293,10 +293,14 @@ namespace Auth0.AuthenticationApi
                 { "audience", request.Audience },
                 { "scope", request.Scope } };
 
+            var headers = String.IsNullOrEmpty(request.ForwardedForIp) ? null
+                : new Dictionary<string, string> { { "auth0-forwarded-for", request.ForwardedForIp } };
+
             return connection.SendAsync<AccessTokenResponse>(
                 HttpMethod.Post,
                 tokenUri,
                 body,
+                headers,
                 cancellationToken: cancellationToken);
         }
 
@@ -371,10 +375,14 @@ namespace Auth0.AuthenticationApi
                 phone_number = request.PhoneNumber
             };
 
+            var headers = String.IsNullOrEmpty(request.ForwardedForIp) ? null
+                : new Dictionary<string, string> { { "auth0-forwarded-for", request.ForwardedForIp } };
+
             return connection.SendAsync<PasswordlessSmsResponse>(
                 HttpMethod.Post,
                 BuildUri("passwordless/start"),
                 body,
+                headers,
                 cancellationToken: cancellationToken);
         }
 

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessSmsRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessSmsRequest.cs
@@ -24,5 +24,14 @@ namespace Auth0.AuthenticationApi.Models
         /// </summary>
         [JsonProperty("phone_number")]
         public string PhoneNumber { get; set; }
+
+        /// <summary>
+        /// IP address of the end user this token is requested for for rate limit purposes.
+        /// </summary>
+        /// <remarks>
+        /// See https://auth0.com/docs/connections/passwordless/best-practices#link-accounts for more details.
+        /// </remarks>
+        [JsonIgnore]
+        public string ForwardedForIp { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessSmsTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessSmsTokenRequest.cs
@@ -11,6 +11,14 @@ namespace Auth0.AuthenticationApi.Models
         /// Phonenumber used for the Passwordless flow
         /// </summary>
         public string PhoneNumber { get; set; }
-        
+
+        /// <summary>
+        /// IP address of the end user this token is requested for for rate limit purposes.
+        /// </summary>
+        /// <remarks>
+        /// See https://auth0.com/docs/connections/passwordless/best-practices#link-accounts for more details.
+        /// </remarks>
+        public string ForwardedForIp { get; set; }
+
     }
 }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

This change is to add auth0-forwarded-for header for passwordless sms authentication for rate limit purposes as per 

(https://auth0.com/docs/connections/passwordless/best-practices#link-accounts)

See section at the bottom 

> Setting the auth0-forwarded-for header for rate-limit purposes

### References

Please include relevant links supporting this change such as a:

(https://auth0.com/docs/connections/passwordless/best-practices#link-accounts)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

I have not included any additional tests as the existing method 

`public async Task<AccessTokenResponse> GetTokenAsync(ResourceOwnerTokenRequest request, CancellationToken cancellationToken = default)`

already makes use of this but I could not find any specific tests for the `ForwardedForIp` field.

Further since this change is simply adding an additional header it shouldn't change the behaviour unless users start setting it.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
