### PR TITLE
Add cleanup after each test run

### DIFF
--- a/Auth0.Net.sln
+++ b/Auth0.Net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29215.179
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{C9550C3F-90EB-42C0-B530-E728566A13C2}"
 EndProject
@@ -32,6 +32,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Auth0.NETCore3", "playground\Auth0.NETCore3\Auth0.NETCore3.csproj", "{F4721D05-77E6-41D7-BFCD-FEEF06F083F3}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auth0.NETFramework", "playground\Auth0.NETFramework\Auth0.NETFramework.csproj", "{FD7D56C3-C152-4C0A-B843-AE54A27077FA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Auth0.IntegrationTests.Shared", "tests\Auth0.IntegrationTests.Shared\Auth0.IntegrationTests.Shared.csproj", "{7AE5A1C8-19E6-4BC9-8B11-9B8921C85FE2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -69,6 +71,10 @@ Global
 		{F4721D05-77E6-41D7-BFCD-FEEF06F083F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD7D56C3-C152-4C0A-B843-AE54A27077FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{FD7D56C3-C152-4C0A-B843-AE54A27077FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AE5A1C8-19E6-4BC9-8B11-9B8921C85FE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AE5A1C8-19E6-4BC9-8B11-9B8921C85FE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AE5A1C8-19E6-4BC9-8B11-9B8921C85FE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AE5A1C8-19E6-4BC9-8B11-9B8921C85FE2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -83,6 +89,7 @@ Global
 		{AEDB01F2-B535-45D0-9ED5-3FEB90179786} = {E0399446-B2A6-44F6-B179-4D97676B479F}
 		{F4721D05-77E6-41D7-BFCD-FEEF06F083F3} = {E0399446-B2A6-44F6-B179-4D97676B479F}
 		{FD7D56C3-C152-4C0A-B843-AE54A27077FA} = {E0399446-B2A6-44F6-B179-4D97676B479F}
+		{7AE5A1C8-19E6-4BC9-8B11-9B8921C85FE2} = {0EBAD055-E431-443B-8212-411D1AFE3796}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8B26058B-3755-4E47-AE0B-350E5B18A4CD}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -25,6 +25,7 @@
     <ProjectReference Include="..\..\src\Auth0.Core\Auth0.Core.csproj" />
     <ProjectReference Include="..\..\src\Auth0.AuthenticationApi\Auth0.AuthenticationApi.csproj" />
     <ProjectReference Include="..\..\src\Auth0.ManagementApi\Auth0.ManagementApi.csproj" />
+    <ProjectReference Include="..\Auth0.IntegrationTests.Shared\Auth0.IntegrationTests.Shared.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="client-secrets.json">
@@ -33,8 +34,5 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Testing\" />
   </ItemGroup>
 </Project>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/DatabaseConnectionTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/DatabaseConnectionTests.cs
@@ -21,7 +21,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         {
             string token = await GenerateManagementApiToken();
 
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"));
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
 
             // We will need a connection to add the users to...
             _connection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBase.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBase.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi;
+using Auth0.Tests.Shared;
+
+namespace Auth0.AuthenticationApi.IntegrationTests.Testing
+{
+    public class ManagementTestBase : TestBase
+    {
+        protected ManagementApiClient ApiClient;
+        
+        public async Task CleanupAndDisposeAsync(CleanUpType? type = null)
+        {
+            if (ApiClient != null)
+            {
+                await RunCleanUp(type);
+                ApiClient.Dispose();
+            }
+        }
+
+        public virtual Task DisposeAsync()
+        {
+            if (ApiClient != null)
+            {
+                ApiClient.Dispose();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task RunCleanUp(CleanUpType? type)
+        {
+            var strategies = new List<CleanUpStrategy>
+            {
+                new ActionsCleanUpStrategy(ApiClient),
+                new ClientsCleanUpStrategy(ApiClient),
+                new ConnectionsCleanUpStrategy(ApiClient),
+                new HooksCleanUpStrategy(ApiClient),
+                new OrganizationsCleanUpStrategy(ApiClient),
+                new ResourceServersCleanUpStrategy(ApiClient),
+                new UsersCleanUpStrategy(ApiClient)
+            };
+
+            var strategiesToRun = type != null ? strategies.FindAll(s => s.Type == type) : strategies;
+
+            foreach (var cleanUpStrategy in strategiesToRun)
+            {
+                await cleanUpStrategy.Run();
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/Auth0.IntegrationTests.Shared.csproj
+++ b/tests/Auth0.IntegrationTests.Shared/Auth0.IntegrationTests.Shared.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Auth0.ManagementApi\Auth0.ManagementApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ActionsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ActionsCleanUpStrategy.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Models.Actions;
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class ActionsCleanUpStrategy: CleanUpStrategy
+    {
+        public ActionsCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Actions, apiClient)
+        {
+                
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running ActionsCleanUpStrategy");
+            var actions = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
+
+            foreach (var action in actions)
+            {
+                if (action.Name.StartsWith(TestingConstants.ActionPrefix))
+                {
+                    Console.WriteLine($"Removing action {action.Name}");
+                    await ApiClient.Actions.DeleteAsync(action.Id);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpStrategy.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public abstract class CleanUpStrategy
+    {
+        public ManagementApiClient ApiClient { get; }
+        public CleanUpType Type { get; }
+
+        protected CleanUpStrategy(CleanUpType type, ManagementApiClient apiClient)
+        {
+            Type = type;
+            ApiClient = apiClient;
+        }
+
+        public abstract Task Run();
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
@@ -1,0 +1,13 @@
+﻿namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public enum CleanUpType
+    {
+        Actions,
+        Clients,
+        Connections,
+        Hooks,
+        Organizations,
+        ResourceServers,
+        Users
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientsCleanUpStrategy.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class ClientsCleanUpStrategy : CleanUpStrategy
+    {
+        public ClientsCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Clients, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running ClientsCleanUpStrategy");
+            var clients = await ApiClient.Clients.GetAllAsync(new ManagementApi.Models.GetClientsRequest { }, new ManagementApi.Paging.PaginationInfo(0, 100));
+
+            foreach (var client in clients)
+            {
+                if (client.Name.StartsWith(TestingConstants.ClientPrefix))
+                {
+                    Console.WriteLine($"Removing client {client.Name}");
+                    await ApiClient.Clients.DeleteAsync(client.ClientId);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ConnectionsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ConnectionsCleanUpStrategy.cs
@@ -1,0 +1,27 @@
+﻿using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class ConnectionsCleanUpStrategy : CleanUpStrategy
+    {
+        public ConnectionsCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Connections, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running ConnectionsCleanUpStrategy");
+            var connections = await ApiClient.Connections.GetAllAsync(new ManagementApi.Models.GetConnectionsRequest { });
+
+            foreach (var connection in connections)
+            {
+                if (connection.Name.StartsWith(TestingConstants.ConnectionPrefix))
+                {
+                    await ApiClient.Connections.DeleteAsync(connection.Id);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/HooksCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/HooksCleanUpStrategy.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Models;
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class HooksCleanUpStrategy : CleanUpStrategy
+    {
+        public HooksCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Hooks, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running HooksCleanUpStrategy");
+            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
+
+            foreach (var hook in hooks)
+            {
+                if (hook.Name.StartsWith(TestingConstants.HooksPrefix))
+                {
+                    Console.WriteLine($"Removing hook {hook.Name}");
+                    await ApiClient.Hooks.DeleteAsync(hook.Id);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/OrganizationsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/OrganizationsCleanUpStrategy.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class OrganizationsCleanUpStrategy : CleanUpStrategy
+    {
+        public OrganizationsCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Organizations, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running OrganizationsCleanUpStrategy");
+            var organizations = await ApiClient.Organizations.GetAllAsync(new PaginationInfo());
+
+            foreach (var organization in organizations)
+            {
+                if (organization.Name.ToLower().StartsWith(TestingConstants.OrganizationPrefix.ToLower()))
+                {
+                    Console.WriteLine($"Removing organization {organization.Name}");
+                    await ApiClient.Organizations.DeleteAsync(organization.Id);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ResourceServersCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ResourceServersCleanUpStrategy.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class ResourceServersCleanUpStrategy : CleanUpStrategy
+    {
+        public ResourceServersCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.ResourceServers, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running ResourceServersCleanUpStrategy");
+            var resourceServers = await ApiClient.ResourceServers.GetAllAsync(new ManagementApi.Paging.PaginationInfo(0, 100));
+
+            foreach (var resourceServer in resourceServers)
+            {
+                if (resourceServer.Name.StartsWith(TestingConstants.ResourceServerPrefix))
+                {
+                    Console.WriteLine($"Removing resourceServer {resourceServer.Name}");
+                    await ApiClient.ResourceServers.DeleteAsync(resourceServer.Id);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/TestingConstants.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/TestingConstants.cs
@@ -1,0 +1,15 @@
+﻿namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class TestingConstants
+    {
+        private static readonly string Suffix = "int-test";
+
+        public static string ActionPrefix = $"{Suffix}";
+        public static string ClientPrefix = $"{Suffix}";
+        public static string ConnectionPrefix = $"{Suffix}";
+        public static string HooksPrefix = $"{Suffix}";
+        public static string ResourceServerPrefix = $"{Suffix}";
+        public static string OrganizationPrefix = $"{Suffix}";
+        public static string UserEmailDomain = $"{Suffix}@nonexistingdomain.aaa";
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/UsersCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/UsersCleanUpStrategy.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Models;
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class UsersCleanUpStrategy : CleanUpStrategy
+    {
+        public UsersCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Users, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running UsersCleanUpStrategy");
+            var users = await ApiClient.Users.GetAllAsync(new GetUsersRequest(), new PaginationInfo());
+
+            foreach (var user in users)
+            {
+                if (user.Email.Contains(TestingConstants.UserEmailDomain))
+                {
+                    Console.WriteLine($"Removing user {user.FullName}");
+                    await ApiClient.Users.DeleteAsync(user.UserId);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/ActionsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ActionsTests.cs
@@ -1,51 +1,51 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models.Actions;
 using Auth0.ManagementApi.Paging;
-using Auth0.Tests.Shared;
 using FluentAssertions;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class ActionsTests : TestBase, IAsyncLifetime
+    public class ActionsTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
         public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
-        public Task DisposeAsync()
+        public override Task DisposeAsync()
         {
-            _apiClient.Dispose();
-            return Task.CompletedTask;
+            return CleanupAndDisposeAsync(CleanUpType.Actions);
         }
 
         [Fact]
         public async Task Test_actions_crud_sequence()
         {
-            var actionsBeforeCreate = await _apiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
+            var actionsBeforeCreate = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
 
-            var createdAction = await _apiClient.Actions.CreateAsync(new CreateActionRequest
+            var createdAction = await ApiClient.Actions.CreateAsync(new CreateActionRequest
             {
-                Name = $"Int-Test-Action-{Guid.NewGuid()}",
+                Name = $"{TestingConstants.ActionPrefix}-{Guid.NewGuid()}",
                 Code = "module.exports = () => {}",
                 Runtime = "node12",
                 Secrets = new List<ActionSecret> { new ActionSecret { Name = "My_Secret", Value  = "Test123" } },
                 SupportedTriggers = new List<ActionSupportedTrigger> { new ActionSupportedTrigger { Id = "post-login", Version = "v2"} }
             });
 
-            var actionsAfterCreate = await _apiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
+            var actionsAfterCreate = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
 
             actionsAfterCreate.Count.Should().Be(actionsBeforeCreate.Count + 1);
             createdAction.Should().BeEquivalentTo(actionsAfterCreate.Last(), options => options.Excluding(o => o.Status));
 
-            var updatedAction = await _apiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
+            var updatedAction = await ApiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
             {
                 Code = "module.exports = () => { console.log(true); }"
             });
@@ -53,21 +53,21 @@ namespace Auth0.ManagementApi.IntegrationTests
             updatedAction.Should().BeEquivalentTo(createdAction, options => options.Excluding(o => o.Code).Excluding(o => o.UpdatedAt));
             updatedAction.Code.Should().Be("module.exports = () => { console.log(true); }");
 
-            var actionAfterUpdate = await _apiClient.Actions.GetAsync(updatedAction.Id);
+            var actionAfterUpdate = await ApiClient.Actions.GetAsync(updatedAction.Id);
 
             updatedAction.Should().BeEquivalentTo(actionAfterUpdate, options => options.Excluding(o => o.Status));
             actionAfterUpdate.Code.Should().Be("module.exports = () => { console.log(true); }");
 
-            await _apiClient.Actions.DeleteAsync(actionAfterUpdate.Id);
+            await ApiClient.Actions.DeleteAsync(actionAfterUpdate.Id);
 
-            var actionsAfterDelete = await _apiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
+            var actionsAfterDelete = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
             actionsAfterDelete.Count.Should().Be(actionsBeforeCreate.Count);
         }
 
         [Fact]
         public async Task Test_get_triggers()
         {
-            var triggers = await _apiClient.Actions.GetAllTriggersAsync();
+            var triggers = await ApiClient.Actions.GetAllTriggersAsync();
 
             triggers.Should().NotBeEmpty();
         }
@@ -75,20 +75,20 @@ namespace Auth0.ManagementApi.IntegrationTests
         [Fact]
         public async Task Test_get_and_update_trigger_bindings()
         {
-            var triggerBindingsBeforeCreate = await _apiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
+            var triggerBindingsBeforeCreate = await ApiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
             
-            var createdAction = await _apiClient.Actions.CreateAsync(new CreateActionRequest
+            var createdAction = await ApiClient.Actions.CreateAsync(new CreateActionRequest
             {
-                Name = $"Int-Test-Action-{Guid.NewGuid()}",
+                Name = $"{TestingConstants.ActionPrefix}-{Guid.NewGuid()}",
                 Code = "module.exports = () => {}",
                 Runtime = "node12",
                 Secrets = new List<ActionSecret> { new ActionSecret { Name = "My_Secret", Value = "Test123" } },
                 SupportedTriggers = new List<ActionSupportedTrigger> { new ActionSupportedTrigger { Id = "post-login", Version = "v2" } }
             });
 
-            await _apiClient.Actions.DeployAsync(createdAction.Id);
+            await ApiClient.Actions.DeployAsync(createdAction.Id);
 
-            await _apiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
+            await ApiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
             {
                 Bindings = new List<UpdateTriggerBindingEntry>
                 {
@@ -104,25 +104,25 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             });
 
-            var triggerBindingsAfterCreate = await _apiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
+            var triggerBindingsAfterCreate = await ApiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
 
             triggerBindingsAfterCreate.Count.Should().Be(triggerBindingsBeforeCreate.Count + 1);
 
-            await _apiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
+            await ApiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
             {
                 Bindings = new List<UpdateTriggerBindingEntry>()
             });
 
-            await _apiClient.Actions.DeleteAsync(createdAction.Id);
+            await ApiClient.Actions.DeleteAsync(createdAction.Id);
         }
 
         [Fact]
         public async Task Test_action_version_crud_sequence()
         {
             // 1. Create a new Action
-            var createdAction = await _apiClient.Actions.CreateAsync(new CreateActionRequest
+            var createdAction = await ApiClient.Actions.CreateAsync(new CreateActionRequest
             {
-                Name = $"Int-Test-Action-{Guid.NewGuid()}",
+                Name = $"{TestingConstants.ActionPrefix}-{Guid.NewGuid()}",
                 Code = "module.exports = () => {}",
                 Runtime = "node12",
                 Secrets = new List<ActionSecret> { new ActionSecret { Name = "My_Secret", Value = "Test123" } },
@@ -130,43 +130,43 @@ namespace Auth0.ManagementApi.IntegrationTests
             });
 
             // 2. Get all the versions after the action was created
-            var versionsAfterCreate = await _apiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionsAfterCreate = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
             
             versionsAfterCreate.Count.Should().Be(0);
 
             // 3. Deploy the current version
-            await _apiClient.Actions.DeployAsync(createdAction.Id);
+            await ApiClient.Actions.DeployAsync(createdAction.Id);
 
             // 4. Get all the versions after the action was deployed
-            var versionsAfterDeploy = await _apiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionsAfterDeploy = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
             
             versionsAfterDeploy.Count.Should().Be(1);
 
             // 5. Update the action
-            await _apiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
+            await ApiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
             {
                 Code = "module.exports = () => { console.log(true); }"
             });
 
             // 6. Deploy the latest version
-            var deployedVersion = await _apiClient.Actions.DeployAsync(createdAction.Id);
+            var deployedVersion = await ApiClient.Actions.DeployAsync(createdAction.Id);
             
             // 7. Get all the versions after the action was updated
-            var versionsAfterSecondDeploy = await _apiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionsAfterSecondDeploy = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
 
             versionsAfterSecondDeploy.Count.Should().Be(2);
             versionsAfterSecondDeploy.Single(v => v.Id == deployedVersion.Id).Deployed.Should().BeTrue();
             versionsAfterSecondDeploy.Single(v => v.Id != deployedVersion.Id).Deployed.Should().BeFalse();
 
-            var action = await _apiClient.Actions.GetAsync(createdAction.Id);
+            var action = await ApiClient.Actions.GetAsync(createdAction.Id);
             action.DeployedVersion.Id.Should().Be(deployedVersion.Id);
 
             // 9. Rollback
-            var rollbackedVersion = await _apiClient.Actions.RollbackToVersionAsync(createdAction.Id, versionsAfterDeploy.Single().Id);
+            var rollbackedVersion = await ApiClient.Actions.RollbackToVersionAsync(createdAction.Id, versionsAfterDeploy.Single().Id);
 
             // 10. Get all the versions after the action was rollbacked
-            var versionsAfterRollback = await _apiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
-            var versionAfterRollback = await _apiClient.Actions.GetVersionAsync(createdAction.Id, rollbackedVersion.Id);
+            var versionsAfterRollback = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionAfterRollback = await ApiClient.Actions.GetVersionAsync(createdAction.Id, rollbackedVersion.Id);
 
             versionsAfterRollback.Count.Should().Be(3);
             versionsAfterRollback.Single(v => v.Id == versionAfterRollback.Id).Should().BeEquivalentTo(versionAfterRollback);
@@ -174,7 +174,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             versionsAfterRollback.Where(v => v.Id != versionAfterRollback.Id).ToList().ForEach(v => v.Deployed.Should().BeFalse());
 
             // 10. Delete Action
-            await _apiClient.Actions.DeleteAsync(createdAction.Id);
+            await ApiClient.Actions.DeleteAsync(createdAction.Id);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
@@ -1,31 +1,24 @@
 ﻿using System.Threading.Tasks;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models.AttackProtection;
-using Auth0.Tests.Shared;
 using FluentAssertions;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class AttackProtectionTests : TestBase, IAsyncLifetime
+    public class AttackProtectionTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
         public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
-        }
-
-        public Task DisposeAsync()
-        {
-            _apiClient.Dispose();
-            return Task.CompletedTask;
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
         [Fact]
         public async Task Test_suspicious_ip_throttling_crud_sequence()
         {
-            var before = await _apiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
+            var before = await ApiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
 
             try
             {
@@ -49,9 +42,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 };
 
-                var updated = await _apiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(toUpdate);
+                var updated = await ApiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(toUpdate);
 
-                var after = await _apiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
+                var after = await ApiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
 
 
                 updated.Should().BeEquivalentTo(toUpdate);
@@ -59,14 +52,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             }
             finally
             {
-                await _apiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(before);
+                await ApiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(before);
             }
         }
 
         [Fact]
         public async Task Test_breached_password_detection_crud_sequence()
         {
-            var before = await _apiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
+            var before = await ApiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
 
             try
             {
@@ -78,9 +71,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                     Enabled = true,
                 };
 
-                var updated = await _apiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(toUpdate);
+                var updated = await ApiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(toUpdate);
 
-                var after = await _apiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
+                var after = await ApiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
 
 
                 updated.Should().BeEquivalentTo(toUpdate);
@@ -88,14 +81,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             }
             finally
             {
-                await _apiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(before);
+                await ApiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(before);
             }
         }
 
         [Fact]
         public async Task Test_brute_force_protection_crud_sequence()
         {
-            var before = await _apiClient.AttackProtection.GetBruteForceProtectionAsync();
+            var before = await ApiClient.AttackProtection.GetBruteForceProtectionAsync();
 
             try
             {
@@ -108,9 +101,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                     MaxAttempts = 11,
                 };
 
-                var updated = await _apiClient.AttackProtection.UpdateBruteForceProtectionAsync(toUpdate);
+                var updated = await ApiClient.AttackProtection.UpdateBruteForceProtectionAsync(toUpdate);
 
-                var after = await _apiClient.AttackProtection.GetBruteForceProtectionAsync();
+                var after = await ApiClient.AttackProtection.GetBruteForceProtectionAsync();
 
 
                 updated.Should().BeEquivalentTo(toUpdate);
@@ -118,7 +111,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             }
             finally
             {
-                await _apiClient.AttackProtection.UpdateBruteForceProtectionAsync(before);
+                await ApiClient.AttackProtection.UpdateBruteForceProtectionAsync(before);
             }
         }
     }

--- a/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
@@ -67,7 +67,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 {
                     Shields = new[] { "admin_notification" },
                     AdminNotificationFrequency = new[] { "daily" },
-                    Method = "enhanced",
+                    Method = "standard",
                     Enabled = true,
                 };
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
@@ -34,6 +34,7 @@
     <ProjectReference Include="..\..\src\Auth0.Core\Auth0.Core.csproj" />
     <ProjectReference Include="..\..\src\Auth0.AuthenticationApi\Auth0.AuthenticationApi.csproj" />
     <ProjectReference Include="..\..\src\Auth0.ManagementApi\Auth0.ManagementApi.csproj" />
+    <ProjectReference Include="..\Auth0.IntegrationTests.Shared\Auth0.IntegrationTests.Shared.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
@@ -1,25 +1,19 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Auth0.Core.Exceptions;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.Tests.Shared;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class BrandingClientTests : TestBase, IAsyncLifetime
+    public class BrandingClientTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
-
         public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
-        }
-
-        public Task DisposeAsync()
-        {
-            return Task.CompletedTask;
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
         [Fact]
@@ -28,7 +22,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             try
             {
                 // Update branding
-                await _apiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
+                await ApiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
                 {
                     LogoUrl = "https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-white.svg",
                     FaviconUrl = "https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-black.svg",
@@ -43,7 +37,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 });
 
-                var updatedBranding = await _apiClient.Branding.GetAsync();
+                var updatedBranding = await ApiClient.Branding.GetAsync();
 
                 Assert.Equal("https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-white.svg", updatedBranding.LogoUrl);
                 Assert.Equal("https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-black.svg", updatedBranding.FaviconUrl);
@@ -55,7 +49,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             finally
             {
                 // Rollback
-                await _apiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
+                await ApiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
                 {
                     Colors = new Models.BrandingColors { 
                         Primary = "#0059d6",
@@ -74,7 +68,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         [Fact(Skip = "Enable when migrated to new Tenant because missing permissions on current")]
         public async Task Test_Branding_ULPTemplate_Reand_Update_Delete()
         {
-            // var temp = await _apiClient.Branding.GetUniversalLoginTemplateAsync();
+            // var temp = await ApiClient.Branding.GetUniversalLoginTemplateAsync();
             try
             {
                 var newTemplateBody = @"<!DOCTYPE html><html>
@@ -85,20 +79,20 @@ namespace Auth0.ManagementApi.IntegrationTests
                     {%- auth0:widget -%}
                   </body></html> ";
 
-                await _apiClient.Branding.SetUniversalLoginTemplateAsync(new Models.UniversalLoginTemplateUpdateRequest
+                await ApiClient.Branding.SetUniversalLoginTemplateAsync(new Models.UniversalLoginTemplateUpdateRequest
                 {
                     Template = newTemplateBody
                 });
 
-                var updatedTemplate = await _apiClient.Branding.GetUniversalLoginTemplateAsync();
+                var updatedTemplate = await ApiClient.Branding.GetUniversalLoginTemplateAsync();
 
                 Assert.Equal(newTemplateBody, updatedTemplate.Body);
             }
             finally
             {
-                await _apiClient.Branding.DeleteUniversalLoginTemplateAsync();
+                await ApiClient.Branding.DeleteUniversalLoginTemplateAsync();
 
-                await Assert.ThrowsAsync<ErrorApiException>(() => _apiClient.Branding.GetUniversalLoginTemplateAsync());
+                await Assert.ThrowsAsync<ErrorApiException>(() => ApiClient.Branding.GetUniversalLoginTemplateAsync());
             }
         }
     }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Auth0.Core.Exceptions;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
 using FluentAssertions;
 using Xunit;
@@ -9,41 +11,38 @@ using Auth0.ManagementApi.Paging;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class ConnectionTests : TestBase, IAsyncLifetime
+    public class ConnectionTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
-
         public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
-        public Task DisposeAsync()
+        public override Task DisposeAsync()
         {
-            _apiClient.Dispose();
-            return Task.CompletedTask;
+            return CleanupAndDisposeAsync(CleanUpType.Connections);
         }
 
         [Fact]
         public async Task Test_database_connection_crud_sequence()
         {
             // Get all connections before
-            var connectionsBefore = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            var connectionsBefore = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest
             {
                 Strategy = new[] { "auth0" }
             }, new PaginationInfo());
 
             // Create a new connection
-            var name = "Temp-Int-Test-" + MakeRandomName();
+            var name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}";
             var newConnectionRequest = new ConnectionCreateRequest
             {
                 Name = name,
                 Strategy = "auth0",
                 Realms = new[] { name }
             };
-            var newConnectionResponse = await _apiClient.Connections.CreateAsync(newConnectionRequest);
+            var newConnectionResponse = await ApiClient.Connections.CreateAsync(newConnectionRequest);
             newConnectionResponse.Should().NotBeNull();
             newConnectionResponse.Name.Should().Be(newConnectionRequest.Name);
             newConnectionResponse.Strategy.Should().Be(newConnectionRequest.Strategy);
@@ -51,14 +50,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             newConnectionResponse.IsDomainConnection.Should().BeFalse();
 
             // Get all connections again
-            var connectionsAfter = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            var connectionsAfter = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest
             {
                 Strategy = new[] { "auth0" }
             }, new PaginationInfo());
             connectionsAfter.Count.Should().Be(connectionsBefore.Count + 1);
 
             // Update a connection
-            var newName = "Temp-Int-Test-" + MakeRandomName();
+            var newName = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}";
             var updateConnectionRequest = new ConnectionUpdateRequest
             {
                 Options = new
@@ -71,7 +70,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 },
                 Realms = new[] { newName }
             };
-            var updateConnectionResponse = await _apiClient.Connections.UpdateAsync(newConnectionResponse.Id, updateConnectionRequest);
+            var updateConnectionResponse = await ApiClient.Connections.UpdateAsync(newConnectionResponse.Id, updateConnectionRequest);
             string a = updateConnectionResponse.Options.a;
             a.Should().Be("123");
             string b = updateConnectionResponse.Metadata.b;
@@ -79,12 +78,12 @@ namespace Auth0.ManagementApi.IntegrationTests
             updateConnectionRequest.Realms.Should().BeEquivalentTo(new[] { newName });
 
             // Get a single connection
-            var connection = await _apiClient.Connections.GetAsync(newConnectionResponse.Id);
+            var connection = await ApiClient.Connections.GetAsync(newConnectionResponse.Id);
             connection.Should().NotBeNull();
 
             // Delete the connection and ensure we get exception when trying to get connection again
-            await _apiClient.Connections.DeleteAsync(newConnectionResponse.Id);
-            Func<Task> getFunc = async () => await _apiClient.Connections.GetAsync(newConnectionResponse.Id);
+            await ApiClient.Connections.DeleteAsync(newConnectionResponse.Id);
+            Func<Task> getFunc = async () => await ApiClient.Connections.GetAsync(newConnectionResponse.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
         }
 
@@ -92,7 +91,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_connection_crud_sequence()
         {
             // Get all connections before
-            var connectionsBefore = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            var connectionsBefore = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest
             {
                 Strategy = new[] {"github"}
             }, new PaginationInfo());
@@ -100,16 +99,16 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Create a new connection
             var newConnectionRequest = new ConnectionCreateRequest
             {
-                Name = "Temp-Int-Test-" + MakeRandomName(),
+                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
                 Strategy = "github"
             };
-            var newConnectionResponse = await _apiClient.Connections.CreateAsync(newConnectionRequest);
+            var newConnectionResponse = await ApiClient.Connections.CreateAsync(newConnectionRequest);
             newConnectionResponse.Should().NotBeNull();
             newConnectionResponse.Name.Should().Be(newConnectionRequest.Name);
             newConnectionResponse.Strategy.Should().Be(newConnectionRequest.Strategy);
 
             // Get all connections again
-            var connectionsAfter = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            var connectionsAfter = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest
             {
                 Strategy = new[] {"github"}
             }, new PaginationInfo());
@@ -127,19 +126,19 @@ namespace Auth0.ManagementApi.IntegrationTests
                     b = "456"
                 }
             };
-            var updateConnectionResponse = await _apiClient.Connections.UpdateAsync(newConnectionResponse.Id, updateConnectionRequest);
+            var updateConnectionResponse = await ApiClient.Connections.UpdateAsync(newConnectionResponse.Id, updateConnectionRequest);
             string a = updateConnectionResponse.Options.a;
             a.Should().Be("123");
             string b = updateConnectionResponse.Metadata.b;
             b.Should().Be("456");
 
             // Get a single connection
-            var connection = await _apiClient.Connections.GetAsync(newConnectionResponse.Id);
+            var connection = await ApiClient.Connections.GetAsync(newConnectionResponse.Id);
             connection.Should().NotBeNull();
 
             // Delete the connection and ensure we get exception when trying to get connection again
-            await _apiClient.Connections.DeleteAsync(newConnectionResponse.Id);
-            Func<Task> getFunc = async () => await _apiClient.Connections.GetAsync(newConnectionResponse.Id);
+            await ApiClient.Connections.DeleteAsync(newConnectionResponse.Id);
+            Func<Task> getFunc = async () => await ApiClient.Connections.GetAsync(newConnectionResponse.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
         }
 
@@ -147,7 +146,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
-            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo());
+            var connections = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo());
 
             // Assert
             Assert.Null(connections.Paging);
@@ -157,7 +156,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, false));
+            var connections = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, false));
 
             // Assert
             Assert.Null(connections.Paging);
@@ -167,7 +166,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, true));
+            var connections = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest(), new PaginationInfo(0, 50, true));
 
             // Assert
             Assert.NotNull(connections.Paging);
@@ -177,7 +176,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_multiple_strategies()
         {
             // Act
-            var connections = await _apiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            var connections = await ApiClient.Connections.GetAllAsync(new GetConnectionsRequest
             {
                 Strategy = new[] { "google-oauth2", "auth0" }
             }, new PaginationInfo());

--- a/tests/Auth0.ManagementApi.IntegrationTests/DeviceCredentialsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/DeviceCredentialsTests.cs
@@ -32,18 +32,18 @@ namespace Auth0.ManagementApi.IntegrationTests
                 // Set up the correct Client, Connection and User
                 _client = await apiClient.Clients.CreateAsync(new ClientCreateRequest
                 {
-                    Name = $"Integration testing {MakeRandomName()}",
+                Name = $"{TestingConstants.ClientPrefix} {MakeRandomName()}",
                 });
                 _connection = await apiClient.Connections.CreateAsync(new ConnectionCreateRequest
                 {
-                    Name = "Temp-Int-Test-" + MakeRandomName(),
+                    Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
                     Strategy = "auth0",
                     EnabledClients = new[] { _client.ClientId }
                 });
                 _user = await apiClient.Users.CreateAsync(new UserCreateRequest
                 {
                     Connection = _connection.Name,
-                    Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                    Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                     EmailVerified = true,
                     Password = Password
                 });

--- a/tests/Auth0.ManagementApi.IntegrationTests/HooksTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/HooksTests.cs
@@ -1,41 +1,39 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Auth0.Core.Exceptions;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
 using FluentAssertions;
 using Xunit;
-using Auth0.Tests.Shared;
 using Auth0.ManagementApi.Paging;
 using Newtonsoft.Json.Linq;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class HooksTests : TestBase, IAsyncLifetime
+    public class HooksTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
-
         public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
-        public Task DisposeAsync()
+        public override Task DisposeAsync()
         {
-            _apiClient.Dispose();
-            return Task.CompletedTask;
+            return CleanupAndDisposeAsync(CleanUpType.Hooks);
         }
 
         [Fact]
         public async Task Test_hooks_crud_sequence()
         {
             // Get all hooks
-            var hooksBefore = await _apiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
+            var hooksBefore = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
 
             // Add a new hook
             var newHookRequest = new HookCreateRequest()
             {
-                Name = $"integration-test-hook-{Guid.NewGuid():N}",
+                Name = $"{TestingConstants.HooksPrefix}-{Guid.NewGuid():N}",
                 Script = @"module.exports = function(client, scope, audience, context, callback) { {
                               // TODO: implement your hook
                               callback(null, context);
@@ -43,36 +41,36 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Dependencies = JObject.Parse("{ \"auth0\": \"2.32.0\"}"),
                 TriggerId = "credentials-exchange"
             };
-            var newHookResponse = await _apiClient.Hooks.CreateAsync(newHookRequest);
+            var newHookResponse = await ApiClient.Hooks.CreateAsync(newHookRequest);
             newHookResponse.Should().NotBeNull();
             Assert.True(JObject.DeepEquals(newHookRequest.Dependencies, newHookResponse.Dependencies));
 
             // Get all the hooks again, and check that we now have one more
-            var hooksAfter = await _apiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
+            var hooksAfter = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
             hooksAfter.Count.Should().Be(hooksBefore.Count + 1);
 
             // Update the Hook
             var updateHookRequest = new HookUpdateRequest
             {
-                Name = $"integration-test-hook-2-{Guid.NewGuid():N}",
+                Name = $"{TestingConstants.HooksPrefix}-2-{Guid.NewGuid():N}",
                 Enabled = true
             };
-            var updateHookResponse = await _apiClient.Hooks.UpdateAsync(newHookResponse.Id, updateHookRequest);
+            var updateHookResponse = await ApiClient.Hooks.UpdateAsync(newHookResponse.Id, updateHookRequest);
             updateHookResponse.Should().NotBeNull();
             // Because the Hooks endpoint changes the name of a Hook when using a Guid in the name, 
             // we can only verify the name starts with the part without the Guid.
-            updateHookResponse.Name.StartsWith("integration-test-hook-2-").Should().BeTrue();
+            updateHookResponse.Name.StartsWith($"{TestingConstants.HooksPrefix}-2-".ToLower()).Should().BeTrue();
             updateHookResponse.Enabled.Should().BeTrue();
 
             // Get a single hook
-            var hook = await _apiClient.Hooks.GetAsync(newHookResponse.Id);
+            var hook = await ApiClient.Hooks.GetAsync(newHookResponse.Id);
             hook.Should().NotBeNull();
-            hook.Name.StartsWith("integration-test-hook-2").Should().BeTrue();
+            hook.Name.StartsWith($"{TestingConstants.HooksPrefix}-2").Should().BeTrue();
             hook.Enabled.Should().BeTrue();
 
             // Delete the hook, and ensure we get exception when trying to fetch it again
-            await _apiClient.Hooks.DeleteAsync(hook.Id);
-            Func<Task> getFunc = async () => await _apiClient.Hooks.GetAsync(hook.Id);
+            await ApiClient.Hooks.DeleteAsync(hook.Id);
+            Func<Task> getFunc = async () => await ApiClient.Hooks.GetAsync(hook.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("HookDoesNotExist");
         }
 
@@ -80,7 +78,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
-            var hooks = await _apiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
+            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
 
             // Assert
             Assert.Null(hooks.Paging);
@@ -90,7 +88,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var hooks = await _apiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, false));
+            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, false));
 
             // Assert
             Assert.Null(hooks.Paging);
@@ -100,7 +98,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var hooks = await _apiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, true));
+            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, true));
 
             // Assert
             Assert.NotNull(hooks.Paging);
@@ -110,9 +108,9 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_without_paging()
         {
             // Add a new hook
-            var newHook = await _apiClient.Hooks.CreateAsync(new HookCreateRequest()
+            var newHook = await ApiClient.Hooks.CreateAsync(new HookCreateRequest()
             {
-                Name = $"integration-test-hook-{Guid.NewGuid():N}",
+                Name = $"{TestingConstants.HooksPrefix}-{Guid.NewGuid():N}",
                 Script = @"module.exports = function(client, scope, audience, context, callback) { {
                               // TODO: implement your hook
                               callback(null, context);
@@ -124,12 +122,12 @@ namespace Auth0.ManagementApi.IntegrationTests
             newHook.Should().NotBeNull();
             
             // Act
-            var hooks = await _apiClient.Hooks.GetAllAsync(new GetHooksRequest());
+            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest());
 
             hooks.Paging.Should().BeNull();
             hooks.Count.Should().BeGreaterThan(0);
 
-            await _apiClient.Hooks.DeleteAsync(newHook.Id);
+            await ApiClient.Hooks.DeleteAsync(newHook.Id);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/KeysTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/KeysTests.cs
@@ -1,26 +1,23 @@
 using System.Linq;
 using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
 using FluentAssertions;
 using Xunit;
-using Auth0.Tests.Shared;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class KeysTests : TestBase, IAsyncLifetime
+    public class KeysTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
-        private Connection _connection;
-        private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
-
         public async Task InitializeAsync()
         {
             await GetTokenAndInitializeAsync();
 
             // We will need a connection to add the roles to...
-            _connection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            var connection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Name = "Temp-Int-Test-" + MakeRandomName(),
+                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
                 Strategy = "auth0",
                 EnabledClients = new[] {GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID")}
             });
@@ -30,19 +27,18 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
-        public async Task DisposeAsync()
+        public override async Task DisposeAsync()
         {
-            await _apiClient.Connections.DeleteAsync(_connection.Id);
-            _apiClient.Dispose();
+            await CleanupAndDisposeAsync(CleanUpType.Connections);
         }
 
         [Fact]
         public async Task Test_keys_can_be_retrieved()
         {
-            var signingKeys = await _apiClient.Keys.GetAllAsync();
+            var signingKeys = await ApiClient.Keys.GetAllAsync();
 
             signingKeys.Any().Should().BeTrue();
         }
@@ -50,13 +46,13 @@ namespace Auth0.ManagementApi.IntegrationTests
         [Fact]
         public async Task Test_keys_can_be_retrieved_by_kid()
         {
-            var signingKeys = await _apiClient.Keys.GetAllAsync();
+            var signingKeys = await ApiClient.Keys.GetAllAsync();
 
             // select the current key id
             var currentKeyId = signingKeys.First(key => key.Current.HasValue && key.Current.Value).Kid;
 
             // retrieve the key by id
-            var currentKey = await _apiClient.Keys.GetAsync(currentKeyId);
+            var currentKey = await ApiClient.Keys.GetAsync(currentKeyId);
 
             currentKey.Kid.Should().Be(currentKeyId);
         }
@@ -65,12 +61,12 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_keys_rotate_signing_key()
         {
             // Rotate the signing key
-            var rotateKeyResponse = await _apiClient.Keys.RotateSigningKeyAsync();
+            var rotateKeyResponse = await ApiClient.Keys.RotateSigningKeyAsync();
             
             await GetTokenAndInitializeAsync();
 
             // Get all signing key
-            var signingKeys = await _apiClient.Keys.GetAllAsync();
+            var signingKeys = await ApiClient.Keys.GetAllAsync();
 
             // Select the next key
             var nextKey = signingKeys.First(key => key.Next.HasValue && key.Next.Value);
@@ -84,18 +80,18 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_keys_can_be_revoked_by_kid()
         {
             // Rotate the signing key before we revoke
-            var rotateKeyResponse = await _apiClient.Keys.RotateSigningKeyAsync();
+            var rotateKeyResponse = await ApiClient.Keys.RotateSigningKeyAsync();
 
             await GetTokenAndInitializeAsync();
 
             // Get all signing keys
-            var signingKeys = await _apiClient.Keys.GetAllAsync();
+            var signingKeys = await ApiClient.Keys.GetAllAsync();
 
             // Select the previous key id
             var previousKeyId = signingKeys.First(key => key.Previous.HasValue && key.Previous.Value).Kid;
 
             // Revoke the key by id
-            var revoked = await _apiClient.Keys.RevokeSigningKeyAsync(previousKeyId);
+            var revoked = await ApiClient.Keys.RevokeSigningKeyAsync(previousKeyId);
 
             // Assert
             revoked.Kid.Should().Be(previousKeyId);

--- a/tests/Auth0.ManagementApi.IntegrationTests/LoadTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LoadTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using Xunit;
@@ -26,7 +28,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             var connection = await apiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Name = "Temp-Int-Test-" + MakeRandomName(),
+                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
                 Strategy = "auth0",
                 EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
             });
@@ -39,7 +41,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 var newUserRequest = new UserCreateRequest
                 {
                     Connection = connection.Name,
-                    Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                    Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                     EmailVerified = true,
                     Password = Password
                 };

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using Xunit;
@@ -7,34 +8,26 @@ using Auth0.ManagementApi.Paging;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class LogsTests : TestBase, IAsyncLifetime
+    public class LogsTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
-
         public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
-        }
-
-        public Task DisposeAsync()
-        {
-            _apiClient.Dispose();
-            return Task.CompletedTask;
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
         [Fact(Skip = "Log entries seem to be disabled? Need to investigate...")]
         public async Task Can_fetch_single_entry()
         {
             // Get all log entries
-            var logEntries = await _apiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
+            var logEntries = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
 
             // Grab the first one
             var firstLogEntry = logEntries[0];
 
             // Now fetch just that single entry
-            var singleLogEntry = await _apiClient.Logs.GetAsync(firstLogEntry.Id);
+            var singleLogEntry = await ApiClient.Logs.GetAsync(firstLogEntry.Id);
 
             // Compare both log entries. They should be the same
             singleLogEntry.Should().BeEquivalentTo(firstLogEntry);
@@ -44,7 +37,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
-            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
+            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
             
             // Assert
             Assert.Null(logs.Paging);
@@ -54,7 +47,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, false));
+            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, false));
             
             // Assert
             Assert.Null(logs.Paging);
@@ -64,7 +57,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, true));
+            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, true));
             
             // Assert
             Assert.NotNull(logs.Paging);
@@ -74,7 +67,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_without_paging()
         {
             // Act
-            var logs = await _apiClient.Logs.GetAllAsync(new GetLogsRequest());
+            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest());
 
             // Assert
             logs.Paging.Should().BeNull();

--- a/tests/Auth0.ManagementApi.IntegrationTests/PromptsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/PromptsTests.cs
@@ -1,45 +1,44 @@
 ﻿using Auth0.Tests.Shared;
 using FluentAssertions;
 using System.Threading.Tasks;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models.Prompts;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class PromptsTests : TestBase, IAsyncLifetime
+    public class PromptsTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
         public async Task InitializeAsync()
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
-        public Task DisposeAsync()
+        public override Task DisposeAsync()
         {
-            _apiClient.Dispose();
-            return Task.CompletedTask;
+            return CleanupAndDisposeAsync();
         }
 
         [Fact]
         public async Task Test_get_and_update_prompts()
         {
-            var prompts = await _apiClient.Prompts.GetAsync();
+            var prompts = await ApiClient.Prompts.GetAsync();
             prompts.Should().NotBeNull();
 
             var originalExperience = prompts.UniversalLoginExperience;
             var newExperience = originalExperience == "classic" ? "new" : "classic";
 
-            await _apiClient.Prompts.UpdateAsync(new PromptUpdateRequest {UniversalLoginExperience = newExperience });
+            await ApiClient.Prompts.UpdateAsync(new PromptUpdateRequest {UniversalLoginExperience = newExperience });
 
-            prompts = await _apiClient.Prompts.GetAsync();
+            prompts = await ApiClient.Prompts.GetAsync();
             prompts.Should().NotBeNull();
             prompts.UniversalLoginExperience.Should().Be(newExperience);
 
-            await _apiClient.Prompts.UpdateAsync(new PromptUpdateRequest { UniversalLoginExperience = originalExperience });
+            await ApiClient.Prompts.UpdateAsync(new PromptUpdateRequest { UniversalLoginExperience = originalExperience });
 
-            prompts = await _apiClient.Prompts.GetAsync();
+            prompts = await ApiClient.Prompts.GetAsync();
             prompts.Should().NotBeNull();
             prompts.UniversalLoginExperience.Should().Be(originalExperience);
         }

--- a/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RolesTests.cs
@@ -9,12 +9,13 @@ using Xunit;
 using Auth0.Tests.Shared;
 using Auth0.ManagementApi.Paging;
 using System.Collections.Generic;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.IntegrationTests.Testing;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class RolesTests : TestBase, IAsyncLifetime
+    public class RolesTests : ManagementTestBase, IAsyncLifetime
     {
-        private ManagementApiClient _apiClient;
         private Connection _connection;
         private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
 
@@ -22,21 +23,21 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             string token = await GenerateManagementApiToken();
 
-            _apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
 
             // We will need a connection to add the roles to...
-            _connection = await _apiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            _connection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Name = "Temp-Int-Test-" + MakeRandomName(),
+                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
                 Strategy = "auth0",
                 EnabledClients = new[] {GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID")}
             });
         }
 
-        public async Task DisposeAsync()
+        public override async Task DisposeAsync()
         {
-            await _apiClient.Connections.DeleteAsync(_connection.Id);
-            _apiClient.Dispose();
+            await ApiClient.Connections.DeleteAsync(_connection.Id);
+            await CleanupAndDisposeAsync();
         }
 
         [Fact]
@@ -48,7 +49,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"{Guid.NewGuid():N}role",
                 Description = $"{Guid.NewGuid():N}description",
             };
-            var newRoleResponse = await _apiClient.Roles.CreateAsync(newRoleRequest);
+            var newRoleResponse = await ApiClient.Roles.CreateAsync(newRoleRequest);
             newRoleResponse.Should().NotBeNull();
             newRoleResponse.Name.Should().Be(newRoleRequest.Name);
             newRoleResponse.Description.Should().Be(newRoleRequest.Description);
@@ -58,12 +59,12 @@ namespace Auth0.ManagementApi.IntegrationTests
             {
                 Name = $"{Guid.NewGuid():N}role",
             };
-            var updateRoleResponse = await _apiClient.Roles.UpdateAsync(newRoleResponse.Id, updateRoleRequest);
+            var updateRoleResponse = await ApiClient.Roles.UpdateAsync(newRoleResponse.Id, updateRoleRequest);
             updateRoleResponse.Should().NotBeNull();
             updateRoleResponse.Name.Should().Be(updateRoleRequest.Name);
 
             // Get a single role
-            var role = await _apiClient.Roles.GetAsync(newRoleResponse.Id);
+            var role = await ApiClient.Roles.GetAsync(newRoleResponse.Id);
             role.Should().NotBeNull();
             role.Name.Should().Be(updateRoleResponse.Name);
 
@@ -71,11 +72,11 @@ namespace Auth0.ManagementApi.IntegrationTests
             var newUserRequest = new UserCreateRequest
             {
                 Connection = _connection.Name,
-                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
                 Password = Password
             };
-            var user = await _apiClient.Users.CreateAsync(newUserRequest);
+            var user = await ApiClient.Users.CreateAsync(newUserRequest);
 
             // Assign a user to the role
             var assignUsersRequest = new AssignUsersRequest
@@ -85,25 +86,25 @@ namespace Auth0.ManagementApi.IntegrationTests
                     user.UserId
                 }
             };
-            await _apiClient.Roles.AssignUsersAsync(role.Id, assignUsersRequest);
+            await ApiClient.Roles.AssignUsersAsync(role.Id, assignUsersRequest);
 
             // Ensure the user is assigned to the role
-            var assignedUsers = await _apiClient.Roles.GetUsersAsync(role.Id);
+            var assignedUsers = await ApiClient.Roles.GetUsersAsync(role.Id);
             assignedUsers.Should().NotBeNull();
             assignedUsers.First().UserId.Should().Be(user.UserId);
 
             // Ensure the Role is assigned to user
-            var assignedRoles = await _apiClient.Users.GetRolesAsync(user.UserId, new PaginationInfo());
+            var assignedRoles = await ApiClient.Users.GetRolesAsync(user.UserId, new PaginationInfo());
             assignedRoles.Should().NotBeNull();
             assignedRoles.First().Id.Should().Be(role.Id);
 
             // Delete the role and ensure we get an exception when trying to fetch them again
-            await _apiClient.Roles.DeleteAsync(role.Id);
-            Func<Task> getFunc = async () => await _apiClient.Roles.GetAsync(role.Id);
+            await ApiClient.Roles.DeleteAsync(role.Id);
+            Func<Task> getFunc = async () => await ApiClient.Roles.GetAsync(role.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.Error.Should().Be("Not Found");
 
             // Delete the user
-            await _apiClient.Users.DeleteAsync(user.UserId);
+            await ApiClient.Users.DeleteAsync(user.UserId);
         }
 
         [Fact]
@@ -115,7 +116,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"{Guid.NewGuid():N}role",
                 Description = $"{Guid.NewGuid():N}description",
             };
-            var role = await _apiClient.Roles.CreateAsync(newRoleRequest);
+            var role = await ApiClient.Roles.CreateAsync(newRoleRequest);
             role.Should().NotBeNull();
             role.Name.Should().Be(newRoleRequest.Name);
             role.Description.Should().Be(newRoleRequest.Description);
@@ -124,11 +125,11 @@ namespace Auth0.ManagementApi.IntegrationTests
             var newUserRequest = new UserCreateRequest
             {
                 Connection = _connection.Name,
-                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
                 Password = Password
             };
-            var user = await _apiClient.Users.CreateAsync(newUserRequest);
+            var user = await ApiClient.Users.CreateAsync(newUserRequest);
 
             // Assign a user to the role
             var assignUsersRequest = new AssignUsersRequest
@@ -138,16 +139,16 @@ namespace Auth0.ManagementApi.IntegrationTests
                     user.UserId
                 }
             };
-            await _apiClient.Roles.AssignUsersAsync(role.Id, assignUsersRequest);
+            await ApiClient.Roles.AssignUsersAsync(role.Id, assignUsersRequest);
 
             // Ensure the user is assigned to the role
-            var assignedUsers = await _apiClient.Roles.GetUsersAsync(role.Id);
+            var assignedUsers = await ApiClient.Roles.GetUsersAsync(role.Id);
             assignedUsers.Should().NotBeNull();
             assignedUsers.First().UserId.Should().Be(user.UserId);
 
             // Clean Up
-            await _apiClient.Roles.DeleteAsync(role.Id);
-            await _apiClient.Users.DeleteAsync(user.UserId);
+            await ApiClient.Roles.DeleteAsync(role.Id);
+            await ApiClient.Users.DeleteAsync(user.UserId);
         }
 
         [Fact]
