### PR TITLE
Use TestAuthenticationApiClient in tests

### DIFF
--- a/tests/Auth0.AuthenticationApi.IntegrationTests/DatabaseConnectionTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/DatabaseConnectionTests.cs
@@ -30,7 +30,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 EnabledClients = new[] {GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID")}
             });
 
-            _authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+            _authenticationApiClient = new TestAuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
         }
 
         public async Task DisposeAsync()

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/DeviceCodeTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/DeviceCodeTests.cs
@@ -77,7 +77,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 });
 
             var httpClient = new HttpClient(mockHandler.Object);
-            var authenticationApiClient = new AuthenticationApiClient(domain, new HttpClientAuthenticationConnection(httpClient));
+            var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
 
             var tokenReponse = await authenticationApiClient.StartDeviceFlowAsync(new DeviceCodeRequest
             {
@@ -118,7 +118,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 });
 
             var httpClient = new HttpClient(mockHandler.Object);
-            var authenticationApiClient = new AuthenticationApiClient(domain, new HttpClientAuthenticationConnection(httpClient));
+            var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
 
             var tokenReponse = await authenticationApiClient.GetTokenAsync(new DeviceCodeTokenRequest
             {


### PR DESCRIPTION
Using TestAuthenticationApiClient would retry calls when getting Rate Limit Exceptions.