### PR TITLE
Added cancellation token to device credentials request

### DIFF
--- a/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/DeviceCredentialsClient.cs
@@ -36,19 +36,22 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="userId">The user id of the devices to retrieve.</param>
         /// <param name="clientId">The client id of the devices to retrieve.</param>
         /// <param name="type">The type of credentials.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>A list of <see cref="DeviceCredential"/> which conforms to the criteria specified.</returns>
         [Obsolete("Getting a list of device credentials without pagination is not recommended. Please use the overload that accepts pagination information.")]
-        public Task<IList<DeviceCredential>> GetAllAsync(string fields = null, bool includeFields = true, string userId = null, string clientId = null, string type = null)
+        public Task<IList<DeviceCredential>> GetAllAsync(string fields = null, bool includeFields = true, string userId = null, string clientId = null, string type = null, CancellationToken cancellationToken = default)
         {
             return Connection.GetAsync<IList<DeviceCredential>>(BuildUri("device-credentials",
-               new Dictionary<string, string>
-               {
-                    {"fields", fields},
-                    {"include_fields", includeFields.ToString().ToLower()},
-                    {"user_id", userId},
-                    {"client_id", clientId},
-                    {"type", type}
-               }), DefaultHeaders);
+                    new Dictionary<string, string>
+                    {
+                        { "fields", fields },
+                        { "include_fields", includeFields.ToString().ToLower() },
+                        { "user_id", userId },
+                        { "client_id", clientId },
+                        { "type", type }
+                    }),
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/IDeviceCredentialsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IDeviceCredentialsClient.cs
@@ -16,8 +16,9 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="userId">The user id of the devices to retrieve.</param>
     /// <param name="clientId">The client id of the devices to retrieve.</param>
     /// <param name="type">The type of credentials.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>A list of <see cref="DeviceCredential"/> which conforms to the criteria specified.</returns>
-    Task<IList<DeviceCredential>> GetAllAsync(string fields = null, bool includeFields = true, string userId = null, string clientId = null, string type = null);
+    Task<IList<DeviceCredential>> GetAllAsync(string fields = null, bool includeFields = true, string userId = null, string clientId = null, string type = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a list of all the device credentials.


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints changed
  - get device credentials
- Classes and methods changed
 - `DeviceCredentialsClient.GetAllAsync` 
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
  - allow cancel request of get device credentials endpoint. Added support for cancellation token. 


### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