@@ -159,7 +160,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"{Guid.NewGuid():N}role",
                 Description = $"{Guid.NewGuid():N}description",
             };
-            var role = await _apiClient.Roles.CreateAsync(newRoleRequest);
+            var role = await ApiClient.Roles.CreateAsync(newRoleRequest);
             role.Should().NotBeNull();
             role.Name.Should().Be(newRoleRequest.Name);
             role.Description.Should().Be(newRoleRequest.Description);
@@ -168,11 +169,11 @@ namespace Auth0.ManagementApi.IntegrationTests
             var newUserRequest = new UserCreateRequest
             {
                 Connection = _connection.Name,
-                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
                 Password = Password
             };
-            var user = await _apiClient.Users.CreateAsync(newUserRequest);
+            var user = await ApiClient.Users.CreateAsync(newUserRequest);
 
             // Assign a user to the role
             var assignRolesRequest = new AssignRolesRequest()
@@ -182,25 +183,25 @@ namespace Auth0.ManagementApi.IntegrationTests
                     role.Id
                 }
             };
-            await _apiClient.Users.AssignRolesAsync(user.UserId, assignRolesRequest);
+            await ApiClient.Users.AssignRolesAsync(user.UserId, assignRolesRequest);
 
             // Ensure the Role is assigned to user
