### PR TITLE
Added revoke refresh token endpoint support

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -352,6 +352,20 @@ namespace Auth0.AuthenticationApi
         }
 
         /// <inheritdoc/>
+
+        public Task<string> RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            return connection.SendAsync<string>(
+                HttpMethod.Post,
+                BuildUri("ouath/revoke"),
+                request,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc/>
         public Task<SignupUserResponse> SignupUserAsync(SignupUserRequest request, CancellationToken cancellationToken = default)
         {
             if (request == null)

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -369,7 +369,7 @@ namespace Auth0.AuthenticationApi
             return connection.SendAsync<string>(
                 HttpMethod.Post,
                 BuildUri("oauth/revoke"),
-                request,
+                body,
                 cancellationToken: cancellationToken);
         }
 

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -353,7 +353,7 @@ namespace Auth0.AuthenticationApi
 
         /// <inheritdoc/>
 
-        public Task<string> RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default)
+        public Task RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
@@ -366,7 +366,7 @@ namespace Auth0.AuthenticationApi
 
             ApplyClientAuthentication(request, body);
 
-            return connection.SendAsync<string>(
+            return connection.SendAsync<object>(
                 HttpMethod.Post,
                 BuildUri("oauth/revoke"),
                 body,

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -358,6 +358,14 @@ namespace Auth0.AuthenticationApi
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
 
+            var body = new Dictionary<string, string>
+            {
+                {"client_id", request.ClientId},
+                {"token", request.RefreshToken}
+            };
+
+            ApplyClientAuthentication(request, body);
+
             return connection.SendAsync<string>(
                 HttpMethod.Post,
                 BuildUri("oauth/revoke"),

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -360,7 +360,7 @@ namespace Auth0.AuthenticationApi
 
             return connection.SendAsync<string>(
                 HttpMethod.Post,
-                BuildUri("ouath/revoke"),
+                BuildUri("oauth/revoke"),
                 request,
                 cancellationToken: cancellationToken);
         }

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -126,6 +126,14 @@ namespace Auth0.AuthenticationApi
         Task<AccessTokenResponse> GetTokenAsync(DeviceCodeTokenRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
+        /// Revokes refresh token provided in request.
+        /// </summary>
+        /// <param name="request"><see cref="RevokeRefreshTokenRequest"/> containing Refresh Token and associated parameters.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns><see cref="Task"/> representing the async operation containing either the JSON error response or the plain text success message response.</returns>
+        Task<string> RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
         /// Creates a new user given the user details specified.
         /// </summary>
         /// <param name="request"><see cref="SignupUserRequest" /> containing information of the user to sign up.</param>

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -131,7 +131,7 @@ namespace Auth0.AuthenticationApi
         /// <param name="request"><see cref="RevokeRefreshTokenRequest"/> containing Refresh Token and associated parameters.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns><see cref="Task"/> representing the async operation containing either the JSON error response or the plain text success message response.</returns>
-        Task<string> RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default);
+        Task RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates a new user given the user details specified.

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -130,7 +130,7 @@ namespace Auth0.AuthenticationApi
         /// </summary>
         /// <param name="request"><see cref="RevokeRefreshTokenRequest"/> containing Refresh Token and associated parameters.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-        /// <returns><see cref="Task"/> representing the async operation containing either the JSON error response or the plain text success message response.</returns>
+        /// <returns><see cref="Task"/> representing the async operation.</returns>
         Task RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/Models/RevokeRefreshTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/RevokeRefreshTokenRequest.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.IdentityModel.Tokens;
+using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    /// <summary>
+    /// Represents a request to get new tokens based on a previously obtained refresh token.
+    /// </summary>
+    public class RevokeRefreshTokenRequest : IClientAuthentication
+    {
+        /// <summary>
+        /// Security Key to use with Client Assertion
+        /// </summary>
+        public SecurityKey ClientAssertionSecurityKey { get; set; }
+
+        /// <summary>
+        /// Algorithm for the Security Key to use with Client Assertion
+        /// </summary>
+        public string ClientAssertionSecurityKeyAlgorithm { get; set; }
+
+        /// <summary>
+        /// Client ID for which the refresh token was issued.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Client secret for which the refresh token was issued.
+        /// </summary>
+        public string ClientSecret { get; set; }
+
+        /// <summary>
+        /// A refresh token you want to revoke.
+        /// </summary>
+        [JsonProperty("token")]
+        public string RefreshToken { get; set; }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/RevokeRefreshTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/RevokeRefreshTokenRequest.cs
@@ -31,7 +31,6 @@ namespace Auth0.AuthenticationApi.Models
         /// <summary>
         /// A refresh token you want to revoke.
         /// </summary>
-        [JsonProperty("token")]
         public string RefreshToken { get; set; }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
@@ -139,5 +139,23 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 token.Should().NotBeNull();
             }
         }
+
+        [Fact]
+        public async Task Can_revoke_refresh_token_when_token_not_null()
+        {
+            using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))
+            {
+                // Get the access token
+                var result = await authenticationApiClient.RevokeRefreshTokenAsync(new RevokeRefreshTokenRequest
+                {
+                    ClientId = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID"),
+                    ClientSecret = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_SECRET"),
+                    RefreshToken = "SomeRefreshToken"
+                });
+
+                // Ensure that we received an access token back
+                result.Should().BeNullOrEmpty();
+            }
+        }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
@@ -145,16 +145,12 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         {
             using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))
             {
-                // Get the access token
-                var result = await authenticationApiClient.RevokeRefreshTokenAsync(new RevokeRefreshTokenRequest
+                await authenticationApiClient.RevokeRefreshTokenAsync(new RevokeRefreshTokenRequest
                 {
                     ClientId = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID"),
                     ClientSecret = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_SECRET"),
                     RefreshToken = "SomeRefreshToken"
                 });
-
-                // Ensure that we received an access token back
-                result.Should().BeNullOrEmpty();
             }
         }
     }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added
  - POST /oauth/revoke 
- Classes and methods added
  - class:  `RevokeRefreshTokenRequest`
  - method: `IAutheticationApiClient.Task<string> RevokeRefreshTokenAsync(RevokeRefreshTokenRequest request, CancellationToken cancellationToken = default)`
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
  - added support for missing Revoke Refresh Token endpoint

### References

Please include relevant links supporting this change such as a:

- support ticket:  #616

### Testing

Added token test to call revoke api

- [ ] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
