### PR TITLE
Add ProvisioningTicketUrl

### DIFF
--- a/src/Auth0.ManagementApi/Models/Connection.cs
+++ b/src/Auth0.ManagementApi/Models/Connection.cs
@@ -32,7 +32,7 @@ namespace Auth0.ManagementApi.Models
         public string Strategy { get; set; }
 
         /// <summary>
-        /// The provisioning ticket URL
+        /// The provisioning ticket URL for AD / LDAP connections
         /// </summary>
         [JsonProperty("provisioning_ticket_url")]
         public string ProvisioningTicketUrl { get; set; }

--- a/src/Auth0.ManagementApi/Models/Connection.cs
+++ b/src/Auth0.ManagementApi/Models/Connection.cs
@@ -30,5 +30,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("strategy")]
         public string Strategy { get; set; }
+
+        /// <summary>
+        /// The provisioning ticket URL
+        /// </summary>
+        [JsonProperty("provisioning_ticket_url")]
+        public string ProvisioningTicketUrl { get; set; }
     }
 }


### PR DESCRIPTION
Added ProvisioningTicketUrl to Connection class.  ProvisioningTicketUrl (provisioning_ticket_url) is returned when getting connections of with specific strategies, including 'google-apps'.