-            var assignedRoles = await _apiClient.Users.GetRolesAsync(user.UserId, new PaginationInfo());
+            var assignedRoles = await ApiClient.Users.GetRolesAsync(user.UserId, new PaginationInfo());
             assignedRoles.Should().NotBeNull();
             assignedRoles.Should().HaveCount(1);
             assignedRoles.First().Id.Should().Be(role.Id);
 
             // Remove role from user
-            await _apiClient.Users.RemoveRolesAsync(user.UserId, assignRolesRequest);
+            await ApiClient.Users.RemoveRolesAsync(user.UserId, assignRolesRequest);
 
             // Ensure the Role has been removed from user
-            var removedRoles = await _apiClient.Users.GetRolesAsync(user.UserId, new PaginationInfo());
+            var removedRoles = await ApiClient.Users.GetRolesAsync(user.UserId, new PaginationInfo());
             removedRoles.Should().NotBeNull();
             removedRoles.Should().HaveCount(0);
 
             // Clean Up
-            await _apiClient.Roles.DeleteAsync(role.Id);
-            await _apiClient.Users.DeleteAsync(user.UserId);
+            await ApiClient.Roles.DeleteAsync(role.Id);
+            await ApiClient.Users.DeleteAsync(user.UserId);
         }
 
         [Fact]
