### PR TITLE
Sign Auth0.IntegrationTests.Shared to avoid console warnings

### DIFF
--- a/tests/Auth0.IntegrationTests.Shared/Auth0.IntegrationTests.Shared.csproj
+++ b/tests/Auth0.IntegrationTests.Shared/Auth0.IntegrationTests.Shared.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\build\Auth0NetStrongName.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Signs the Auth0.IntegrationTests.Shared project to avoid console warnings:

<img width="1219" alt="image" src="https://user-images.githubusercontent.com/2146903/178476212-2fc28cbc-f2e5-49aa-9d05-4e712bb02f0f.png">
