### PR TITLE
Remove DisplayName from Connection as it exists on ConnectionBase

### DIFF
--- a/src/Auth0.ManagementApi/Models/Connection.cs
+++ b/src/Auth0.ManagementApi/Models/Connection.cs
@@ -14,12 +14,6 @@ namespace Auth0.ManagementApi.Models
         public string Id { get; set; }
 
         /// <summary>
-        /// Connection name used in login screen for Enterprise Connections.
-        /// </summary>
-        [JsonProperty("display_name")]
-        public string DisplayName { get; set; }
-
-        /// <summary>
         /// Whether the connection is domain level (true), or not (false).
         /// </summary>
         [JsonProperty("is_domain_connection")]


### PR DESCRIPTION
### Changes

As `DisplayName` is now defined on `ConnectionBase` (see #572), it should not be defined on `Connection`.

### References

#572 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