@@ -212,20 +213,20 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"{Guid.NewGuid():N}role",
                 Description = $"{Guid.NewGuid():N}description",
             };
-            var role = await _apiClient.Roles.CreateAsync(newRoleRequest);
+            var role = await ApiClient.Roles.CreateAsync(newRoleRequest);
             role.Should().NotBeNull();
             role.Name.Should().Be(newRoleRequest.Name);
             role.Description.Should().Be(newRoleRequest.Description);
 
             // Get a resource server
-            var resourceServer = await _apiClient.ResourceServers.GetAsync("dotnet-testing");
+            var resourceServer = await ApiClient.ResourceServers.GetAsync("dotnet-testing");
             var originalScopes = resourceServer.Scopes != null ? resourceServer.Scopes.ToList() : new List<ResourceServerScope>();
 
             // Create a permission/scope
             var newScope = new ResourceServerScope { Value = $"{Guid.NewGuid():N}scope", Description = "Integration test" };
 
             // Update resource server with new scope
-            resourceServer = await _apiClient.ResourceServers.UpdateAsync(resourceServer.Id, new ResourceServerUpdateRequest
+            resourceServer = await ApiClient.ResourceServers.UpdateAsync(resourceServer.Id, new ResourceServerUpdateRequest
             {
                 Scopes = originalScopes.Concat(new[] { newScope }).ToList(),
             });
@@ -235,38 +236,38 @@ namespace Auth0.ManagementApi.IntegrationTests
             {
                 Permissions = new[] { new PermissionIdentity { Identifier = resourceServer.Identifier, Name = newScope.Value } } 
             };
-            await _apiClient.Roles.AssignPermissionsAsync(role.Id, assignPermissionsRequest);
+            await ApiClient.Roles.AssignPermissionsAsync(role.Id, assignPermissionsRequest);
 
             // Ensure the permission is associated with the role
-            var associatedPermissions = await _apiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo());
+            var associatedPermissions = await ApiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo());
             associatedPermissions.Should().NotBeNull();
             associatedPermissions.Should().HaveCount(1);
             associatedPermissions.First().Identifier.Should().Be(resourceServer.Identifier);
             associatedPermissions.First().Name.Should().Be(newScope.Value);
 
             // Unassociate a permission with the role
