### PR TITLE
Rework IdTokenValidator to be able to use a proxy

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -17,7 +17,7 @@ namespace Auth0.AuthenticationApi
     /// </remarks>
     public class AuthenticationApiClient : IAuthenticationApiClient, IDisposable
     {
-        static readonly IdTokenValidator idTokenValidator = new IdTokenValidator();
+        readonly IdTokenValidator idTokenValidator;
         readonly TimeSpan idTokenValidationLeeway = TimeSpan.FromMinutes(1);
         readonly Uri tokenUri;
         protected readonly IAuthenticationConnection connection;        
@@ -50,6 +50,8 @@ namespace Auth0.AuthenticationApi
             {
                 this.connection = connection;
             }
+
+            idTokenValidator = new IdTokenValidator(new OpenIdConnectDocumentRetriever(this.connection));
 
             tokenUri = BuildUri("oauth/token");
         }

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
@@ -1,4 +1,5 @@
 ﻿using Auth0.AuthenticationApi.Tokens;
+using Microsoft.IdentityModel.Protocols;
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Threading.Tasks;
@@ -9,7 +10,12 @@ namespace Auth0.AuthenticationApi
     {
         readonly TimeSpan maxJwksKeySetValidFor = TimeSpan.FromMinutes(10);
         readonly TimeSpan minJwksRefreshInterval = TimeSpan.FromSeconds(15);
-        readonly JsonWebKeyCache jsonWebKeyCache = new JsonWebKeyCache();
+        readonly JsonWebKeyCache jsonWebKeyCache;
+
+        public IdTokenValidator(IDocumentRetriever openIdConnectDcumentRetriever = null)
+        {
+            jsonWebKeyCache = new JsonWebKeyCache(new JsonWebKeys(openIdConnectDcumentRetriever));
+        }
 
         public async Task Assert(IdTokenRequirements requirements, string idToken, string clientSecret, DateTime? pointInTime = null)
         {

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenValidator.cs
@@ -12,9 +12,9 @@ namespace Auth0.AuthenticationApi
         readonly TimeSpan minJwksRefreshInterval = TimeSpan.FromSeconds(15);
         readonly JsonWebKeyCache jsonWebKeyCache;
 
-        public IdTokenValidator(IDocumentRetriever openIdConnectDcumentRetriever = null)
+        public IdTokenValidator(IDocumentRetriever openIdConnectDocumentRetriever = null)
         {
-            jsonWebKeyCache = new JsonWebKeyCache(new JsonWebKeys(openIdConnectDcumentRetriever));
+            jsonWebKeyCache = new JsonWebKeyCache(new JsonWebKeys(openIdConnectDocumentRetriever));
         }
 
         public async Task Assert(IdTokenRequirements requirements, string idToken, string clientSecret, DateTime? pointInTime = null)

--- a/src/Auth0.AuthenticationApi/Tokens/JsonWebKeyCache.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/JsonWebKeyCache.cs
@@ -6,7 +6,12 @@ namespace Auth0.AuthenticationApi.Tokens
 {
     internal class JsonWebKeyCache
     {
-        readonly AsyncAgedCache<string, JsonWebKeySet> cache = new AsyncAgedCache<string, JsonWebKeySet>(JsonWebKeys.GetForIssuer);
+        readonly AsyncAgedCache<string, JsonWebKeySet> cache;
+
+        public JsonWebKeyCache(JsonWebKeys jsonWebKeys)
+        {
+            cache = new AsyncAgedCache<string, JsonWebKeySet>(jsonWebKeys.GetForIssuer);
+        }
 
         public Task<JsonWebKeySet> Get(string issuer, TimeSpan maxAge)
         {

--- a/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
@@ -6,20 +6,27 @@ using System.Threading.Tasks;
 
 namespace Auth0.AuthenticationApi.Tokens
 {
-    static class JsonWebKeys
+    public class JsonWebKeys
     {
-        public static async Task<JsonWebKeySet> GetForIssuer(string issuer)
+        private readonly IDocumentRetriever openIdConnectDcumentRetriever;
+
+        public JsonWebKeys(IDocumentRetriever openIdConnectDcumentRetriever = null)
+        {
+            this.openIdConnectDcumentRetriever = openIdConnectDcumentRetriever;
+        }
+
+        public async Task<JsonWebKeySet> GetForIssuer(string issuer)
         {
             var metadataAddress = new UriBuilder(issuer) { Path = "/.well-known/openid-configuration" }.Uri.OriginalString;
             var openIdConfiguration = await GetOpenIdConfiguration(metadataAddress).ConfigureAwait(false);
             return openIdConfiguration.JsonWebKeySet;
         }
 
-        private static Task<OpenIdConnectConfiguration> GetOpenIdConfiguration(string metadataAddress)
+        private Task<OpenIdConnectConfiguration> GetOpenIdConfiguration(string metadataAddress)
         {
             try
             {
-                var configurationManager = new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever());
+                var configurationManager = openIdConnectDcumentRetriever != null ? new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever(), openIdConnectDcumentRetriever) : new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever());
                 return configurationManager.GetConfigurationAsync();
             }
             catch (Exception e)

--- a/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Auth0.AuthenticationApi.Tokens
 {
-    public class JsonWebKeys
+    internal class JsonWebKeys
     {
         private readonly IDocumentRetriever openIdConnectDocumentRetriever;
 

--- a/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/JsonWebKeys.cs
@@ -8,11 +8,11 @@ namespace Auth0.AuthenticationApi.Tokens
 {
     public class JsonWebKeys
     {
-        private readonly IDocumentRetriever openIdConnectDcumentRetriever;
+        private readonly IDocumentRetriever openIdConnectDocumentRetriever;
 
-        public JsonWebKeys(IDocumentRetriever openIdConnectDcumentRetriever = null)
+        public JsonWebKeys(IDocumentRetriever openIdConnectDocumentRetriever = null)
         {
-            this.openIdConnectDcumentRetriever = openIdConnectDcumentRetriever;
+            this.openIdConnectDocumentRetriever = openIdConnectDocumentRetriever;
         }
 
         public async Task<JsonWebKeySet> GetForIssuer(string issuer)
@@ -26,7 +26,7 @@ namespace Auth0.AuthenticationApi.Tokens
         {
             try
             {
-                var configurationManager = openIdConnectDcumentRetriever != null ? new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever(), openIdConnectDcumentRetriever) : new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever());
+                var configurationManager = openIdConnectDocumentRetriever != null ? new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever(), openIdConnectDocumentRetriever) : new ConfigurationManager<OpenIdConnectConfiguration>(metadataAddress, new OpenIdConnectConfigurationRetriever());
                 return configurationManager.GetConfigurationAsync();
             }
             catch (Exception e)

--- a/src/Auth0.AuthenticationApi/Tokens/OpenIdConnectDocumentRetriever.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/OpenIdConnectDocumentRetriever.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Protocols;
+
+namespace Auth0.AuthenticationApi.Tokens
+{
+    public class OpenIdConnectDocumentRetriever : IDocumentRetriever
+    {
+        private readonly IAuthenticationConnection connection;
+
+        public OpenIdConnectDocumentRetriever(IAuthenticationConnection connection)
+        {
+            this.connection = connection;
+        }
+
+        public Task<string> GetDocumentAsync(string address, CancellationToken cancel)
+        {
+            return connection.GetAsync<string>(new Uri(address), cancellationToken: cancel);
+        }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Tokens/OpenIdConnectDocumentRetriever.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/OpenIdConnectDocumentRetriever.cs
@@ -5,7 +5,7 @@ using Microsoft.IdentityModel.Protocols;
 
 namespace Auth0.AuthenticationApi.Tokens
 {
-    public class OpenIdConnectDocumentRetriever : IDocumentRetriever
+    internal class OpenIdConnectDocumentRetriever : IDocumentRetriever
     {
         private readonly IAuthenticationConnection connection;
 


### PR DESCRIPTION
### Changes

When using the SDK with a proxy, there is no way for the call to retrieve the `openid-configuration` to use that same proxy. This PR updates the internals of the SDK in such a way that it reuses the same `IAuthenticationConnection` implementation that's used by the `AuthenticationApiClient`.

### References

Closes #567

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
