### PR TITLE
Add support for the connection status API

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -136,10 +136,10 @@ namespace Auth0.ManagementApi.Clients
         /// <summary>
         /// Retrieves the status of an ad/ldap connection 
         /// </summary>
-        /// <param name="id">D of the connection to check</param>
+        /// <param name="id">ID of the connection to check</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous check operation. Will throw if the check fails.</returns>
-        public Task CheckAsync(string id, CancellationToken cancellationToken = default)
+        public Task CheckStatusAsync(string id, CancellationToken cancellationToken = default)
         {
             return Connection.GetAsync<object>(BuildUri($"connections/{EncodePath(id)}/status"), DefaultHeaders, cancellationToken: cancellationToken);
         }

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -134,9 +134,9 @@ namespace Auth0.ManagementApi.Clients
         }
 
         /// <summary>
-        /// Retrieves the status of an ad/ldap connection 
+        /// Retrieves the status of an ad/ldap connection.
         /// </summary>
-        /// <param name="id">ID of the connection to check</param>
+        /// <param name="id">ID of the connection to check.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous check operation. Will throw if the check fails.</returns>
         public Task CheckStatusAsync(string id, CancellationToken cancellationToken = default)

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -132,5 +132,16 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection.SendAsync<Connection>(new HttpMethod("PATCH"), BuildUri($"connections/{EncodePath(id)}"), request, DefaultHeaders, cancellationToken: cancellationToken);
         }
+
+        /// <summary>
+        /// Retrieves the status of an ad/ldap connection 
+        /// </summary>
+        /// <param name="id">D of the connection to check</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="Task"/> that represents the asynchronous check operation. Will throw if the check fails.</returns>
+        public Task CheckAsync(string id, CancellationToken cancellationToken = default)
+        {
+            return Connection.GetAsync<object>(BuildUri($"connections/{EncodePath(id)}/status"), DefaultHeaders, cancellationToken: cancellationToken);
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
@@ -62,5 +62,13 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>The <see cref="Connection"/> that has been updated.</returns>
     Task<Connection> UpdateAsync(string id, ConnectionUpdateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the status of an ad/ldap connection.
+    /// </summary>
+    /// <param name="id">ID of the connection to check.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous check operation. Will throw if the status check fails.</returns>
+    Task CheckAsync(string id, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
@@ -69,6 +69,6 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="id">ID of the connection to check.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous check operation. Will throw if the status check fails.</returns>
-    Task CheckAsync(string id, CancellationToken cancellationToken = default);
+    Task CheckStatusAsync(string id, CancellationToken cancellationToken = default);
   }
 }


### PR DESCRIPTION
### Changes

Adds the connection status check API as I noticed it was missing from the connections client.

### References

https://auth0.com/docs/api/management/v2#!/Connections/get_status

### Testing

Not sure of a good way of adding tests for this, as a valid AD or LDAP connection would need to be setup on the Auth0 side.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