-            await _apiClient.Roles.RemovePermissionsAsync(role.Id, assignPermissionsRequest);
+            await ApiClient.Roles.RemovePermissionsAsync(role.Id, assignPermissionsRequest);
 
             // Ensure the permission is unassociated with the role
-            associatedPermissions = await _apiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo());
+            associatedPermissions = await ApiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo());
             associatedPermissions.Should().NotBeNull();
             associatedPermissions.Should().HaveCount(0);
 
             // Clean Up - Remove the permission from the resource server
-            await _apiClient.ResourceServers.UpdateAsync(resourceServer.Id, new ResourceServerUpdateRequest
+            await ApiClient.ResourceServers.UpdateAsync(resourceServer.Id, new ResourceServerUpdateRequest
             {
                 Scopes = originalScopes
             });
 
             // Clean Up - Remove the role
-            await _apiClient.Roles.DeleteAsync(role.Id);
+            await ApiClient.Roles.DeleteAsync(role.Id);
         }
 
         [Fact]
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
-            var roles = await _apiClient.Roles.GetAllAsync(new GetRolesRequest());
+            var roles = await ApiClient.Roles.GetAllAsync(new GetRolesRequest());
 
             // Assert
             Assert.Null(roles.Paging);
@@ -276,7 +277,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var roles = await _apiClient.Roles.GetAllAsync(new GetRolesRequest(), new PaginationInfo(0, 50, false));
+            var roles = await ApiClient.Roles.GetAllAsync(new GetRolesRequest(), new PaginationInfo(0, 50, false));
 
             // Assert
             Assert.Null(roles.Paging);
