### PR TITLE
[SDK-2557] Add support for Ephemeral sessions

### DIFF
--- a/src/Auth0.ManagementApi/Models/TenantSettingsBase.cs
+++ b/src/Auth0.ManagementApi/Models/TenantSettingsBase.cs
@@ -2,6 +2,16 @@
 
 namespace Auth0.ManagementApi.Models
 {
+    public class SessionCookie
+    {
+        /// <summary>
+        /// Behavior of the session cookie
+        /// </summary>
+        /// <remarks>Can be any of 'persistent' or 'non-persistent'</remarks>
+        [JsonProperty("mode")]
+        public string Mode { get; set; }
+    }
+
     /// <summary>
     /// Settings for a given tenant.
     /// </summary>
@@ -108,5 +118,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("enabled_locales")]
         public string[] EnabledLocales { get; set; }
+
+        /// <summary>
+        /// Session cookie configuration
+        /// </summary>
+        [JsonProperty("session_cookie")]
+        public SessionCookie SessionCookie { get; set; }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
@@ -17,7 +17,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             using (var apiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 })))
             {
                 // Get the current settings
-                var settings = apiClient.TenantSettings.GetAsync();
+                var settings = await apiClient.TenantSettings.GetAsync();
                 settings.Should().NotBeNull();
 
                 // Update the tenant settings - do not set some properties as the tenant is pre-configured
@@ -59,7 +59,8 @@ namespace Auth0.ManagementApi.IntegrationTests
                     {
                         Charset = TenantDeviceFlowCharset.Base20,
                         Mask = "***-***-***"
-                    }
+                    },
+                    SessionCookie = new SessionCookie { Mode = "persistent" }
                 };
 
                 var settingsUpdateResponse = await apiClient.TenantSettings.UpdateAsync(settingsUpdateRequest);
@@ -75,6 +76,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 settingsUpdateResponse.Flags.EnableAPIsSection.Should().BeTrue();
                 settingsUpdateResponse.Flags.EnableClientConnections.Should().BeFalse();
                 settingsUpdateResponse.Flags.EnablePipeline2.Should().BeTrue();
+                settingsUpdateResponse.SessionCookie.Mode.Should().Be("persistent");
 
                 var resetUpdateRequest = new TenantSettingsUpdateRequest
                 {


### PR DESCRIPTION
### Changes

Adds support for `session_cookie` on the `/tenant/settings` endpoint.

### References

https://auth0.com/docs/api/management/v2#!/Tenants/tenant_settings_route

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
