### PR TITLE
[SDK-3104] Retrieve and Update the Enabled Phone Factors

### DIFF
--- a/src/Auth0.ManagementApi/Clients/GuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/GuardianClient.cs
@@ -171,5 +171,38 @@ namespace Auth0.ManagementApi.Clients
                 request,
                 DefaultHeaders, cancellationToken: cancellationToken);
         }
+
+        /// <summary>
+        /// Retrieve the enabled phone factors for multi-factor authentication
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="GuardianPhoneMessageTypes" /> containing the message types.</returns>
+        public Task<GuardianPhoneMessageTypes> GetPhoneMessageTypesAsync(CancellationToken cancellationToken = default)
+        {
+            return Connection
+                .GetAsync<GuardianPhoneMessageTypes>(
+                    BuildUri("guardian/factors/phone/message-types"), 
+                    DefaultHeaders,
+                    cancellationToken: cancellationToken
+                 );
+        }
+
+        /// <summary>
+        /// Update enabled phone factors for multi-factor authentication
+        /// </summary>
+        /// <param name="messageTypes">A <see cref="GuardianPhoneMessageTypes" /> containing the list of phone factors to enable on the tenan.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="GuardianPhoneMessageTypes" /> containing the message types.</returns>
+        public Task<GuardianPhoneMessageTypes> UpdatePhoneMessageTypesAsync(GuardianPhoneMessageTypes messageTypes, CancellationToken cancellationToken = default)
+        {
+            return Connection
+                .SendAsync<GuardianPhoneMessageTypes>(
+                    HttpMethod.Put,
+                    BuildUri("guardian/factors/phone/message-types"),
+                    messageTypes,
+                    DefaultHeaders,
+                    cancellationToken: cancellationToken
+                );
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Models/GuardianPhoneMessageTypes.cs
+++ b/src/Auth0.ManagementApi/Models/GuardianPhoneMessageTypes.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class GuardianPhoneMessageTypes
+    {
+        /// <summary>
+        /// The list of phone factors to enable on the tenant. Can include `sms` and `voice`.
+        /// </summary>
+        [JsonProperty("message_types")]
+        public IList<string> MessageTypes { get; set; }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
@@ -3,6 +3,7 @@ using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using FluentAssertions;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -170,6 +171,27 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             response = await _managementApiClient.Guardian.GetTwilioConfigurationAsync();
             response.Should().BeEquivalentTo(request);
+        }
+
+        [Fact]
+        public async Task Can_update_phone_messagetypes()
+        {
+            GuardianPhoneMessageTypes response;
+
+            response = await _managementApiClient.Guardian.UpdatePhoneMessageTypesAsync(new GuardianPhoneMessageTypes
+            {
+                MessageTypes = new List<string> { "sms" }
+            });
+            response.MessageTypes.Count.Should().Be(1);
+
+            response = await _managementApiClient.Guardian.UpdatePhoneMessageTypesAsync(new GuardianPhoneMessageTypes
+            {
+                MessageTypes = new List<string> { "sms", "voice" }
+            });
+            response.MessageTypes.Count.Should().Be(2);
+
+            response = await _managementApiClient.Guardian.GetPhoneMessageTypesAsync();
+            response.MessageTypes.Count.Should().Be(2);
         }
     }
 }


### PR DESCRIPTION
### Changes

Implements missing methods to retrieve and update the Enabled Phone Factors for MFA.

Docs:
- https://auth0.com/docs/api/management/v2#!/Guardian/get_message_types
- https://auth0.com/docs/api/management/v2#!/Guardian/put_message_types
- https://auth0.com/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-sms-voice-notifications-mfa#use-the-management-api

### References

Closes #528 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