@@ -286,7 +287,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var roles = await _apiClient.Roles.GetAllAsync(new GetRolesRequest(), new PaginationInfo(0, 50, true));
+            var roles = await ApiClient.Roles.GetAllAsync(new GetRolesRequest(), new PaginationInfo(0, 50, true));
 
             // Assert
             Assert.NotNull(roles.Paging);
@@ -295,29 +296,29 @@ namespace Auth0.ManagementApi.IntegrationTests
         [Fact]
         public async Task Test_checkpoint_pagination()
         {
-            var role = await _apiClient.Roles.CreateAsync(new RoleCreateRequest
+            var role = await ApiClient.Roles.CreateAsync(new RoleCreateRequest
             {
                 Name = $"{Guid.NewGuid():N}role",
                 Description = $"{Guid.NewGuid():N}description",
             });
 
             // Create a user
-            var user1 = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            var user1 = await ApiClient.Users.CreateAsync(new UserCreateRequest
             {
                 Connection = _connection.Name,
-                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
                 Password = Password
             });
-            var user2 = await _apiClient.Users.CreateAsync(new UserCreateRequest
+            var user2 = await ApiClient.Users.CreateAsync(new UserCreateRequest
             {
                 Connection = _connection.Name,
-                Email = $"{Guid.NewGuid():N}@nonexistingdomain.aaa",
+                Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
                 Password = Password
             });
             
-            await _apiClient.Roles.AssignUsersAsync(role.Id, new AssignUsersRequest
+            await ApiClient.Roles.AssignUsersAsync(role.Id, new AssignUsersRequest
             {
                 Users = new[]
                 {
@@ -326,19 +327,19 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             });
 
-            var firstCheckPointPaginationRequest = await _apiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(1));
-            var secondCheckPointPaginationRequest = await _apiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(1, firstCheckPointPaginationRequest.Paging.Next));
+            var firstCheckPointPaginationRequest = await ApiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(1));
+            var secondCheckPointPaginationRequest = await ApiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(1, firstCheckPointPaginationRequest.Paging.Next));
 
             secondCheckPointPaginationRequest.Count.Should().Be(1);
             secondCheckPointPaginationRequest.Paging.Next.Should().NotBeNullOrEmpty();
 
-            var checkpointPagingationRequestWithoutNext = await _apiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(50));
+            var checkpointPagingationRequestWithoutNext = await ApiClient.Roles.GetUsersAsync(role.Id, new Paging.CheckpointPaginationInfo(50));
             checkpointPagingationRequestWithoutNext.Count.Should().Be(2);
             checkpointPagingationRequestWithoutNext.Paging.Next.Should().BeNullOrEmpty();
 
