### PR TITLE
Stabilize Integration Tests by using ClassFixtures in our tests

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ActionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ActionsClient.cs
@@ -97,7 +97,7 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="id">The id of the action to update.</param>
         /// <param name="request">Specifies criteria to use when updating an action.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-        /// <returns>The <see cref="Client"/> that was updated.</returns>
+        /// <returns>The <see cref="Action"/> that was updated.</returns>
         public Task<Action> UpdateAsync(string id, UpdateActionRequest request, CancellationToken cancellationToken = default)
         {
             return Connection.SendAsync<Action>(new HttpMethod("PATCH"), BuildUri($"{ActionsBasePath}/{ActionsPath}/{EncodePath(id)}"), request, DefaultHeaders, cancellationToken: cancellationToken);

--- a/src/Auth0.ManagementApi/Clients/IActionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IActionsClient.cs
@@ -45,7 +45,7 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="id">The id of the action to update.</param>
     /// <param name="request">Specifies criteria to use when updating an action.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-    /// <returns>The <see cref="Client"/> that was updated.</returns>
+    /// <returns>The <see cref="Action"/> that was updated.</returns>
     Task<Action> UpdateAsync(string id, UpdateActionRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
+++ b/src/Auth0.ManagementApi/HttpClientManagementConnection.cs
@@ -216,10 +216,10 @@ namespace Auth0.ManagementApi
                 // Use an exponential back-off with the formula:
                 // max(MIN_REQUEST_RETRY_DELAY, min(MAX_REQUEST_RETRY_DELAY, (BASE_DELAY * (2 ** attempt - 1)) + random_between(0, MAX_REQUEST_RETRY_JITTER)))
                 //
-                // ✔ Each attempt increases base delay by (100ms * (2 ** attempt - 1))
+                // ✔ Each attempt increases base delay by (250ms * (2 ** attempt - 1))
                 // ✔ Randomizes jitter, adding up to MAX_REQUEST_RETRY_JITTER (250ms)
-                // ✔ Never less than MIN_REQUEST_RETRY_DELAY (100ms)
-                // ✔ Never more than MAX_REQUEST_RETRY_DELAY (500ms)
+                // ✔ Never less than MIN_REQUEST_RETRY_DELAY (250ms)
+                // ✔ Never more than MAX_REQUEST_RETRY_DELAY (1000ms)
 
                 var wait = Convert.ToInt32(BASE_DELAY * Math.Pow(2, nrOfTries - 1));
                 wait = random.Next(wait + 1, wait + MAX_REQUEST_RETRY_JITTER);

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -31,6 +31,9 @@
     <None Update="client-secrets.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TestBaseFixture.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TestBaseFixture.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Auth0.AuthenticationApi.IntegrationTests.Testing;
+using Auth0.ManagementApi;
+using Auth0.Tests.Shared;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests
+{
+    public class TestBaseFixture : IAsyncLifetime
+    {
+        public ManagementApiClient ApiClient { get; private set; }
+
+        public virtual async Task InitializeAsync()
+        {
+            string token = await TestBaseUtils.GenerateManagementApiToken();
+
+            ApiClient = new ManagementApiClient(token, TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+        }
+
+        public virtual async Task DisposeAsync()
+        {
+            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient);
+        }
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TestBaseUtils.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TestBaseUtils.cs
@@ -1,0 +1,41 @@
+﻿using Auth0.AuthenticationApi.Models;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Auth0.Tests.Shared
+{
+    public class TestBaseUtils
+    {
+        public static string GetVariable(string variableName, bool throwIfMissing = true)
+        {
+            var value = TestBase.Config[variableName];
+            if (String.IsNullOrEmpty(value) && throwIfMissing)
+                throw new ArgumentOutOfRangeException($"Configuration value '{variableName}' has not been set.");
+            return value;
+        }
+
+        private static readonly Regex _alphaNumeric = new Regex("[^a-zA-Z0-9]");
+
+        public static string MakeRandomName()
+        {
+            return _alphaNumeric.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "");
+        }
+
+        public static async Task<string> GenerateManagementApiToken()
+        {
+            using (var authenticationApiClient = new TestAuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))
+            {
+                // Get the access token
+                var token = await authenticationApiClient.GetTokenAsync(new ClientCredentialsTokenRequest
+                {
+                    ClientId = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID"),
+                    ClientSecret = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_SECRET"),
+                    Audience = GetVariable("AUTH0_MANAGEMENT_API_AUDIENCE")
+                });
+
+                return token.AccessToken;
+            }
+        }
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi;
+
+namespace Auth0.AuthenticationApi.IntegrationTests.Testing
+{
+    public class ManagementTestBaseUtils
+    {
+        public static async Task CleanupAndDisposeAsync(ManagementApiClient client, IList<CleanUpType> types = null)
+        {
+            await RunCleanUp(client, types);
+            client.Dispose();
+        }
+        
+
+        private static async Task RunCleanUp(ManagementApiClient client, IList<CleanUpType> types = null)
+        {
+            var strategies = new List<CleanUpStrategy>
+            {
+                new ActionsCleanUpStrategy(client),
+                new ClientsCleanUpStrategy(client),
+                new ConnectionsCleanUpStrategy(client),
+                new HooksCleanUpStrategy(client),
+                new OrganizationsCleanUpStrategy(client),
+                new ResourceServersCleanUpStrategy(client),
+                new UsersCleanUpStrategy(client)
+            };
+
+            var strategiesToRun = types != null ? strategies.FindAll(s => types.Contains(s.Type)) : strategies;
+
+            foreach (var cleanUpStrategy in strategiesToRun)
+            {
+                await cleanUpStrategy.Run();
+            }
+        }
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/TestHttpClientAuthenticationConnection.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/TestHttpClientAuthenticationConnection.cs
@@ -1,4 +1,4 @@
-﻿using Auth0.AuthenticationApi;
+using Auth0.AuthenticationApi;
 using Auth0.Core.Exceptions;
 using Newtonsoft.Json;
 using System;
@@ -86,7 +86,7 @@ namespace Auth0.Tests.Shared
         {
             var maxNrOfTries = 3;
             var nrOfTries = 0;
-            var exponentialInterval = 1500;
+            var exponentialInterval = 5000;
 
             while (true)
             {
@@ -104,7 +104,7 @@ namespace Auth0.Tests.Shared
                     }
                 }
 
-                Thread.Sleep(nrOfTries * exponentialInterval);
+                await Task.Delay(nrOfTries * exponentialInterval);
             }
         }
 

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/xunit.runner.json
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
@@ -8,6 +8,7 @@
         Hooks,
         Organizations,
         ResourceServers,
-        Users
+        Users,
+        Rules
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/RulesCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/RulesCleanUpStrategy.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class RulesCleanUpStrategy : CleanUpStrategy
+    {
+        public RulesCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Rules, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            System.Diagnostics.Debug.WriteLine("Running RulesCleanUpStrategy");
+            var rules = await ApiClient.Rules.GetAllAsync(new ManagementApi.Models.GetRulesRequest(), new PaginationInfo());
+
+            foreach (var rule in rules)
+            {
+                if (rule.Name.StartsWith(TestingConstants.RulesRefix))
+                {
+                    Console.WriteLine($"Removing rule {rule.Name}");
+                    await ApiClient.Rules.DeleteAsync(rule.Id);
+                }
+            }
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/TestingConstants.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/TestingConstants.cs
@@ -5,6 +5,7 @@
         private static readonly string Suffix = "int-test";
 
         public static string ActionPrefix = $"{Suffix}";
+        public static string RulesRefix = $"{Suffix}";
         public static string ClientPrefix = $"{Suffix}";
         public static string ConnectionPrefix = $"{Suffix}";
         public static string HooksPrefix = $"{Suffix}";

--- a/tests/Auth0.ManagementApi.IntegrationTests/ActionsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ActionsTests.cs
@@ -10,28 +10,32 @@ using Auth0.ManagementApi.Paging;
 using FluentAssertions;
 using Xunit;
 
+
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class ActionsTests : ManagementTestBase, IAsyncLifetime
+    public class ActionsTestsFixture : TestBaseFixture
     {
-        public async Task InitializeAsync()
+        public override async Task DisposeAsync()
         {
-            string token = await GenerateManagementApiToken();
-
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Actions });
         }
+    }
 
-        public override Task DisposeAsync()
+    public class ActionsTests : IClassFixture<ActionsTestsFixture>
+    {
+        ActionsTestsFixture fixture;
+
+        public ActionsTests(ActionsTestsFixture fixture)
         {
-            return CleanupAndDisposeAsync(CleanUpType.Actions);
+            this.fixture = fixture;
         }
 
         [Fact]
         public async Task Test_actions_crud_sequence()
         {
-            var actionsBeforeCreate = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
+            var actionsBeforeCreate = await fixture.ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
 
-            var createdAction = await ApiClient.Actions.CreateAsync(new CreateActionRequest
+            var createdAction = await fixture.ApiClient.Actions.CreateAsync(new CreateActionRequest
             {
                 Name = $"{TestingConstants.ActionPrefix}-{Guid.NewGuid()}",
                 Code = "module.exports = () => {}",
@@ -40,12 +44,12 @@ namespace Auth0.ManagementApi.IntegrationTests
                 SupportedTriggers = new List<ActionSupportedTrigger> { new ActionSupportedTrigger { Id = "post-login", Version = "v2"} }
             });
 
-            var actionsAfterCreate = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
+            var actionsAfterCreate = await fixture.ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
 
             actionsAfterCreate.Count.Should().Be(actionsBeforeCreate.Count + 1);
             createdAction.Should().BeEquivalentTo(actionsAfterCreate.Last(), options => options.Excluding(o => o.Status));
 
-            var updatedAction = await ApiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
+            var updatedAction = await fixture.ApiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
             {
                 Code = "module.exports = () => { console.log(true); }"
             });
@@ -53,21 +57,21 @@ namespace Auth0.ManagementApi.IntegrationTests
             updatedAction.Should().BeEquivalentTo(createdAction, options => options.Excluding(o => o.Code).Excluding(o => o.UpdatedAt));
             updatedAction.Code.Should().Be("module.exports = () => { console.log(true); }");
 
-            var actionAfterUpdate = await ApiClient.Actions.GetAsync(updatedAction.Id);
+            var actionAfterUpdate = await fixture.ApiClient.Actions.GetAsync(updatedAction.Id);
 
             updatedAction.Should().BeEquivalentTo(actionAfterUpdate, options => options.Excluding(o => o.Status));
             actionAfterUpdate.Code.Should().Be("module.exports = () => { console.log(true); }");
 
-            await ApiClient.Actions.DeleteAsync(actionAfterUpdate.Id);
+            await fixture.ApiClient.Actions.DeleteAsync(actionAfterUpdate.Id);
 
-            var actionsAfterDelete = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
+            var actionsAfterDelete = await fixture.ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
             actionsAfterDelete.Count.Should().Be(actionsBeforeCreate.Count);
         }
 
         [Fact]
         public async Task Test_get_triggers()
         {
-            var triggers = await ApiClient.Actions.GetAllTriggersAsync();
+            var triggers = await fixture.ApiClient.Actions.GetAllTriggersAsync();
 
             triggers.Should().NotBeEmpty();
         }
@@ -75,9 +79,9 @@ namespace Auth0.ManagementApi.IntegrationTests
         [Fact]
         public async Task Test_get_and_update_trigger_bindings()
         {
-            var triggerBindingsBeforeCreate = await ApiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
+            var triggerBindingsBeforeCreate = await fixture.ApiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
             
-            var createdAction = await ApiClient.Actions.CreateAsync(new CreateActionRequest
+            var createdAction = await fixture.ApiClient.Actions.CreateAsync(new CreateActionRequest
             {
                 Name = $"{TestingConstants.ActionPrefix}-{Guid.NewGuid()}",
                 Code = "module.exports = () => {}",
@@ -86,9 +90,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                 SupportedTriggers = new List<ActionSupportedTrigger> { new ActionSupportedTrigger { Id = "post-login", Version = "v2" } }
             });
 
-            await ApiClient.Actions.DeployAsync(createdAction.Id);
+            await fixture.ApiClient.Actions.DeployAsync(createdAction.Id);
 
-            await ApiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
+            await fixture.ApiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
             {
                 Bindings = new List<UpdateTriggerBindingEntry>
                 {
@@ -104,23 +108,23 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             });
 
-            var triggerBindingsAfterCreate = await ApiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
+            var triggerBindingsAfterCreate = await fixture.ApiClient.Actions.GetAllTriggerBindingsAsync("post-login", new PaginationInfo());
 
             triggerBindingsAfterCreate.Count.Should().Be(triggerBindingsBeforeCreate.Count + 1);
 
-            await ApiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
+            await fixture.ApiClient.Actions.UpdateTriggerBindingsAsync("post-login", new UpdateTriggerBindingsRequest
             {
                 Bindings = new List<UpdateTriggerBindingEntry>()
             });
 
-            await ApiClient.Actions.DeleteAsync(createdAction.Id);
+            await fixture.ApiClient.Actions.DeleteAsync(createdAction.Id);
         }
 
         [Fact]
         public async Task Test_action_version_crud_sequence()
         {
             // 1. Create a new Action
-            var createdAction = await ApiClient.Actions.CreateAsync(new CreateActionRequest
+            var createdAction = await fixture.ApiClient.Actions.CreateAsync(new CreateActionRequest
             {
                 Name = $"{TestingConstants.ActionPrefix}-{Guid.NewGuid()}",
                 Code = "module.exports = () => {}",
@@ -130,43 +134,46 @@ namespace Auth0.ManagementApi.IntegrationTests
             });
 
             // 2. Get all the versions after the action was created
-            var versionsAfterCreate = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionsAfterCreate = await fixture.ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
             
             versionsAfterCreate.Count.Should().Be(0);
 
             // 3. Deploy the current version
-            await ApiClient.Actions.DeployAsync(createdAction.Id);
+            await fixture.ApiClient.Actions.DeployAsync(createdAction.Id);
 
             // 4. Get all the versions after the action was deployed
-            var versionsAfterDeploy = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionsAfterDeploy = await fixture.ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
             
             versionsAfterDeploy.Count.Should().Be(1);
 
             // 5. Update the action
-            await ApiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
+            await fixture.ApiClient.Actions.UpdateAsync(createdAction.Id, new UpdateActionRequest
             {
                 Code = "module.exports = () => { console.log(true); }"
             });
 
             // 6. Deploy the latest version
-            var deployedVersion = await ApiClient.Actions.DeployAsync(createdAction.Id);
-            
+            var deployedVersion = await fixture.ApiClient.Actions.DeployAsync(createdAction.Id);
+
+            // Wait 2 seconds because it can take a while for the Action to be deployed
+            await Task.Delay(2000);
+
             // 7. Get all the versions after the action was updated
-            var versionsAfterSecondDeploy = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionsAfterSecondDeploy = await fixture.ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
 
             versionsAfterSecondDeploy.Count.Should().Be(2);
             versionsAfterSecondDeploy.Single(v => v.Id == deployedVersion.Id).Deployed.Should().BeTrue();
             versionsAfterSecondDeploy.Single(v => v.Id != deployedVersion.Id).Deployed.Should().BeFalse();
 
-            var action = await ApiClient.Actions.GetAsync(createdAction.Id);
+            var action = await fixture.ApiClient.Actions.GetAsync(createdAction.Id);
             action.DeployedVersion.Id.Should().Be(deployedVersion.Id);
 
             // 9. Rollback
-            var rollbackedVersion = await ApiClient.Actions.RollbackToVersionAsync(createdAction.Id, versionsAfterDeploy.Single().Id);
+            var rollbackedVersion = await fixture.ApiClient.Actions.RollbackToVersionAsync(createdAction.Id, versionsAfterDeploy.Single().Id);
 
             // 10. Get all the versions after the action was rollbacked
-            var versionsAfterRollback = await ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
-            var versionAfterRollback = await ApiClient.Actions.GetVersionAsync(createdAction.Id, rollbackedVersion.Id);
+            var versionsAfterRollback = await fixture.ApiClient.Actions.GetAllVersionsAsync(createdAction.Id, new PaginationInfo());
+            var versionAfterRollback = await fixture.ApiClient.Actions.GetVersionAsync(createdAction.Id, rollbackedVersion.Id);
 
             versionsAfterRollback.Count.Should().Be(3);
             versionsAfterRollback.Single(v => v.Id == versionAfterRollback.Id).Should().BeEquivalentTo(versionAfterRollback);
@@ -174,7 +181,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             versionsAfterRollback.Where(v => v.Id != versionAfterRollback.Id).ToList().ForEach(v => v.Deployed.Should().BeFalse());
 
             // 10. Delete Action
-            await ApiClient.Actions.DeleteAsync(createdAction.Id);
+            await fixture.ApiClient.Actions.DeleteAsync(createdAction.Id);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
@@ -6,19 +6,21 @@ using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class AttackProtectionTests : ManagementTestBase, IAsyncLifetime
-    {
-        public async Task InitializeAsync()
-        {
-            string token = await GenerateManagementApiToken();
+    public class AttackProtectionTestsFixture : TestBaseFixture {}
 
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+    public class AttackProtectionTests : IClassFixture<AttackProtectionTestsFixture>
+    {
+        AttackProtectionTestsFixture fixture;
+
+        public AttackProtectionTests(AttackProtectionTestsFixture fixture)
+        {
+            this.fixture = fixture;
         }
 
         [Fact]
         public async Task Test_suspicious_ip_throttling_crud_sequence()
         {
-            var before = await ApiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
+            var before = await fixture.ApiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
 
             try
             {
@@ -42,9 +44,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 };
 
-                var updated = await ApiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(toUpdate);
+                var updated = await fixture.ApiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(toUpdate);
 
-                var after = await ApiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
+                var after = await fixture.ApiClient.AttackProtection.GetSuspiciousIpThrottlingAsync();
 
 
                 updated.Should().BeEquivalentTo(toUpdate);
@@ -52,14 +54,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             }
             finally
             {
-                await ApiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(before);
+                await fixture.ApiClient.AttackProtection.UpdateSuspiciousIpThrottlingAsync(before);
             }
         }
 
         [Fact]
         public async Task Test_breached_password_detection_crud_sequence()
         {
-            var before = await ApiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
+            var before = await fixture.ApiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
 
             try
             {
@@ -71,9 +73,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                     Enabled = true,
                 };
 
-                var updated = await ApiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(toUpdate);
+                var updated = await fixture.ApiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(toUpdate);
 
-                var after = await ApiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
+                var after = await fixture.ApiClient.AttackProtection.GetBreachedPasswordDetectionAsync();
 
 
                 updated.Should().BeEquivalentTo(toUpdate);
@@ -81,14 +83,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             }
             finally
             {
-                await ApiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(before);
+                await fixture.ApiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(before);
             }
         }
 
         [Fact]
         public async Task Test_brute_force_protection_crud_sequence()
         {
-            var before = await ApiClient.AttackProtection.GetBruteForceProtectionAsync();
+            var before = await fixture.ApiClient.AttackProtection.GetBruteForceProtectionAsync();
 
             try
             {
@@ -101,9 +103,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                     MaxAttempts = 11,
                 };
 
-                var updated = await ApiClient.AttackProtection.UpdateBruteForceProtectionAsync(toUpdate);
+                var updated = await fixture.ApiClient.AttackProtection.UpdateBruteForceProtectionAsync(toUpdate);
 
-                var after = await ApiClient.AttackProtection.GetBruteForceProtectionAsync();
+                var after = await fixture.ApiClient.AttackProtection.GetBruteForceProtectionAsync();
 
 
                 updated.Should().BeEquivalentTo(toUpdate);
@@ -111,7 +113,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             }
             finally
             {
-                await ApiClient.AttackProtection.UpdateBruteForceProtectionAsync(before);
+                await fixture.ApiClient.AttackProtection.UpdateBruteForceProtectionAsync(before);
             }
         }
     }

--- a/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
@@ -41,6 +41,9 @@
     <None Update="client-secrets.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
@@ -7,13 +7,15 @@ using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class BrandingClientTests : ManagementTestBase, IAsyncLifetime
-    {
-        public async Task InitializeAsync()
-        {
-            string token = await GenerateManagementApiToken();
+    public class BrandingClientTestsFixture : TestBaseFixture {}
 
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+    public class BrandingClientTests : IClassFixture<BrandingClientTestsFixture>
+    {
+        BrandingClientTestsFixture fixture;
+
+        public BrandingClientTests(BrandingClientTestsFixture fixture)
+        {
+            this.fixture = fixture;
         }
 
         [Fact]
@@ -22,7 +24,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             try
             {
                 // Update branding
-                await ApiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
+                await fixture.ApiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
                 {
                     LogoUrl = "https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-white.svg",
                     FaviconUrl = "https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-black.svg",
@@ -37,7 +39,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 });
 
-                var updatedBranding = await ApiClient.Branding.GetAsync();
+                var updatedBranding = await fixture.ApiClient.Branding.GetAsync();
 
                 Assert.Equal("https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-white.svg", updatedBranding.LogoUrl);
                 Assert.Equal("https://cdn.auth0.com/website/press/resources/auth0-logo-monotone-black.svg", updatedBranding.FaviconUrl);
@@ -49,7 +51,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             finally
             {
                 // Rollback
-                await ApiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
+                await fixture.ApiClient.Branding.UpdateAsync(new Models.BrandingUpdateRequest
                 {
                     Colors = new Models.BrandingColors { 
                         Primary = "#0059d6",
@@ -79,20 +81,20 @@ namespace Auth0.ManagementApi.IntegrationTests
                     {%- auth0:widget -%}
                   </body></html> ";
 
-                await ApiClient.Branding.SetUniversalLoginTemplateAsync(new Models.UniversalLoginTemplateUpdateRequest
+                await fixture.ApiClient.Branding.SetUniversalLoginTemplateAsync(new Models.UniversalLoginTemplateUpdateRequest
                 {
                     Template = newTemplateBody
                 });
 
-                var updatedTemplate = await ApiClient.Branding.GetUniversalLoginTemplateAsync();
+                var updatedTemplate = await fixture.ApiClient.Branding.GetUniversalLoginTemplateAsync();
 
                 Assert.Equal(newTemplateBody, updatedTemplate.Body);
             }
             finally
             {
-                await ApiClient.Branding.DeleteUniversalLoginTemplateAsync();
+                await fixture.ApiClient.Branding.DeleteUniversalLoginTemplateAsync();
 
-                await Assert.ThrowsAsync<ErrorApiException>(() => ApiClient.Branding.GetUniversalLoginTemplateAsync());
+                await Assert.ThrowsAsync<ErrorApiException>(() => fixture.ApiClient.Branding.GetUniversalLoginTemplateAsync());
             }
         }
     }

--- a/tests/Auth0.ManagementApi.IntegrationTests/EmailTemplatesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/EmailTemplatesTests.cs
@@ -2,51 +2,47 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Auth0.Core.Exceptions;
-using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
-using Auth0.Tests.Shared;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class EmailTemplatesTests : ManagementTestBase, IAsyncLifetime
+    public class EmailTemplatesTestsFixture : TestBaseFixture
     {
-        public async Task InitializeAsync()
+        public override async Task InitializeAsync()
         {
-            string token = await GenerateManagementApiToken();
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            await base.InitializeAsync();
 
-            try
+            await ApiClient.EmailProvider.ConfigureAsync(new EmailProviderConfigureRequest
             {
-                // We need to set an email provider when configuring templates
-                await ApiClient.EmailProvider.ConfigureAsync(new EmailProviderConfigureRequest
+                Name = "mandrill",
+                IsEnabled = true,
+                Credentials = new EmailProviderCredentials
                 {
-                    Name = "mandrill",
-                    IsEnabled = true,
-                    Credentials = new EmailProviderCredentials
-                    {
-                        ApiKey = "ABC"
-                    }
-                });
-            }
-            catch (ApiException)
-            {
-                // Was likely not cleaned-up in a previously failed test run
-            }
+                    ApiKey = "ABC"
+                }
+            });
         }
-
         public override async Task DisposeAsync()
         {
             await ApiClient.EmailProvider.DeleteAsync();
             await base.DisposeAsync();
+        }
+    }
+
+    public class EmailTemplatesTests : IClassFixture<EmailTemplatesTestsFixture>
+    {
+        EmailTemplatesTestsFixture fixture;
+
+        public EmailTemplatesTests(EmailTemplatesTestsFixture fixture)
+        {
+            this.fixture = fixture;
         }
 
         [Fact]
         public async Task Test_email_templates_crud_sequence()
         {
             var emailTemplateNames = Enum.GetValues(typeof(EmailTemplateName)).Cast<EmailTemplateName>();
-
-            string token = await GenerateManagementApiToken();
             
             // Create each template
             foreach (var emailTemplateName in emailTemplateNames)
@@ -55,7 +51,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 try
                 {
                     // Try and create the template. If it already exisits, we'll just update it
-                    emailTemplate = await ApiClient.EmailTemplates.CreateAsync(new EmailTemplateCreateRequest
+                    emailTemplate = await fixture.ApiClient.EmailTemplates.CreateAsync(new EmailTemplateCreateRequest
                     {
                         Template = emailTemplateName,
                         Body = "<html>",
@@ -68,7 +64,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
                 catch (ApiException)
                 {
-                    emailTemplate = await ApiClient.EmailTemplates.UpdateAsync(emailTemplateName, new EmailTemplateUpdateRequest
+                    emailTemplate = await fixture.ApiClient.EmailTemplates.UpdateAsync(emailTemplateName, new EmailTemplateUpdateRequest
                     {
                         Template = emailTemplateName,
                         Body = "<html>",
@@ -84,7 +80,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 foreach (var _emailTemplateName in emailTemplateNames)
                 {
                     // Try and create the template. If it already exisits, we'll just update it
-                    var _emailTemplate = await ApiClient.EmailTemplates.PatchAsync(_emailTemplateName, new EmailTemplatePatchRequest
+                    var _emailTemplate = await fixture.ApiClient.EmailTemplates.PatchAsync(_emailTemplateName, new EmailTemplatePatchRequest
                     {
                         Enabled = false,
                         From = "test2@test.com"

--- a/tests/Auth0.ManagementApi.IntegrationTests/HooksTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/HooksTests.cs
@@ -8,27 +8,32 @@ using FluentAssertions;
 using Xunit;
 using Auth0.ManagementApi.Paging;
 using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class HooksTests : ManagementTestBase, IAsyncLifetime
+    public class HooksTestsFixture : TestBaseFixture
     {
-        public async Task InitializeAsync()
+        public override async Task DisposeAsync()
         {
-            string token = await GenerateManagementApiToken();
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Hooks });
         }
+    }
 
-        public override Task DisposeAsync()
+    public class HooksTests : IClassFixture<HooksTestsFixture>
+    {
+        HooksTestsFixture fixture;
+
+        public HooksTests(HooksTestsFixture fixture)
         {
-            return CleanupAndDisposeAsync(CleanUpType.Hooks);
+            this.fixture = fixture;
         }
 
         [Fact]
         public async Task Test_hooks_crud_sequence()
         {
             // Get all hooks
-            var hooksBefore = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
+            var hooksBefore = await fixture.ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
 
             // Add a new hook
             var newHookRequest = new HookCreateRequest()
@@ -41,12 +46,12 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Dependencies = JObject.Parse("{ \"auth0\": \"2.32.0\"}"),
                 TriggerId = "credentials-exchange"
             };
-            var newHookResponse = await ApiClient.Hooks.CreateAsync(newHookRequest);
+            var newHookResponse = await fixture.ApiClient.Hooks.CreateAsync(newHookRequest);
             newHookResponse.Should().NotBeNull();
             Assert.True(JObject.DeepEquals(newHookRequest.Dependencies, newHookResponse.Dependencies));
 
             // Get all the hooks again, and check that we now have one more
-            var hooksAfter = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
+            var hooksAfter = await fixture.ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
             hooksAfter.Count.Should().Be(hooksBefore.Count + 1);
 
             // Update the Hook
@@ -55,7 +60,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Name = $"{TestingConstants.HooksPrefix}-2-{Guid.NewGuid():N}",
                 Enabled = true
             };
-            var updateHookResponse = await ApiClient.Hooks.UpdateAsync(newHookResponse.Id, updateHookRequest);
+            var updateHookResponse = await fixture.ApiClient.Hooks.UpdateAsync(newHookResponse.Id, updateHookRequest);
             updateHookResponse.Should().NotBeNull();
             // Because the Hooks endpoint changes the name of a Hook when using a Guid in the name, 
             // we can only verify the name starts with the part without the Guid.
@@ -63,14 +68,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             updateHookResponse.Enabled.Should().BeTrue();
 
             // Get a single hook
-            var hook = await ApiClient.Hooks.GetAsync(newHookResponse.Id);
+            var hook = await fixture.ApiClient.Hooks.GetAsync(newHookResponse.Id);
             hook.Should().NotBeNull();
             hook.Name.StartsWith($"{TestingConstants.HooksPrefix}-2").Should().BeTrue();
             hook.Enabled.Should().BeTrue();
 
             // Delete the hook, and ensure we get exception when trying to fetch it again
-            await ApiClient.Hooks.DeleteAsync(hook.Id);
-            Func<Task> getFunc = async () => await ApiClient.Hooks.GetAsync(hook.Id);
+            await fixture.ApiClient.Hooks.DeleteAsync(hook.Id);
+            Func<Task> getFunc = async () => await fixture.ApiClient.Hooks.GetAsync(hook.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("HookDoesNotExist");
         }
 
@@ -78,7 +83,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
-            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
+            var hooks = await fixture.ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
 
             // Assert
             Assert.Null(hooks.Paging);
@@ -88,7 +93,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, false));
+            var hooks = await fixture.ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, false));
 
             // Assert
             Assert.Null(hooks.Paging);
@@ -98,7 +103,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, true));
+            var hooks = await fixture.ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo(0, 50, true));
 
             // Assert
             Assert.NotNull(hooks.Paging);
@@ -108,7 +113,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_without_paging()
         {
             // Add a new hook
-            var newHook = await ApiClient.Hooks.CreateAsync(new HookCreateRequest()
+            var newHook = await fixture.ApiClient.Hooks.CreateAsync(new HookCreateRequest()
             {
                 Name = $"{TestingConstants.HooksPrefix}-{Guid.NewGuid():N}",
                 Script = @"module.exports = function(client, scope, audience, context, callback) { {
@@ -122,12 +127,12 @@ namespace Auth0.ManagementApi.IntegrationTests
             newHook.Should().NotBeNull();
             
             // Act
-            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest());
+            var hooks = await fixture.ApiClient.Hooks.GetAllAsync(new GetHooksRequest());
 
             hooks.Paging.Should().BeNull();
             hooks.Count.Should().BeGreaterThan(0);
 
-            await ApiClient.Hooks.DeleteAsync(newHook.Id);
+            await fixture.ApiClient.Hooks.DeleteAsync(newHook.Id);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
@@ -10,56 +10,64 @@ using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class JobsTest : ManagementTestBase, IAsyncLifetime
+    public class JobsTestsFixture : TestBaseFixture
     {
-        private Connection _auth0Connection;
-        private Connection _emailConnection;
-        private User _auth0User;
-        private User _emailUser;
+        public Connection TestAuth0Connection;
+        public Connection TestEmailConnection;
+        public User TestAuth0User;
+        public User TestEmailUser;
         private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
 
-        public async Task InitializeAsync()
+        public override async Task InitializeAsync()
         {
-            string token = await GenerateManagementApiToken();
-
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            await base.InitializeAsync();
 
             // Create a connection
-            _auth0Connection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            TestAuth0Connection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
+                Name = $"{TestingConstants.ConnectionPrefix}-{TestBaseUtils.MakeRandomName()}",
                 Strategy = "auth0",
-                EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
+                EnabledClients = new[] { TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"), TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
             });
 
-            _emailConnection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            TestEmailConnection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
+                Name = $"{TestingConstants.ConnectionPrefix}-{TestBaseUtils.MakeRandomName()}",
                 Strategy = "email",
-                EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
+                EnabledClients = new[] { TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"), TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
             });
 
             // Create a user
-            _auth0User = await ApiClient.Users.CreateAsync(new UserCreateRequest
+            TestAuth0User = await ApiClient.Users.CreateAsync(new UserCreateRequest
             {
-                Connection = _auth0Connection.Name,
+                Connection = TestAuth0Connection.Name,
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
                 Password = Password
             });
 
-            _emailUser = await ApiClient.Users.CreateAsync(new UserCreateRequest
+            TestEmailUser = await ApiClient.Users.CreateAsync(new UserCreateRequest
             {
-                Connection = _emailConnection.Name,
+                Connection = TestEmailConnection.Name,
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
             });
+
         }
 
         public override async Task DisposeAsync()
         {
-            await CleanupAndDisposeAsync(CleanUpType.Users);
-            await CleanupAndDisposeAsync(CleanUpType.Connections);
+            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Users, CleanUpType.Connections });
+        }
+    }
+
+    public class JobsTest : IClassFixture<JobsTestsFixture>
+    {
+        JobsTestsFixture fixture;
+
+        public JobsTest(JobsTestsFixture fixture)
+        {
+            this.fixture = fixture;
         }
 
         [Fact]
@@ -67,52 +75,52 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var existingOrganizationId = "org_Jif6mLeWXT5ec0nu";
 
-            await ApiClient.Organizations.AddMembersAsync(existingOrganizationId, new OrganizationAddMembersRequest
+            await fixture.ApiClient.Organizations.AddMembersAsync(existingOrganizationId, new OrganizationAddMembersRequest
             {
-                Members = new List<string> { _auth0User.UserId }
+                Members = new List<string> { fixture.TestAuth0User.UserId }
             });
 
-            var sendVerification = await ApiClient.Jobs.SendVerificationEmailAsync(new VerifyEmailJobRequest
+            var sendVerification = await fixture.ApiClient.Jobs.SendVerificationEmailAsync(new VerifyEmailJobRequest
             {
-                UserId = _auth0User.UserId,
-                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                UserId = fixture.TestAuth0User.UserId,
+                ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
                 OrganizationId = existingOrganizationId
             });
             sendVerification.Should().NotBeNull();
             sendVerification.Id.Should().NotBeNull();
 
             // Check to see whether we can get the same job again
-            var job = await ApiClient.Jobs.GetAsync(sendVerification.Id);
+            var job = await fixture.ApiClient.Jobs.GetAsync(sendVerification.Id);
             job.Should().NotBeNull();
             job.Id.Should().Be(sendVerification.Id);
             job.Type.Should().Be("verification_email");
             job.Status.Should().Be("pending");
             job.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
 
-            await ApiClient.Organizations.DeleteMemberAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
+            await fixture.ApiClient.Organizations.DeleteMemberAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
             {
-                Members = new List<string> { _auth0User.UserId }
+                Members = new List<string> { fixture.TestAuth0User.UserId }
             });
         }
 
         [Fact]
         public async Task Can_send_verification_email_with_identity()
         {
-            var sendVerification = await ApiClient.Jobs.SendVerificationEmailAsync(new VerifyEmailJobRequest
+            var sendVerification = await fixture.ApiClient.Jobs.SendVerificationEmailAsync(new VerifyEmailJobRequest
             {
-                UserId = _emailUser.UserId,
-                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                UserId = fixture.TestEmailUser.UserId,
+                ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
                 Identity = new EmailVerificationIdentity
                 {
                     Provider = "email",
-                    UserId = _emailUser.UserId.Replace("email|", "")
+                    UserId = fixture.TestEmailUser.UserId.Replace("email|", "")
                 }
             });
             sendVerification.Should().NotBeNull();
             sendVerification.Id.Should().NotBeNull();
 
             // Check to see whether we can get the same job again
-            var job = await ApiClient.Jobs.GetAsync(sendVerification.Id);
+            var job = await fixture.ApiClient.Jobs.GetAsync(sendVerification.Id);
             job.Should().NotBeNull();
             job.Id.Should().Be(sendVerification.Id);
             job.Type.Should().Be("verification_email");
@@ -126,14 +134,14 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Send a user import request
             using (var stream = GetType().Assembly.GetManifestResourceStream("Auth0.ManagementApi.IntegrationTests.user-import-test.json"))
             {
-                var importUsers = await ApiClient.Jobs.ImportUsersAsync(_auth0Connection.Id, "user-import-test.json", stream, sendCompletionEmail: false);
+                var importUsers = await fixture.ApiClient.Jobs.ImportUsersAsync(fixture.TestAuth0Connection.Id, "user-import-test.json", stream, sendCompletionEmail: false);
                 importUsers.Should().NotBeNull();
                 importUsers.Id.Should().NotBeNull();
                 importUsers.Type.Should().Be("users_import");
                 importUsers.Status.Should().Be("pending");
                 importUsers.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
-                importUsers.ConnectionId.Should().Be(_auth0Connection.Id);
-                importUsers.Connection.Should().Be(_auth0Connection.Name);
+                importUsers.ConnectionId.Should().Be(fixture.TestAuth0Connection.Id);
+                importUsers.Connection.Should().Be(fixture.TestAuth0Connection.Name);
             }
         }
 
@@ -142,20 +150,20 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var request = new UsersExportsJobRequest
             {
-                ConnectionId = _auth0Connection.Id,
+                ConnectionId = fixture.TestAuth0Connection.Id,
                 Format = UsersExportsJobFormat.JSON,
                 Limit = 1,
                 Fields = new System.Collections.Generic.List<UsersExportsJobField> { new UsersExportsJobField { Name = "email" } }
             };
 
-            var exportUsers = await ApiClient.Jobs.ExportUsersAsync(request);
+            var exportUsers = await fixture.ApiClient.Jobs.ExportUsersAsync(request);
             exportUsers.Should().NotBeNull();
             exportUsers.Id.Should().NotBeNull();
             exportUsers.Type.Should().Be("users_export");
             exportUsers.Status.Should().Be("pending");
             exportUsers.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
-            exportUsers.ConnectionId.Should().Be(_auth0Connection.Id);
-            exportUsers.Connection.Should().Be(_auth0Connection.Name);
+            exportUsers.ConnectionId.Should().Be(fixture.TestAuth0Connection.Id);
+            exportUsers.Connection.Should().Be(fixture.TestAuth0Connection.Name);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/KeysTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/KeysTests.cs
@@ -1,44 +1,25 @@
 using System.Linq;
 using System.Threading.Tasks;
-using Auth0.IntegrationTests.Shared.CleanUp;
-using Auth0.ManagementApi.IntegrationTests.Testing;
-using Auth0.ManagementApi.Models;
 using FluentAssertions;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class KeysTests : ManagementTestBase, IAsyncLifetime
+    public class KeysTestsFixture : TestBaseFixture {}
+
+    public class KeysTests : IClassFixture<KeysTestsFixture>
     {
-        public async Task InitializeAsync()
+        KeysTestsFixture fixture;
+
+        public KeysTests(KeysTestsFixture fixture)
         {
-            await GetTokenAndInitializeAsync();
-
-            // We will need a connection to add the roles to...
-            var connection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
-            {
-                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
-                Strategy = "auth0",
-                EnabledClients = new[] {GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID")}
-            });
-        }
-
-        private async Task GetTokenAndInitializeAsync()
-        {
-            string token = await GenerateManagementApiToken();
-
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
-        }
-
-        public override async Task DisposeAsync()
-        {
-            await CleanupAndDisposeAsync(CleanUpType.Connections);
+            this.fixture = fixture;
         }
 
         [Fact]
         public async Task Test_keys_can_be_retrieved()
         {
-            var signingKeys = await ApiClient.Keys.GetAllAsync();
+            var signingKeys = await fixture.ApiClient.Keys.GetAllAsync();
 
             signingKeys.Any().Should().BeTrue();
         }
@@ -46,13 +27,13 @@ namespace Auth0.ManagementApi.IntegrationTests
         [Fact]
         public async Task Test_keys_can_be_retrieved_by_kid()
         {
-            var signingKeys = await ApiClient.Keys.GetAllAsync();
+            var signingKeys = await fixture.ApiClient.Keys.GetAllAsync();
 
             // select the current key id
             var currentKeyId = signingKeys.First(key => key.Current.HasValue && key.Current.Value).Kid;
 
             // retrieve the key by id
-            var currentKey = await ApiClient.Keys.GetAsync(currentKeyId);
+            var currentKey = await fixture.ApiClient.Keys.GetAsync(currentKeyId);
 
             currentKey.Kid.Should().Be(currentKeyId);
         }
@@ -61,12 +42,12 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_keys_rotate_signing_key()
         {
             // Rotate the signing key
-            var rotateKeyResponse = await ApiClient.Keys.RotateSigningKeyAsync();
+            var rotateKeyResponse = await fixture.ApiClient.Keys.RotateSigningKeyAsync();
             
-            await GetTokenAndInitializeAsync();
+            await fixture.InitializeAsync();
 
             // Get all signing key
-            var signingKeys = await ApiClient.Keys.GetAllAsync();
+            var signingKeys = await fixture.ApiClient.Keys.GetAllAsync();
 
             // Select the next key
             var nextKey = signingKeys.First(key => key.Next.HasValue && key.Next.Value);
@@ -80,18 +61,18 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_keys_can_be_revoked_by_kid()
         {
             // Rotate the signing key before we revoke
-            var rotateKeyResponse = await ApiClient.Keys.RotateSigningKeyAsync();
+            var rotateKeyResponse = await fixture.ApiClient.Keys.RotateSigningKeyAsync();
 
-            await GetTokenAndInitializeAsync();
+            await fixture.InitializeAsync();
 
             // Get all signing keys
-            var signingKeys = await ApiClient.Keys.GetAllAsync();
+            var signingKeys = await fixture.ApiClient.Keys.GetAllAsync();
 
             // Select the previous key id
             var previousKeyId = signingKeys.First(key => key.Previous.HasValue && key.Previous.Value).Kid;
 
             // Revoke the key by id
-            var revoked = await ApiClient.Keys.RevokeSigningKeyAsync(previousKeyId);
+            var revoked = await fixture.ApiClient.Keys.RevokeSigningKeyAsync(previousKeyId);
 
             // Assert
             revoked.Kid.Should().Be(previousKeyId);

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogStreamsTests.cs
@@ -1,32 +1,39 @@
 ﻿using Auth0.Core.Exceptions;
 using Auth0.ManagementApi.Models;
-using Auth0.Tests.Shared;
 using FluentAssertions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Auth0.ManagementApi.IntegrationTests.Testing;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class LogStreamsTests : ManagementTestBase, IAsyncLifetime
+    public class LogStreamsTestsFixture : TestBaseFixture
     {
+    }
+
+    public class LogStreamsTests : IClassFixture<LogStreamsTestsFixture>, IAsyncLifetime
+    {
+        LogStreamsTestsFixture fixture;
         private readonly List<LogStream> _createdStreams = new List<LogStream>();
 
-        public async Task InitializeAsync()
+        public LogStreamsTests(LogStreamsTestsFixture fixture)
         {
-            string token = await GenerateManagementApiToken();
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            this.fixture = fixture;
         }
 
-        public override Task DisposeAsync()
+        public Task InitializeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task DisposeAsync()
         {
             // Clean up any log stream entities on the tenant after every test executes
-            var deleteTasks = _createdStreams.Select(stream => ApiClient.LogStreams.DeleteAsync(stream.Id));
+            var deleteTasks = _createdStreams.Select(stream => fixture.ApiClient.LogStreams.DeleteAsync(stream.Id));
 
-            return Task.WhenAll(deleteTasks.ToArray()).ContinueWith(_ => base.DisposeAsync());
+            await Task.WhenAll(deleteTasks.ToArray());
         }
 
         [Fact]
@@ -48,14 +55,14 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             };
 
-            var createdLogStream = await ApiClient.LogStreams.CreateAsync(request);
+            var createdLogStream = await fixture.ApiClient.LogStreams.CreateAsync(request);
             _createdStreams.Add(createdLogStream);
 
             createdLogStream.Should().NotBeNull();
             createdLogStream.Name.Should().Be(name);
 
             // Get an entity
-            var fetchedLogStream = await ApiClient.LogStreams.GetAsync(createdLogStream.Id);
+            var fetchedLogStream = await fixture.ApiClient.LogStreams.GetAsync(createdLogStream.Id);
             fetchedLogStream.Should().NotBeNull();
             fetchedLogStream.Name.Should().Be(name);
             fetchedLogStream.Id.Should().Be(createdLogStream.Id);
@@ -71,7 +78,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 }
             };
 
-            var updatedLogStream = await ApiClient.LogStreams.UpdateAsync(fetchedLogStream.Id, updateRequest);
+            var updatedLogStream = await fixture.ApiClient.LogStreams.UpdateAsync(fetchedLogStream.Id, updateRequest);
             updatedLogStream.Name.Should().Be(updateRequest.Name);
             updatedLogStream.Status.Should().Be(LogStreamStatus.Paused);
             updatedLogStream.Id.Should().Be(fetchedLogStream.Id);
@@ -81,8 +88,8 @@ namespace Auth0.ManagementApi.IntegrationTests
             ((string)updatedLogStream.Sink.httpEndpoint).Should().Be(updateRequest.Sink.httpEndpoint);
 
             // Delete the entity
-            await ApiClient.LogStreams.DeleteAsync(createdLogStream.Id);
-            Func<Task> getFunc = async () => await ApiClient.LogStreams.GetAsync(createdLogStream.Id);
+            await fixture.ApiClient.LogStreams.DeleteAsync(createdLogStream.Id);
+            Func<Task> getFunc = async () => await fixture.ApiClient.LogStreams.GetAsync(createdLogStream.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.Error.Should().Be("Not Found");
         }
 
@@ -119,11 +126,11 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             foreach(var request in requests)
             {
-                _createdStreams.Add(await ApiClient.LogStreams.CreateAsync(request));
+                _createdStreams.Add(await fixture.ApiClient.LogStreams.CreateAsync(request));
             }
 
             // Act
-            var streams = await ApiClient.LogStreams.GetAllAsync();
+            var streams = await fixture.ApiClient.LogStreams.GetAllAsync();
 
             // Assert
             streams.Count.Should().Be(2);

--- a/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/LogsTests.cs
@@ -1,33 +1,33 @@
 ﻿using System.Threading.Tasks;
-using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
-using Auth0.Tests.Shared;
 using Xunit;
 using FluentAssertions;
 using Auth0.ManagementApi.Paging;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class LogsTests : ManagementTestBase, IAsyncLifetime
-    {
-        public async Task InitializeAsync()
-        {
-            string token = await GenerateManagementApiToken();
+    public class LogsTestsFixture : TestBaseFixture {}
 
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+    public class LogsTests : IClassFixture<LogsTestsFixture>
+    {
+        LogsTestsFixture fixture;
+
+        public LogsTests(LogsTestsFixture fixture)
+        {
+            this.fixture = fixture;
         }
 
         [Fact(Skip = "Log entries seem to be disabled? Need to investigate...")]
         public async Task Can_fetch_single_entry()
         {
             // Get all log entries
-            var logEntries = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
+            var logEntries = await fixture.ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
 
             // Grab the first one
             var firstLogEntry = logEntries[0];
 
             // Now fetch just that single entry
-            var singleLogEntry = await ApiClient.Logs.GetAsync(firstLogEntry.Id);
+            var singleLogEntry = await fixture.ApiClient.Logs.GetAsync(firstLogEntry.Id);
 
             // Compare both log entries. They should be the same
             singleLogEntry.Should().BeEquivalentTo(firstLogEntry);
@@ -37,7 +37,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
-            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
+            var logs = await fixture.ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo());
             
             // Assert
             Assert.Null(logs.Paging);
@@ -47,7 +47,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, false));
+            var logs = await fixture.ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, false));
             
             // Assert
             Assert.Null(logs.Paging);
@@ -57,7 +57,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, true));
+            var logs = await fixture.ApiClient.Logs.GetAllAsync(new GetLogsRequest(), new PaginationInfo(0, 50, true));
             
             // Assert
             Assert.NotNull(logs.Paging);
@@ -67,7 +67,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_without_paging()
         {
             // Act
-            var logs = await ApiClient.Logs.GetAllAsync(new GetLogsRequest());
+            var logs = await fixture.ApiClient.Logs.GetAllAsync(new GetLogsRequest());
 
             // Assert
             logs.Paging.Should().BeNull();

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -4,7 +4,6 @@ using Auth0.Tests.Shared;
 using FluentAssertions;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi.IntegrationTests.Testing;
@@ -12,33 +11,36 @@ using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class OrganizationTests : ManagementTestBase, IAsyncLifetime
+    public class OrganizationTestsFixture : TestBaseFixture
+    {
+        public override async Task DisposeAsync()
+        {
+            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Organizations });
+        }
+    }
+
+    public class OrganizationTests : IClassFixture<OrganizationTestsFixture>
     {
         private const string ExistingOrganizationId = "org_Jif6mLeWXT5ec0nu";
         private const string ExistingConnectionId = "con_vKey1CGOPTJClWrB";
         private const string ExistingRoleId = "rol_gOsYvLA232E0vg7p";
         private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
 
-        public async Task InitializeAsync()
-        {
-            string token = await GenerateManagementApiToken();
+        OrganizationTestsFixture fixture;
 
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
-        }
-
-        public override Task DisposeAsync()
+        public OrganizationTests(OrganizationTestsFixture fixture)
         {
-            return CleanupAndDisposeAsync(CleanUpType.Organizations);
+            this.fixture = fixture;
         }
 
         [Fact]
         public async Task Test_organizations_crud_sequence()
         {
-            var initialOrganizations = await ApiClient.Organizations.GetAllAsync(new Paging.PaginationInfo());
+            var initialOrganizations = await fixture.ApiClient.Organizations.GetAllAsync(new Paging.PaginationInfo());
 
             var createRequest = new OrganizationCreateRequest
             {
-                Name = ($"{TestingConstants.OrganizationPrefix}-{MakeRandomName()}").ToLower(),
+                Name = ($"{TestingConstants.OrganizationPrefix}-{TestBaseUtils.MakeRandomName()}").ToLower(),
                 DisplayName = "Integration testing",
                 Branding = new OrganizationBranding
                 {
@@ -50,7 +52,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 }
             };
-            var createResponse = await ApiClient.Organizations.CreateAsync(createRequest);
+            var createResponse = await fixture.ApiClient.Organizations.CreateAsync(createRequest);
             createResponse.Should().NotBeNull();
             createResponse.Name.Should().Be(createRequest.Name);
             createResponse.Branding.LogoUrl.Should().Be(createRequest.Branding.LogoUrl);
@@ -61,23 +63,23 @@ namespace Auth0.ManagementApi.IntegrationTests
             {
                 DisplayName = $"Integration testing 123",
             };
-            var updateResponse = await ApiClient.Organizations.UpdateAsync(createResponse.Id, updateRequest);
+            var updateResponse = await fixture.ApiClient.Organizations.UpdateAsync(createResponse.Id, updateRequest);
             updateResponse.Should().NotBeNull();
             updateResponse.DisplayName.Should().Be(updateRequest.DisplayName);
 
-            var organization = await ApiClient.Organizations.GetAsync(createResponse.Id);
+            var organization = await fixture.ApiClient.Organizations.GetAsync(createResponse.Id);
             organization.Should().NotBeNull();
             organization.DisplayName.Should().Be(updateResponse.DisplayName);
 
-            var organizationByName = await ApiClient.Organizations.GetByNameAsync(organization.Name);
+            var organizationByName = await fixture.ApiClient.Organizations.GetByNameAsync(organization.Name);
             organizationByName.Should().NotBeNull();
             organizationByName.DisplayName.Should().Be(updateResponse.DisplayName);
 
-            var organizations = await ApiClient.Organizations.GetAllAsync(new Paging.PaginationInfo());
+            var organizations = await fixture.ApiClient.Organizations.GetAllAsync(new Paging.PaginationInfo());
             organizations.Count.Should().Be(initialOrganizations.Count + 1);
 
-            await ApiClient.Organizations.DeleteAsync(updateResponse.Id);
-            Func<Task> getFunc = async () => await ApiClient.Organizations.GetAsync(organization.Id);
+            await fixture.ApiClient.Organizations.DeleteAsync(updateResponse.Id);
+            Func<Task> getFunc = async () => await fixture.ApiClient.Organizations.GetAsync(organization.Id);
             getFunc.Should().Throw<ErrorApiException>().And.Message.Should().Be("No organization found by that id or name");
         }
 
@@ -86,7 +88,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var organization1 = new OrganizationCreateRequest
             {
-                Name = ($"{TestingConstants.OrganizationPrefix}-{MakeRandomName()}").ToLower(),
+                Name = ($"{TestingConstants.OrganizationPrefix}-{TestBaseUtils.MakeRandomName()}").ToLower(),
                 DisplayName = "Integration testing",
                 Branding = new OrganizationBranding
                 {
@@ -98,11 +100,11 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 }
             };
-            var createResponse1 = await ApiClient.Organizations.CreateAsync(organization1);
+            var createResponse1 = await fixture.ApiClient.Organizations.CreateAsync(organization1);
 
             var organization2 = new OrganizationCreateRequest
             {
-                Name = ($"{TestingConstants.OrganizationPrefix}-" + MakeRandomName()).ToLower(),
+                Name = ($"{TestingConstants.OrganizationPrefix}-" + TestBaseUtils.MakeRandomName()).ToLower(),
                 DisplayName = "Integration testing",
                 Branding = new OrganizationBranding
                 {
@@ -114,24 +116,24 @@ namespace Auth0.ManagementApi.IntegrationTests
                     }
                 }
             };
-            var createResponse2 = await ApiClient.Organizations.CreateAsync(organization2);
+            var createResponse2 = await fixture.ApiClient.Organizations.CreateAsync(organization2);
 
-            var firstCheckPointPaginationRequest = await ApiClient.Organizations.GetAllAsync(new Paging.CheckpointPaginationInfo(1));
-            var secondCheckPointPaginationRequest = await ApiClient.Organizations.GetAllAsync(new Paging.CheckpointPaginationInfo(1, firstCheckPointPaginationRequest.Paging.Next));
+            var firstCheckPointPaginationRequest = await fixture.ApiClient.Organizations.GetAllAsync(new Paging.CheckpointPaginationInfo(1));
+            var secondCheckPointPaginationRequest = await fixture.ApiClient.Organizations.GetAllAsync(new Paging.CheckpointPaginationInfo(1, firstCheckPointPaginationRequest.Paging.Next));
 
             secondCheckPointPaginationRequest.Count.Should().Be(1);
             secondCheckPointPaginationRequest.Paging.Next.Should().NotBeNullOrEmpty();
 
-            await ApiClient.Organizations.DeleteAsync(createResponse1.Id);
-            await ApiClient.Organizations.DeleteAsync(createResponse2.Id);
+            await fixture.ApiClient.Organizations.DeleteAsync(createResponse1.Id);
+            await fixture.ApiClient.Organizations.DeleteAsync(createResponse2.Id);
         }
 
         [Fact]
         public async Task Test_organization_connections_crud_sequence()
         {
-            var initialConnections = await ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
+            var initialConnections = await fixture.ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
 
-            var createConnectionResponse = await ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
+            var createConnectionResponse = await fixture.ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
             {
                 ConnectionId = ExistingConnectionId,
                 AssignMembershipOnLogin = true
@@ -140,7 +142,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             createConnectionResponse.Should().NotBeNull();
             createConnectionResponse.AssignMembershipOnLogin.Should().Be(true);
 
-            var updateConnectionResponse = await ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
+            var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
             {
                 AssignMembershipOnLogin = false
             });
@@ -148,27 +150,27 @@ namespace Auth0.ManagementApi.IntegrationTests
             updateConnectionResponse.Should().NotBeNull();
             updateConnectionResponse.AssignMembershipOnLogin.Should().Be(false);
 
-            var connection = await ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
+            var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
 
             connection.Should().NotBeNull();
             connection.AssignMembershipOnLogin.Should().Be(false);
 
-            var connections = await ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
+            var connections = await fixture.ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
             connections.Count.Should().Be(initialConnections.Count + 1);
 
-            await ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
+            await fixture.ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
 
-            Func<Task> getFunc = async () => await ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
+            Func<Task> getFunc = async () => await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
             getFunc.Should().Throw<ErrorApiException>().And.Message.Should().Be("No connection found by that id");
 
             // Unlink Connection
-            await ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
+            await fixture.ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
         }
 
         [Fact]
         public async Task Test_organization_members_crud_sequence()
         {
-            var user = await ApiClient.Users.CreateAsync(new UserCreateRequest
+            var user = await fixture.ApiClient.Users.CreateAsync(new UserCreateRequest
             {
                 Connection = "Username-Password-Authentication",
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
@@ -176,7 +178,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Password = Password
             });
 
-            var user2 = await ApiClient.Users.CreateAsync(new UserCreateRequest
+            var user2 = await fixture.ApiClient.Users.CreateAsync(new UserCreateRequest
             {
                 Connection = "Username-Password-Authentication",
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
@@ -184,32 +186,32 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Password = Password
             });
 
-            await ApiClient.Organizations.AddMembersAsync(ExistingOrganizationId, new OrganizationAddMembersRequest
+            await fixture.ApiClient.Organizations.AddMembersAsync(ExistingOrganizationId, new OrganizationAddMembersRequest
             {
                 Members = new List<string> { user.UserId, user2.UserId }
             });
 
-            var members = await ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.PaginationInfo());
+            var members = await fixture.ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.PaginationInfo());
 
             members.Count.Should().Be(2);
 
-            await ApiClient.Organizations.DeleteMemberAsync(ExistingOrganizationId, new OrganizationDeleteMembersRequest
+            await fixture.ApiClient.Organizations.DeleteMemberAsync(ExistingOrganizationId, new OrganizationDeleteMembersRequest
             {
                 Members = new List<string> { user2.UserId }
             });
 
-            var updatedMembers = await ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.PaginationInfo());
+            var updatedMembers = await fixture.ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.PaginationInfo());
 
             updatedMembers.Count.Should().Be(1);
 
-            await ApiClient.Users.DeleteAsync(user.UserId);
-            await ApiClient.Users.DeleteAsync(user2.UserId);
+            await fixture.ApiClient.Users.DeleteAsync(user.UserId);
+            await fixture.ApiClient.Users.DeleteAsync(user2.UserId);
         }
 
         [Fact]
         public async Task Test_organization_members_checkpoint_pagination()
         {
-            var user = await ApiClient.Users.CreateAsync(new UserCreateRequest
+            var user = await fixture.ApiClient.Users.CreateAsync(new UserCreateRequest
             {
                 Connection = "Username-Password-Authentication",
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
@@ -217,7 +219,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Password = Password
             });
 
-            var user2 = await ApiClient.Users.CreateAsync(new UserCreateRequest
+            var user2 = await fixture.ApiClient.Users.CreateAsync(new UserCreateRequest
             {
                 Connection = "Username-Password-Authentication",
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
@@ -225,26 +227,26 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Password = Password
             });
 
-            await ApiClient.Organizations.AddMembersAsync(ExistingOrganizationId, new OrganizationAddMembersRequest
+            await fixture.ApiClient.Organizations.AddMembersAsync(ExistingOrganizationId, new OrganizationAddMembersRequest
             {
                 Members = new List<string> { user.UserId, user2.UserId }
             });
 
 
-            var firstCheckPointPaginationRequest = await ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.CheckpointPaginationInfo(1));
-            var secondCheckPointPaginationRequest = await ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.CheckpointPaginationInfo(1, firstCheckPointPaginationRequest.Paging.Next));
+            var firstCheckPointPaginationRequest = await fixture.ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.CheckpointPaginationInfo(1));
+            var secondCheckPointPaginationRequest = await fixture.ApiClient.Organizations.GetAllMembersAsync(ExistingOrganizationId, new Paging.CheckpointPaginationInfo(1, firstCheckPointPaginationRequest.Paging.Next));
 
             secondCheckPointPaginationRequest.Count.Should().Be(1);
             secondCheckPointPaginationRequest.Paging.Next.Should().NotBeNullOrEmpty();
             
-            await ApiClient.Users.DeleteAsync(user.UserId);
-            await ApiClient.Users.DeleteAsync(user2.UserId);
+            await fixture.ApiClient.Users.DeleteAsync(user.UserId);
+            await fixture.ApiClient.Users.DeleteAsync(user2.UserId);
         }
 
         [Fact]
         public async Task Test_organization_member_roles_crud_sequence()
         {
-            var user = await ApiClient.Users.CreateAsync(new UserCreateRequest
+            var user = await fixture.ApiClient.Users.CreateAsync(new UserCreateRequest
             {
                 Connection = "Username-Password-Authentication",
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
@@ -252,49 +254,49 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Password = Password
             });
 
-            await ApiClient.Organizations.AddMembersAsync(ExistingOrganizationId, new OrganizationAddMembersRequest
+            await fixture.ApiClient.Organizations.AddMembersAsync(ExistingOrganizationId, new OrganizationAddMembersRequest
             {
                 Members = new List<string> { user.UserId }
             });
 
             // Create
-            await ApiClient.Organizations.AddMemberRolesAsync(ExistingOrganizationId, user.UserId, new OrganizationAddMemberRolesRequest
+            await fixture.ApiClient.Organizations.AddMemberRolesAsync(ExistingOrganizationId, user.UserId, new OrganizationAddMemberRolesRequest
             {
                 Roles = new List<string> { ExistingRoleId }
             });
 
-            var roles = await ApiClient.Organizations.GetAllMemberRolesAsync(ExistingOrganizationId, user.UserId, new Paging.PaginationInfo());
+            var roles = await fixture.ApiClient.Organizations.GetAllMemberRolesAsync(ExistingOrganizationId, user.UserId, new Paging.PaginationInfo());
 
             roles.Should().NotBeNull();
             roles.Count.Should().Be(1);
             roles[0].Name.Should().Be("Admin");
 
-            await ApiClient.Organizations.DeleteMemberRolesAsync(ExistingOrganizationId, user.UserId, new OrganizationDeleteMemberRolesRequest
+            await fixture.ApiClient.Organizations.DeleteMemberRolesAsync(ExistingOrganizationId, user.UserId, new OrganizationDeleteMemberRolesRequest
             {
                 Roles = new List<string> { ExistingRoleId }
             });
 
-            roles = await ApiClient.Organizations.GetAllMemberRolesAsync(ExistingOrganizationId, user.UserId, new Paging.PaginationInfo());
+            roles = await fixture.ApiClient.Organizations.GetAllMemberRolesAsync(ExistingOrganizationId, user.UserId, new Paging.PaginationInfo());
 
             roles.Should().NotBeNull();
             roles.Count.Should().Be(0);
 
-            await ApiClient.Users.DeleteAsync(user.UserId);
+            await fixture.ApiClient.Users.DeleteAsync(user.UserId);
         }
 
         [Fact]
         public async Task Test_organization_invitations_crud_sequence()
         {
             // Link Connection
-            await ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
+            await fixture.ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
             {
                 ConnectionId = ExistingConnectionId,
                 AssignMembershipOnLogin = true
             });
 
-            var createdInvitation = await ApiClient.Organizations.CreateInvitationAsync(ExistingOrganizationId, new OrganizationCreateInvitationRequest
+            var createdInvitation = await fixture.ApiClient.Organizations.CreateInvitationAsync(ExistingOrganizationId, new OrganizationCreateInvitationRequest
             {
-                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
                 ConnectionId = ExistingConnectionId,
                 Inviter = new OrganizationInvitationInviter
                 {
@@ -311,26 +313,26 @@ namespace Auth0.ManagementApi.IntegrationTests
             createdInvitation.Should().NotBeNull();
             createdInvitation.InvitationUrl.Should().NotBeNull();
 
-            var invitations = await ApiClient.Organizations.GetAllInvitationsAsync(ExistingOrganizationId, new OrganizationGetAllInvitationsRequest(), new Paging.PaginationInfo());
+            var invitations = await fixture.ApiClient.Organizations.GetAllInvitationsAsync(ExistingOrganizationId, new OrganizationGetAllInvitationsRequest(), new Paging.PaginationInfo());
 
             invitations.Should().NotBeNull();
             invitations.Count.Should().Be(1);
 
-            var invitation = await ApiClient.Organizations.GetInvitationAsync(ExistingOrganizationId, createdInvitation.Id, new OrganizationGetInvitationRequest());
+            var invitation = await fixture.ApiClient.Organizations.GetInvitationAsync(ExistingOrganizationId, createdInvitation.Id, new OrganizationGetInvitationRequest());
 
             invitation.Should().NotBeNull();
             invitation.Id.Should().Be(createdInvitation.Id);
             invitation.InvitationUrl.Should().NotBeNull();
 
-            await ApiClient.Organizations.DeleteInvitationAsync(ExistingOrganizationId, createdInvitation.Id);
+            await fixture.ApiClient.Organizations.DeleteInvitationAsync(ExistingOrganizationId, createdInvitation.Id);
 
-            invitations = await ApiClient.Organizations.GetAllInvitationsAsync(ExistingOrganizationId, new OrganizationGetAllInvitationsRequest(), new Paging.PaginationInfo());
+            invitations = await fixture.ApiClient.Organizations.GetAllInvitationsAsync(ExistingOrganizationId, new OrganizationGetAllInvitationsRequest(), new Paging.PaginationInfo());
 
             invitations.Should().NotBeNull();
             invitations.Count.Should().Be(0);
 
             // Unlink Connection
-            await ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
+            await fixture.ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
@@ -5,64 +5,71 @@ using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
 using FluentAssertions;
 using Xunit;
-using Auth0.Tests.Shared;
 using Auth0.ManagementApi.Paging;
+using System.Collections.Generic;
+using Auth0.IntegrationTests.Shared.CleanUp;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class RulesTests : ManagementTestBase, IAsyncLifetime
+    public class RulesTestsFixture : TestBaseFixture
     {
-        public async Task InitializeAsync()
-        {
-            string token = await GenerateManagementApiToken();
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
-        }
+        public readonly List<LogStream> TestCreatedStreams = new List<LogStream>();
 
-        public override Task DisposeAsync()
+        public override async Task DisposeAsync()
         {
-            return CleanupAndDisposeAsync();
+            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Rules });
+        }
+    }
+
+    public class RulesTests : IClassFixture<RulesTestsFixture>
+    {
+        RulesTestsFixture fixture;
+
+        public RulesTests(RulesTestsFixture fixture)
+        {
+            this.fixture = fixture;
         }
 
         [Fact]
         public async Task Test_rules_crud_sequence()
         {
             // Get all rules
-            var rulesBefore = await ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo());
+            var rulesBefore = await fixture.ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo());
 
             // Add a new rule
             var newRuleRequest = new RuleCreateRequest
             {
-                Name = $"integration-test-rule-{Guid.NewGuid():N}",
+                Name = $"{TestingConstants.RulesRefix}-{Guid.NewGuid():N}",
                 Script = @"function (user, context, callback) {
                               // TODO: implement your rule
                               callback(null, user, context);
                             }"
             };
-            var newRuleResponse = await ApiClient.Rules.CreateAsync(newRuleRequest);
+            var newRuleResponse = await fixture.ApiClient.Rules.CreateAsync(newRuleRequest);
             newRuleResponse.Should().NotBeNull();
             newRuleResponse.Name.Should().Be(newRuleRequest.Name);
 
             // Get all the rules again, and check that we now have one more
-            var rulesAfter = await ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo());
+            var rulesAfter = await fixture.ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo());
             rulesAfter.Count.Should().Be(rulesBefore.Count + 1);
 
             // Update the Rule
             var updateRuleRequest = new RuleUpdateRequest
             {
-                Name = $"integration-test-rule-{Guid.NewGuid():N}"
+                Name = $"{TestingConstants.RulesRefix}-{Guid.NewGuid():N}"
             };
-            var updateRuleResponse = await ApiClient.Rules.UpdateAsync(newRuleResponse.Id, updateRuleRequest);
+            var updateRuleResponse = await fixture.ApiClient.Rules.UpdateAsync(newRuleResponse.Id, updateRuleRequest);
             updateRuleResponse.Should().NotBeNull();
             updateRuleResponse.Name.Should().Be(updateRuleRequest.Name);
 
             // Get a single rule
-            var rule = await ApiClient.Rules.GetAsync(newRuleResponse.Id);
+            var rule = await fixture.ApiClient.Rules.GetAsync(newRuleResponse.Id);
             rule.Should().NotBeNull();
             rule.Name.Should().Be(updateRuleRequest.Name);
 
             // Delete the rule, and ensure we get exception when trying to fetch it again
-            await ApiClient.Rules.DeleteAsync(rule.Id);
-            Func<Task> getFunc = async () => await ApiClient.Rules.GetAsync(rule.Id);
+            await fixture.ApiClient.Rules.DeleteAsync(rule.Id);
+            Func<Task> getFunc = async () => await fixture.ApiClient.Rules.GetAsync(rule.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_rule");
         }
         
@@ -70,7 +77,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_when_paging_not_specified_does_not_include_totals()
         {
             // Act
-            var rules = await ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo());
+            var rules = await fixture.ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo());
             
             // Assert
             Assert.Null(rules.Paging);
@@ -80,7 +87,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_does_not_include_totals()
         {
             // Act
-            var rules = await ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo(0, 50, false));
+            var rules = await fixture.ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo(0, 50, false));
             
             // Assert
             Assert.Null(rules.Paging);
@@ -90,7 +97,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_paging_includes_totals()
         {
             // Act
-            var rules = await ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo(0, 50, true));
+            var rules = await fixture.ApiClient.Rules.GetAllAsync(new GetRulesRequest(), new PaginationInfo(0, 50, true));
             
             // Assert
             Assert.NotNull(rules.Paging);
@@ -100,9 +107,9 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_without_paging()
         {
             // Add a new rule
-            var newRule = await ApiClient.Rules.CreateAsync(new RuleCreateRequest
+            var newRule = await fixture.ApiClient.Rules.CreateAsync(new RuleCreateRequest
             {
-                Name = $"integration-test-rule-{Guid.NewGuid():N}",
+                Name = $"i{TestingConstants.RulesRefix}-{Guid.NewGuid():N}",
                 Script = @"function (user, context, callback) {
                               // TODO: implement your rule
                               callback(null, user, context);
@@ -112,13 +119,13 @@ namespace Auth0.ManagementApi.IntegrationTests
             newRule.Should().NotBeNull();
 
             // Act
-            var rules = await ApiClient.Rules.GetAllAsync(new GetRulesRequest());
+            var rules = await fixture.ApiClient.Rules.GetAllAsync(new GetRulesRequest());
 
             // Assert
             rules.Paging.Should().BeNull();
             rules.Count.Should().BeGreaterThan(0);
 
-            await ApiClient.Rules.DeleteAsync(newRule.Id);
+            await fixture.ApiClient.Rules.DeleteAsync(newRule.Id);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
@@ -20,7 +20,7 @@ namespace Auth0.Tests.Shared
             IdentityModelEventSource.ShowPII = true;
         }
 
-        private static readonly IConfigurationRoot _config = new ConfigurationBuilder()
+        public static readonly IConfigurationRoot Config = new ConfigurationBuilder()
                 .AddJsonFile("client-secrets.json", true)
                 .AddEnvironmentVariables()
                 .Build();
@@ -65,7 +65,7 @@ namespace Auth0.Tests.Shared
 
         protected static string GetVariable(string variableName, bool throwIfMissing = true)
         {
-            var value = _config[variableName];
+            var value = Config[variableName];
             if (String.IsNullOrEmpty(value) && throwIfMissing)
                 throw new ArgumentOutOfRangeException($"Configuration value '{variableName}' has not been set.");
             return value;

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBaseFixture.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBaseFixture.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using Auth0.ManagementApi.IntegrationTests.Testing;
+using Auth0.Tests.Shared;
+using Xunit;
+
+namespace Auth0.ManagementApi.IntegrationTests
+{
+    public class TestBaseFixture : IAsyncLifetime
+    {
+        public ManagementApiClient ApiClient { get; private set; }
+
+        public virtual async Task InitializeAsync()
+        {
+            string token = await TestBaseUtils.GenerateManagementApiToken();
+
+            ApiClient = new ManagementApiClient(token, TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+        }
+
+        public virtual async Task DisposeAsync()
+        {
+            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient);
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBaseUtils.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBaseUtils.cs
@@ -1,0 +1,41 @@
+﻿using Auth0.AuthenticationApi.Models;
+using System;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Auth0.Tests.Shared
+{
+    public class TestBaseUtils
+    {
+        public static string GetVariable(string variableName, bool throwIfMissing = true)
+        {
+            var value = TestBase.Config[variableName];
+            if (String.IsNullOrEmpty(value) && throwIfMissing)
+                throw new ArgumentOutOfRangeException($"Configuration value '{variableName}' has not been set.");
+            return value;
+        }
+
+        private static readonly Regex _alphaNumeric = new Regex("[^a-zA-Z0-9]");
+
+        public static string MakeRandomName()
+        {
+            return _alphaNumeric.Replace(Convert.ToBase64String(Guid.NewGuid().ToByteArray()), "");
+        }
+
+        public static async Task<string> GenerateManagementApiToken()
+        {
+            using (var authenticationApiClient = new TestAuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))
+            {
+                // Get the access token
+                var token = await authenticationApiClient.GetTokenAsync(new ClientCredentialsTokenRequest
+                {
+                    ClientId = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID"),
+                    ClientSecret = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_SECRET"),
+                    Audience = GetVariable("AUTH0_MANAGEMENT_API_AUDIENCE")
+                });
+
+                return token.AccessToken;
+            }
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+
+namespace Auth0.ManagementApi.IntegrationTests.Testing
+{
+    public class ManagementTestBaseUtils
+    {
+        public static async Task CleanupAndDisposeAsync(ManagementApiClient client, IList<CleanUpType> types = null)
+        {
+            await RunCleanUp(client, types);
+            client.Dispose();
+        }
+        
+
+        private static async Task RunCleanUp(ManagementApiClient client, IList<CleanUpType> types = null)
+        {
+            var strategies = new List<CleanUpStrategy>
+            {
+                new ActionsCleanUpStrategy(client),
+                new ClientsCleanUpStrategy(client),
+                new ConnectionsCleanUpStrategy(client),
+                new HooksCleanUpStrategy(client),
+                new OrganizationsCleanUpStrategy(client),
+                new ResourceServersCleanUpStrategy(client),
+                new UsersCleanUpStrategy(client),
+                new RulesCleanUpStrategy(client)
+            };
+
+            var strategiesToRun = types != null ? strategies.FindAll(s => types.Contains(s.Type)) : strategies;
+
+            foreach (var cleanUpStrategy in strategiesToRun)
+            {
+                await cleanUpStrategy.Run();
+            }
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Auth0.ManagementApi.Models;
 using FluentAssertions;
 using Xunit;
-using Auth0.Tests.Shared;
 using System.Collections.Generic;
 using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi.IntegrationTests.Testing;

--- a/tests/Auth0.ManagementApi.IntegrationTests/UserBlockTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UserBlockTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Data.Common;
 using System.Threading.Tasks;
 using Auth0.AuthenticationApi;
 using Auth0.AuthenticationApi.Models;
@@ -9,41 +11,68 @@ using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using FluentAssertions;
 using Xunit;
+using Xunit.Sdk;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class UserBlockTests : ManagementTestBase, IAsyncLifetime
+    public class UserBlockTestsFixture : TestBaseFixture
     {
-        private AuthenticationApiClient _authenticationApiClient;
-        private Connection _connection;
-        private User _user;
-        private const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
+        public AuthenticationApiClient TestAuthenticationApiClient;
+        public Connection TestConnection;
+        public User TestUser;
+        public const string Password = "4cX8awB3T%@Aw-R:=h@ae@k?";
 
-        public async Task InitializeAsync()
+        public override async Task InitializeAsync()
         {
-            string token = await GenerateManagementApiToken();
+            await base.InitializeAsync();
 
-            ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
-            _authenticationApiClient = new TestAuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+            TestAuthenticationApiClient = new TestAuthenticationApiClient(TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL"));
 
             // We will need a connection to add the users to...
-            _connection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
+            TestConnection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
-                Name = $"{TestingConstants.ConnectionPrefix}-{MakeRandomName()}",
+                Name = $"{TestingConstants.ConnectionPrefix}-{TestBaseUtils.MakeRandomName()}",
                 Strategy = "auth0",
-                EnabledClients = new[] { GetVariable("AUTH0_CLIENT_ID"), GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
+                EnabledClients = new[] { TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"), TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
             });
 
             // Add a new user
             var newUserRequest = new UserCreateRequest
             {
-                Connection = _connection.Name,
+                Connection = TestConnection.Name,
                 Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
                 EmailVerified = true,
                 Password = Password
             };
-            _user = await ApiClient.Users.CreateAsync(newUserRequest);
+            TestUser = await ApiClient.Users.CreateAsync(newUserRequest);
 
+            
+
+        }
+        public override async Task DisposeAsync()
+        {
+            await ApiClient.Users.DeleteAsync(TestUser.UserId);
+            await ApiClient.Connections.DeleteAsync(TestConnection.Id);
+            await base.DisposeAsync();
+        }
+    }
+
+    public class UserBlockTests : IClassFixture<UserBlockTestsFixture>, IAsyncLifetime
+    {
+        UserBlockTestsFixture fixture;
+
+        public UserBlockTests(UserBlockTestsFixture fixture)
+        {
+            this.fixture = fixture;
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task InitializeAsync()
+        {
             // Now try and sign in with a wrong password until we get "too many attempts"
             bool userBlocked = false;
             int attempts = 0;
@@ -53,13 +82,13 @@ namespace Auth0.ManagementApi.IntegrationTests
                 {
                     attempts++;
 
-                    await _authenticationApiClient.GetTokenAsync(new ResourceOwnerTokenRequest
+                    await fixture.TestAuthenticationApiClient.GetTokenAsync(new ResourceOwnerTokenRequest
                     {
-                        ClientId = GetVariable("AUTH0_CLIENT_ID"),
-                        ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
-                        Realm = _connection.Name,
+                        ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+                        ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+                        Realm = fixture.TestConnection.Name,
                         Scope = "openid",
-                        Username = _user.Email,
+                        Username = fixture.TestUser.Email,
                         Password = "wrong_password"
                     });
                 }
@@ -73,28 +102,20 @@ namespace Auth0.ManagementApi.IntegrationTests
                         userBlocked = true;
                 }
             } while (!userBlocked && attempts < 20); // Add failsafe to stop if we go over 20 attempts. User should be blocked by then, but just to make sure...
-
-        }
-
-        public override async Task DisposeAsync()
-        {
-            await ApiClient.Users.DeleteAsync(_user.UserId);
-            await ApiClient.Connections.DeleteAsync(_connection.Id);
-            await CleanupAndDisposeAsync();
         }
 
         [Fact]
         public async Task Test_user_blocks_by_identifier()
         {
             // Check we should have 1 block for the user
-            var userBlocks = await ApiClient.UserBlocks.GetByIdentifierAsync(_user.Email);
+            var userBlocks = await fixture.ApiClient.UserBlocks.GetByIdentifierAsync(fixture.TestUser.Email);
             userBlocks.BlockedFor.Should().HaveCount(1);
 
             // Now unblock the user
-            await ApiClient.UserBlocks.UnblockByIdentifierAsync(_user.Email);
+            await fixture.ApiClient.UserBlocks.UnblockByIdentifierAsync(fixture.TestUser.Email);
 
             // Now ensure user is not blocked anymore
-            userBlocks = await ApiClient.UserBlocks.GetByIdentifierAsync(_user.Email);
+            userBlocks = await fixture.ApiClient.UserBlocks.GetByIdentifierAsync(fixture.TestUser.Email);
             userBlocks.BlockedFor.Should().BeEmpty();
         }
 
@@ -103,14 +124,14 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_user_blocks_by_userid()
         {
             // Check we should have 1 block for the user
-            var userBlocks = await ApiClient.UserBlocks.GetByUserIdAsync(_user.UserId);
+            var userBlocks = await fixture.ApiClient.UserBlocks.GetByUserIdAsync(fixture.TestUser.UserId);
             userBlocks.BlockedFor.Should().HaveCount(1);
 
             // Now unblock the user
-            await ApiClient.UserBlocks.UnblockByUserIdAsync(_user.UserId);
+            await fixture.ApiClient.UserBlocks.UnblockByUserIdAsync(fixture.TestUser.UserId);
 
             // Now ensure user is not blocked anymore
-            userBlocks = await ApiClient.UserBlocks.GetByUserIdAsync(_user.UserId);
+            userBlocks = await fixture.ApiClient.UserBlocks.GetByUserIdAsync(fixture.TestUser.UserId);
             userBlocks.BlockedFor.Should().BeEmpty();
         }
     }

--- a/tests/Auth0.ManagementApi.IntegrationTests/xunit.runner.json
+++ b/tests/Auth0.ManagementApi.IntegrationTests/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeTestCollections": false
+}


### PR DESCRIPTION
Migrating the tests to use [xUnit's ClassFixture](https://xunit.net/docs/shared-context#class-fixture), allowing us to share state between multiple test runs. Currently we have a lot of code using `InitializeAsync` on the TestClass itself, which is called before _every_ test run, which is not always neccesary.

The effect of this should also be that we should be hitting Auth0 less frequently than before.