### PR TITLE
[SDK-3641] Support stage property in Breached Password Detection configuration

### DIFF
--- a/src/Auth0.ManagementApi/Models/AttackProtection/BreachedPasswordDetection.cs
+++ b/src/Auth0.ManagementApi/Models/AttackProtection/BreachedPasswordDetection.cs
@@ -3,6 +3,23 @@ using System.Collections.Generic;
 
 namespace Auth0.ManagementApi.Models.AttackProtection
 {
+    public class BreachedPasswordDetectionStage
+    {
+        public class StageEntry {
+            /// <summary>
+            /// Action to take when a breached password is detected. Possible values: "block", "admin_notification".
+            /// </summary>
+            [JsonProperty("shields")]
+            public IList<string> Shields { get; set; }
+        }
+
+        /// <summary>
+        /// Configuration options that apply before every user registration attempt.
+        /// </summary>
+        [JsonProperty("pre-user-registration")]
+        public StageEntry PreUserRegistration { get; set; }
+    }
+
     public class BreachedPasswordDetection
     {
         /// <summary>
@@ -28,6 +45,12 @@ namespace Auth0.ManagementApi.Models.AttackProtection
         /// </summary>
         [JsonProperty("method")]
         public string Method { get; set; }
+
+        /// <summary>
+        /// Holds per-stage configuration options (shiels).
+        /// </summary>
+        [JsonProperty("stage")]
+        public Stage Stage { get; set; }
     }
 
 }

--- a/src/Auth0.ManagementApi/Models/AttackProtection/BreachedPasswordDetection.cs
+++ b/src/Auth0.ManagementApi/Models/AttackProtection/BreachedPasswordDetection.cs
@@ -47,10 +47,10 @@ namespace Auth0.ManagementApi.Models.AttackProtection
         public string Method { get; set; }
 
         /// <summary>
-        /// Holds per-stage configuration options (shiels).
+        /// Holds per-stage configuration options (shields).
         /// </summary>
         [JsonProperty("stage")]
-        public Stage Stage { get; set; }
+        public BreachedPasswordDetectionStage Stage { get; set; }
     }
 
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
@@ -71,6 +71,13 @@ namespace Auth0.ManagementApi.IntegrationTests
                     AdminNotificationFrequency = new[] { "daily" },
                     Method = "standard",
                     Enabled = true,
+                    Stage = new BreachedPasswordDetectionStage
+                    {
+                        PreUserRegistration = new BreachedPasswordDetectionStage.StageEntry
+                        {
+                            Shields = new[] { "admin_notification" }
+                        }
+                    }
                 };
 
                 var updated = await fixture.ApiClient.AttackProtection.UpdateBreachedPasswordDetectionAsync(toUpdate);


### PR DESCRIPTION
### Changes

Adds support for the `stages` property on Breached Password Detection configuration. Similar to Suspicious IP Throttling this is used to configured the `shields` applied at different stages. Currently only `pre-user-registration` is supported 

### References

See linked tickets on SDK-3641

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