-            await _apiClient.Users.DeleteAsync(user1.UserId);
-            await _apiClient.Users.DeleteAsync(user2.UserId);
-            await _apiClient.Roles.DeleteAsync(role.Id);
+            await ApiClient.Users.DeleteAsync(user1.UserId);
+            await ApiClient.Users.DeleteAsync(user2.UserId);
+            await ApiClient.Roles.DeleteAsync(role.Id);
         }
 
         [Fact]
@@ -349,7 +350,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"{Guid.NewGuid():N}role",
                 Description = $"{Guid.NewGuid():N}description",
             };
-            var role = await _apiClient.Roles.CreateAsync(newRoleRequest);
+            var role = await ApiClient.Roles.CreateAsync(newRoleRequest);
 
             var assignPermissionsRequest = new AssignPermissionsRequest
             {
@@ -358,14 +359,14 @@ namespace Auth0.ManagementApi.IntegrationTests
                     new PermissionIdentity { Name = "dotnet:testing", Identifier = "dotnet-testing",  }
                 }
             };
-            await _apiClient.Roles.AssignPermissionsAsync(role.Id, assignPermissionsRequest);
+            await ApiClient.Roles.AssignPermissionsAsync(role.Id, assignPermissionsRequest);
 
-            var userPermissions = await _apiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo(0, 50, true));
+            var userPermissions = await ApiClient.Roles.GetPermissionsAsync(role.Id, new PaginationInfo(0, 50, true));
 
             Assert.Equal(1, userPermissions.Count);
 
