### PR TITLE
Fix warnings regarding XML comments

### DIFF
--- a/src/Auth0.ManagementApi/Clients/RulesConfigClient.cs
+++ b/src/Auth0.ManagementApi/Clients/RulesConfigClient.cs
@@ -37,7 +37,7 @@ namespace Auth0.ManagementApi.Clients
         /// <summary>
         /// Deletes a rules config variable.
         /// </summary>
-        /// <param name="id">The key of the rules-config to delete.</param>
+        /// <param name="key">The key of the rules-config to delete.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
         public Task DeleteAsync(string key, CancellationToken cancellationToken = default)

--- a/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
+++ b/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
@@ -36,6 +36,7 @@ namespace Auth0.ManagementApi
         /// </summary>
         /// <param name="httpClient">Optional <see cref="HttpClient"/> to use. If not specified one will
         /// be created and be used for all requests made by this instance.</param>
+        /// <param name="options">Optional <see cref="HttpClientManagementConnectionOptions"/> to use.</param>
         public HttpClientManagementConnection(HttpClient httpClient = null, HttpClientManagementConnectionOptions options = null)
         {
             ownHttpClient = httpClient == null;
@@ -49,6 +50,7 @@ namespace Auth0.ManagementApi
         /// <param name="handler"><see cref="HttpMessageHandler"/> to use with the managed 
         /// <see cref="HttpClient"/> that will be created and used for all requests made
         /// by this instance.</param>
+        /// <param name="options">Optional <see cref="HttpClientManagementConnectionOptions"/> to use.</param>
         public HttpClientManagementConnection(HttpMessageHandler handler, HttpClientManagementConnectionOptions options = null)
             : this(new HttpClient(handler ?? new HttpClientHandler()), options)
         {


### PR DESCRIPTION
Adds a few missing XML comments, and fixes one that was incorrectly using `id` instead of `key`.