### PR TITLE
[SDK-3172] Add ID Token validation to device-code and passwordless

### DIFF
--- a/src/Auth0.AuthenticationApi/Models/DeviceCodeTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/DeviceCodeTokenRequest.cs
@@ -14,5 +14,11 @@ namespace Auth0.AuthenticationApi.Models
         /// Client ID of the application.
         /// </summary>
         public string ClientId { get; set; }
+
+        /// <summary>
+        /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature
+        /// of Id Tokens.
+        /// </summary>
+        public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessTokenRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessTokenRequestBase.cs
@@ -37,5 +37,11 @@ namespace Auth0.AuthenticationApi.Models
         /// Optional, use `openid` to get an ID Token, or `openid profile email` to also include user profile information in the ID Token.
         /// </remarks>
         public string Scope { get; set; }
+
+        /// <summary>
+        /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature
+        /// of Id Tokens.
+        /// </summary>
+        public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
     }
 }


### PR DESCRIPTION
Our SDK validates ID Tokens for all but 3 method calls:

- Device Code
- Passwordless with Email
- Passwordless with SMS

We should align the validation here and ensure the above methods also validate the ID Token.

Note that this is technically a breaking change ... Anyone retrieving an Invalid ID Token will be able to use the methods today, while after this change they suddenly get an exception when calling one of these methods.

However, I would argue this should be fine to release in a **minor version**, as anyone that we break here is made aware of the incorrect ID Token usage. When needed, they can still rollback to a version prior to this change if they need a fix ASAP and then circle back on fixing their incorrect ID Tokens. But regardless I would argue we want to push them into correct ID Token usage sooner rather than later.

Apart from the above, this should be backwards compatible and not require any change for anyone using valid ID Tokens.

What do you think @stevehobbsdev ?