-            await _apiClient.Roles.RemovePermissionsAsync(role.Id, assignPermissionsRequest);
-            await _apiClient.Roles.DeleteAsync(role.Id);
+            await ApiClient.Roles.RemovePermissionsAsync(role.Id, assignPermissionsRequest);
+            await ApiClient.Roles.DeleteAsync(role.Id);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
@@ -1,9 +1,9 @@
 ﻿using Auth0.AuthenticationApi.Models;
-using Microsoft.Extensions.Configuration;
 using Microsoft.IdentityModel.Logging;
 using System;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 // We do not want to hit the management API rate limit

--- a/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBase.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBase.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.Tests.Shared;
+
+namespace Auth0.ManagementApi.IntegrationTests.Testing
+{
+    public class ManagementTestBase : TestBase
+    {
+        protected ManagementApiClient ApiClient;
+        
+        public async Task CleanupAndDisposeAsync(CleanUpType? type = null)
+        {
+            if (ApiClient != null)
+            {
+                await RunCleanUp(type);
+                ApiClient.Dispose();
+            }
+        }
+
+        public virtual Task DisposeAsync()
+        {
+            if (ApiClient != null)
+            {
+                ApiClient.Dispose();
+            }
+
+            return Task.CompletedTask;
+        }
+
+        private async Task RunCleanUp(CleanUpType? type)
+        {
+            var strategies = new List<CleanUpStrategy>
+            {
+                new ActionsCleanUpStrategy(ApiClient),
+                new ClientsCleanUpStrategy(ApiClient),
+                new ConnectionsCleanUpStrategy(ApiClient),
+                new HooksCleanUpStrategy(ApiClient),
+                new OrganizationsCleanUpStrategy(ApiClient),
+                new ResourceServersCleanUpStrategy(ApiClient),
+                new UsersCleanUpStrategy(ApiClient)
+            };
+
+            var strategiesToRun = type != null ? strategies.FindAll(s => s.Type == type) : strategies;
+
+            foreach (var cleanUpStrategy in strategiesToRun)
+            {
+                await cleanUpStrategy.Run();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Our tests often leak resources on the Auth0 tenant, causing unstable CI runs.

This PR tries to improve this by adding a couple of clean ups.