### PR TITLE
Optimize Test Clean up to only remove resources created by the tests

### DIFF
--- a/tests/Auth0.AuthenticationApi.IntegrationTests/AuthenticationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/AuthenticationTests.cs
@@ -41,6 +41,8 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 EnabledClients = new[] { TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"), TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") }
             });
 
+            TrackIdentifier(CleanUpType.Connections, TestConnection.Id);
+
             // And add a dummy user to test against
             TestUser = await ApiClient.Users.CreateAsync(new UserCreateRequest
             {
@@ -49,6 +51,8 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 EmailVerified = true,
                 Password = TestPassword
             });
+
+            TrackIdentifier(CleanUpType.Users, TestUser.UserId);
 
             // Add a user with a + in the username
             TestPlusUser = await ApiClient.Users.CreateAsync(new UserCreateRequest
@@ -59,6 +63,8 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 Password = TestPassword
             });
 
+            TrackIdentifier(CleanUpType.Users, TestPlusUser.UserId);
+
             // Add a user with a + in the username
             TestUserInDefaultDirectory = await ApiClient.Users.CreateAsync(new UserCreateRequest
             {
@@ -68,11 +74,18 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 Password = TestPassword
             });
 
+            TrackIdentifier(CleanUpType.Users, TestUserInDefaultDirectory.UserId);
+
             TestAuthenticationApiClient = new TestAuthenticationApiClient(TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL"));
         }
         public override async Task DisposeAsync()
         {
-            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Users, CleanUpType.Connections });
+            foreach (KeyValuePair<CleanUpType, IList<string>> entry in identifiers)
+            {
+                await ManagementTestBaseUtils.CleanupAsync(ApiClient, entry.Key, entry.Value);
+            }
+
+            ApiClient.Dispose();
         }
     }
 

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TestBaseFixture.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TestBaseFixture.cs
@@ -1,5 +1,7 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Auth0.AuthenticationApi.IntegrationTests.Testing;
+using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi;
 using Auth0.Tests.Shared;
 using Xunit;
@@ -9,6 +11,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests
     public class TestBaseFixture : IAsyncLifetime
     {
         public ManagementApiClient ApiClient { get; private set; }
+        protected IDictionary<CleanUpType, IList<string>> identifiers = new Dictionary<CleanUpType, IList<string>>();
 
         public virtual async Task InitializeAsync()
         {
@@ -19,7 +22,27 @@ namespace Auth0.AuthenticationApi.IntegrationTests
 
         public virtual async Task DisposeAsync()
         {
-            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient);
+            await Task.CompletedTask;
+        }
+
+        public void TrackIdentifier(CleanUpType type, string identifier)
+        {
+            if (!identifiers.ContainsKey(type))
+            {
+                identifiers[type] = new List<string>();
+            }
+
+            identifiers[type].Add(identifier);
+        }
+
+        public void UnTrackIdentifier(CleanUpType type, string identifier)
+        {
+            if (!identifiers.ContainsKey(type))
+            {
+                return;
+            }
+
+            identifiers[type].Remove(identifier);
         }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBase.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBase.cs
@@ -10,15 +10,6 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Testing
     {
         protected ManagementApiClient ApiClient;
         
-        public async Task CleanupAndDisposeAsync(CleanUpType? type = null)
-        {
-            if (ApiClient != null)
-            {
-                await RunCleanUp(type);
-                ApiClient.Dispose();
-            }
-        }
-
         public virtual Task DisposeAsync()
         {
             if (ApiClient != null)
@@ -27,27 +18,6 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Testing
             }
 
             return Task.CompletedTask;
-        }
-
-        private async Task RunCleanUp(CleanUpType? type)
-        {
-            var strategies = new List<CleanUpStrategy>
-            {
-                new ActionsCleanUpStrategy(ApiClient),
-                new ClientsCleanUpStrategy(ApiClient),
-                new ConnectionsCleanUpStrategy(ApiClient),
-                new HooksCleanUpStrategy(ApiClient),
-                new OrganizationsCleanUpStrategy(ApiClient),
-                new ResourceServersCleanUpStrategy(ApiClient),
-                new UsersCleanUpStrategy(ApiClient)
-            };
-
-            var strategiesToRun = type != null ? strategies.FindAll(s => s.Type == type) : strategies;
-
-            foreach (var cleanUpStrategy in strategiesToRun)
-            {
-                await cleanUpStrategy.Run();
-            }
         }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi;
@@ -7,31 +8,28 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Testing
 {
     public class ManagementTestBaseUtils
     {
-        public static async Task CleanupAndDisposeAsync(ManagementApiClient client, IList<CleanUpType> types = null)
-        {
-            await RunCleanUp(client, types);
-            client.Dispose();
-        }
-        
-
-        private static async Task RunCleanUp(ManagementApiClient client, IList<CleanUpType> types = null)
+        public static async Task CleanupAsync(ManagementApiClient client, CleanUpType type, IList<string> identifiers)
         {
             var strategies = new List<CleanUpStrategy>
             {
                 new ActionsCleanUpStrategy(client),
+                new ClientGrantsCleanUpStrategy(client),
                 new ClientsCleanUpStrategy(client),
                 new ConnectionsCleanUpStrategy(client),
                 new HooksCleanUpStrategy(client),
                 new OrganizationsCleanUpStrategy(client),
                 new ResourceServersCleanUpStrategy(client),
-                new UsersCleanUpStrategy(client)
+                new UsersCleanUpStrategy(client),
+                new RulesCleanUpStrategy(client),
+                new LogStreamsCleanUpStrategy(client),
+                new RolesCleanUpStrategy(client)
             };
 
-            var strategiesToRun = types != null ? strategies.FindAll(s => types.Contains(s.Type)) : strategies;
+            var cleanUpStrategy = strategies.Single(s => s.Type == type);
 
-            foreach (var cleanUpStrategy in strategiesToRun)
+            foreach (var identifier in identifiers)
             {
-                await cleanUpStrategy.Run();
+                await cleanUpStrategy.Run(identifier);
             }
         }
     }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ActionsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ActionsCleanUpStrategy.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Auth0.ManagementApi;
 using Auth0.ManagementApi.Models.Actions;
 using Auth0.ManagementApi.Paging;
+using static System.Collections.Specialized.BitVector32;
 
 namespace Auth0.IntegrationTests.Shared.CleanUp
 {
@@ -23,9 +24,15 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 if (action.Name.StartsWith(TestingConstants.ActionPrefix))
                 {
                     Console.WriteLine($"Removing action {action.Name}");
-                    await ApiClient.Actions.DeleteAsync(action.Id);
+                    await Run(action.Id);
                 }
             }
+        }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running ActionsCleanUpStrategy");
+            await ApiClient.Actions.DeleteAsync(id);
         }
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ActionsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ActionsCleanUpStrategy.cs
@@ -14,21 +14,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 
         }
 
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running ActionsCleanUpStrategy");
-            var actions = await ApiClient.Actions.GetAllAsync(new GetActionsRequest(), new PaginationInfo());
-
-            foreach (var action in actions)
-            {
-                if (action.Name.StartsWith(TestingConstants.ActionPrefix))
-                {
-                    Console.WriteLine($"Removing action {action.Name}");
-                    await Run(action.Id);
-                }
-            }
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running ActionsCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpStrategy.cs
@@ -15,5 +15,7 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
         }
 
         public abstract Task Run();
+
+        public abstract Task Run(string id);
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpStrategy.cs
@@ -14,8 +14,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
             ApiClient = apiClient;
         }
 
-        public abstract Task Run();
-
         public abstract Task Run(string id);
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
@@ -3,12 +3,15 @@
     public enum CleanUpType
     {
         Actions,
+        ClientGrants,
         Clients,
         Connections,
         Hooks,
         Organizations,
         ResourceServers,
         Users,
-        Rules
+        Roles,
+        Rules,
+        LogStreams
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientGrantsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientGrantsCleanUpStrategy.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class ClientGrantsCleanUpStrategy : CleanUpStrategy
+    {
+        public ClientGrantsCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.ClientGrants, apiClient)
+        {
+
+        }
+
+        public override async Task Run()
+        {
+            // SHOULD NOT BE USED
+            await Task.CompletedTask;
+        }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running ClientGrantsCleanUpStrategy");
+            await ApiClient.ClientGrants.DeleteAsync(id);
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientGrantsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientGrantsCleanUpStrategy.cs
@@ -10,12 +10,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override async Task Run()
-        {
-            // SHOULD NOT BE USED
-            await Task.CompletedTask;
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running ClientGrantsCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientsCleanUpStrategy.cs
@@ -11,21 +11,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running ClientsCleanUpStrategy");
-            var clients = await ApiClient.Clients.GetAllAsync(new ManagementApi.Models.GetClientsRequest { }, new ManagementApi.Paging.PaginationInfo(0, 100));
-
-            foreach (var client in clients)
-            {
-                if (client.Name.StartsWith(TestingConstants.ClientPrefix))
-                {
-                    Console.WriteLine($"Removing client {client.Name}");
-                    await ApiClient.Clients.DeleteAsync(client.ClientId);
-                }
-            }
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running ClientsCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ClientsCleanUpStrategy.cs
@@ -25,5 +25,11 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 }
             }
         }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running ClientsCleanUpStrategy");
+            await ApiClient.Clients.DeleteAsync(id);
+        }
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ConnectionsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ConnectionsCleanUpStrategy.cs
@@ -10,20 +10,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running ConnectionsCleanUpStrategy");
-            var connections = await ApiClient.Connections.GetAllAsync(new ManagementApi.Models.GetConnectionsRequest { });
-
-            foreach (var connection in connections)
-            {
-                if (connection.Name.StartsWith(TestingConstants.ConnectionPrefix))
-                {
-                    await ApiClient.Connections.DeleteAsync(connection.Id);
-                }
-            }
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running ConnectionsCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ConnectionsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ConnectionsCleanUpStrategy.cs
@@ -23,5 +23,12 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 }
             }
         }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running ConnectionsCleanUpStrategy");
+            var connections = await ApiClient.Connections.GetAllAsync(new ManagementApi.Models.GetConnectionsRequest { });
+            await ApiClient.Connections.DeleteAsync(id);        
+        }
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/HooksCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/HooksCleanUpStrategy.cs
@@ -27,5 +27,13 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 }
             }
         }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running HooksCleanUpStrategy");
+            
+            await ApiClient.Hooks.DeleteAsync(id);
+                
+        }
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/HooksCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/HooksCleanUpStrategy.cs
@@ -13,21 +13,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running HooksCleanUpStrategy");
-            var hooks = await ApiClient.Hooks.GetAllAsync(new GetHooksRequest(), new PaginationInfo());
-
-            foreach (var hook in hooks)
-            {
-                if (hook.Name.StartsWith(TestingConstants.HooksPrefix))
-                {
-                    Console.WriteLine($"Removing hook {hook.Name}");
-                    await ApiClient.Hooks.DeleteAsync(hook.Id);
-                }
-            }
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running HooksCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/LogStreamsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/LogStreamsCleanUpStrategy.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class LogStreamsCleanUpStrategy : CleanUpStrategy
+    {
+        public LogStreamsCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.LogStreams, apiClient)
+        {
+
+        }
+
+        public override Task Run()
+        {
+            // Not supported
+            return Task.CompletedTask;
+        }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running LogStreamsCleanUpStrategy");
+            await ApiClient.LogStreams.DeleteAsync(id);
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/LogStreamsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/LogStreamsCleanUpStrategy.cs
@@ -10,12 +10,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override Task Run()
-        {
-            // Not supported
-            return Task.CompletedTask;
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running LogStreamsCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/OrganizationsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/OrganizationsCleanUpStrategy.cs
@@ -26,5 +26,12 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 }
             }
         }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running OrganizationsCleanUpStrategy");
+
+            await ApiClient.Organizations.DeleteAsync(id); 
+        }
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/OrganizationsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/OrganizationsCleanUpStrategy.cs
@@ -11,22 +11,7 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
         {
 
         }
-
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running OrganizationsCleanUpStrategy");
-            var organizations = await ApiClient.Organizations.GetAllAsync(new PaginationInfo());
-
-            foreach (var organization in organizations)
-            {
-                if (organization.Name.ToLower().StartsWith(TestingConstants.OrganizationPrefix.ToLower()))
-                {
-                    Console.WriteLine($"Removing organization {organization.Name}");
-                    await ApiClient.Organizations.DeleteAsync(organization.Id);
-                }
-            }
-        }
-
+ 
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running OrganizationsCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ResourceServersCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ResourceServersCleanUpStrategy.cs
@@ -25,5 +25,11 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 }
             }
         }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running ResourceServersCleanUpStrategy");
+            await ApiClient.ResourceServers.DeleteAsync(id);
+        }
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/ResourceServersCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/ResourceServersCleanUpStrategy.cs
@@ -11,21 +11,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running ResourceServersCleanUpStrategy");
-            var resourceServers = await ApiClient.ResourceServers.GetAllAsync(new ManagementApi.Paging.PaginationInfo(0, 100));
-
-            foreach (var resourceServer in resourceServers)
-            {
-                if (resourceServer.Name.StartsWith(TestingConstants.ResourceServerPrefix))
-                {
-                    Console.WriteLine($"Removing resourceServer {resourceServer.Name}");
-                    await ApiClient.ResourceServers.DeleteAsync(resourceServer.Id);
-                }
-            }
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running ResourceServersCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/RolesCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/RolesCleanUpStrategy.cs
@@ -10,12 +10,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override Task Run()
-        {
-            // Not supported
-            return Task.CompletedTask;
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running RolesCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/RolesCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/RolesCleanUpStrategy.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class RolesCleanUpStrategy : CleanUpStrategy
+    {
+        public RolesCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Roles, apiClient)
+        {
+
+        }
+
+        public override Task Run()
+        {
+            // Not supported
+            return Task.CompletedTask;
+        }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running RolesCleanUpStrategy");
+            await ApiClient.Roles.DeleteAsync(id);
+        }
+    }
+}

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/RulesCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/RulesCleanUpStrategy.cs
@@ -12,21 +12,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running RulesCleanUpStrategy");
-            var rules = await ApiClient.Rules.GetAllAsync(new ManagementApi.Models.GetRulesRequest(), new PaginationInfo());
-
-            foreach (var rule in rules)
-            {
-                if (rule.Name.StartsWith(TestingConstants.RulesRefix))
-                {
-                    Console.WriteLine($"Removing rule {rule.Name}");
-                    await ApiClient.Rules.DeleteAsync(rule.Id);
-                }
-            }
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running RulesCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/RulesCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/RulesCleanUpStrategy.cs
@@ -26,5 +26,11 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 }
             }
         }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running RulesCleanUpStrategy");
+            await ApiClient.Rules.DeleteAsync(id);   
+        }
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/UsersCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/UsersCleanUpStrategy.cs
@@ -13,21 +13,6 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
 
         }
 
-        public override async Task Run()
-        {
-            System.Diagnostics.Debug.WriteLine("Running UsersCleanUpStrategy");
-            var users = await ApiClient.Users.GetAllAsync(new GetUsersRequest(), new PaginationInfo());
-
-            foreach (var user in users)
-            {
-                if (user.Email.Contains(TestingConstants.UserEmailDomain))
-                {
-                    Console.WriteLine($"Removing user {user.FullName}");
-                    await ApiClient.Users.DeleteAsync(user.UserId);
-                }
-            }
-        }
-
         public override async Task Run(string id)
         {
             System.Diagnostics.Debug.WriteLine("Running UsersCleanUpStrategy");

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/UsersCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/UsersCleanUpStrategy.cs
@@ -27,5 +27,11 @@ namespace Auth0.IntegrationTests.Shared.CleanUp
                 }
             }
         }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running UsersCleanUpStrategy");
+            await ApiClient.Users.DeleteAsync(id);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ActionsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ActionsTests.cs
@@ -177,7 +177,10 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Code = "module.exports = () => { console.log(true); }"
             });
 
-            // 6. Deploy the latest version
+            // 6.a Before deploying, ensure it's in built status (this is async and sometimes causes CI to fail)
+            await RetryUtils.Retry(() => fixture.ApiClient.Actions.GetAsync(createdAction.Id), (action) => action.Status != "built");
+
+            // 6.b. Deploy the latest version
             var deployedVersion = await fixture.ApiClient.Actions.DeployAsync(createdAction.Id);
 
             // Wait 2 seconds because it can take a while for the Action to be deployed

--- a/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/AttackProtectionTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models.AttackProtection;
 using FluentAssertions;
@@ -6,7 +8,18 @@ using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
 {
-    public class AttackProtectionTestsFixture : TestBaseFixture {}
+    public class AttackProtectionTestsFixture : TestBaseFixture
+    {
+        public override async Task DisposeAsync()
+        {
+            foreach (KeyValuePair<CleanUpType, IList<string>> entry in identifiers)
+            {
+                await ManagementTestBaseUtils.CleanupAsync(ApiClient, entry.Key, entry.Value);
+            }
+
+            ApiClient.Dispose();
+        }
+    }
 
     public class AttackProtectionTests : IClassFixture<AttackProtectionTestsFixture>
     {

--- a/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
@@ -19,7 +19,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
-        public async Task Test_Branding_Reand_And_Update()
+        public async Task Test_Branding_Read_And_Update()
         {
             try
             {
@@ -68,7 +68,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact(Skip = "Enable when migrated to new Tenant because missing permissions on current")]
-        public async Task Test_Branding_ULPTemplate_Reand_Update_Delete()
+        public async Task Test_Branding_ULPTemplate_Read_Update_Delete()
         {
             // var temp = await ApiClient.Branding.GetUniversalLoginTemplateAsync();
             try

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -20,9 +20,15 @@ namespace Auth0.ManagementApi.IntegrationTests
 {
     public class ClientTestsFixture : TestBaseFixture
     {
+
         public override async Task DisposeAsync()
         {
-            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Clients });
+            foreach (KeyValuePair<CleanUpType, IList<string>> entry in identifiers)
+            {
+                await ManagementTestBaseUtils.CleanupAsync(ApiClient, entry.Key, entry.Value);
+            }
+
+            ApiClient.Dispose();
         }
     }
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
@@ -16,7 +16,12 @@ namespace Auth0.ManagementApi.IntegrationTests
     {
         public override async Task DisposeAsync()
         {
-            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient, new List<CleanUpType> { CleanUpType.Connections });
+            foreach (KeyValuePair<CleanUpType, IList<string>> entry in identifiers)
+            {
+                await ManagementTestBaseUtils.CleanupAsync(ApiClient, entry.Key, entry.Value);
+            }
+
+            ApiClient.Dispose();
         }
     }
 
@@ -49,6 +54,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Realms = new[] { name }
             };
             var newConnectionResponse = await fixture.ApiClient.Connections.CreateAsync(newConnectionRequest);
+
+            fixture.TrackIdentifier(CleanUpType.Connections, newConnectionResponse.Id);
+
             newConnectionResponse.Should().NotBeNull();
             newConnectionResponse.Name.Should().Be(newConnectionRequest.Name);
             newConnectionResponse.Strategy.Should().Be(newConnectionRequest.Strategy);
@@ -95,6 +103,9 @@ namespace Auth0.ManagementApi.IntegrationTests
             await fixture.ApiClient.Connections.DeleteAsync(newConnectionResponse.Id);
             Func<Task> getFunc = async () => await fixture.ApiClient.Connections.GetAsync(newConnectionResponse.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
+
+
+            fixture.UnTrackIdentifier(CleanUpType.Connections, newConnectionResponse.Id);
         }
 
         [Fact]
@@ -114,6 +125,9 @@ namespace Auth0.ManagementApi.IntegrationTests
                 DisplayName = "displayname"
             };
             var newConnectionResponse = await fixture.ApiClient.Connections.CreateAsync(newConnectionRequest);
+
+            fixture.TrackIdentifier(CleanUpType.Connections, newConnectionResponse.Id);
+
             newConnectionResponse.Should().NotBeNull();
             newConnectionResponse.Name.Should().Be(newConnectionRequest.Name);
             newConnectionResponse.Strategy.Should().Be(newConnectionRequest.Strategy);
@@ -155,6 +169,8 @@ namespace Auth0.ManagementApi.IntegrationTests
             await fixture.ApiClient.Connections.DeleteAsync(newConnectionResponse.Id);
             Func<Task> getFunc = async () => await fixture.ApiClient.Connections.GetAsync(newConnectionResponse.Id);
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
+
+            fixture.UnTrackIdentifier(CleanUpType.Connections, newConnectionResponse.Id);
         }
 
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/PromptsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/PromptsTests.cs
@@ -16,11 +16,6 @@ namespace Auth0.ManagementApi.IntegrationTests
             ApiClient = new ManagementApiClient(token, GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
         }
 
-        public override Task DisposeAsync()
-        {
-            return CleanupAndDisposeAsync();
-        }
-
         [Fact]
         public async Task Test_get_and_update_prompts()
         {

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBaseFixture.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBaseFixture.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.Tests.Shared;
 using Xunit;
@@ -9,6 +11,8 @@ namespace Auth0.ManagementApi.IntegrationTests
     {
         public ManagementApiClient ApiClient { get; private set; }
 
+        protected IDictionary<CleanUpType, IList<string>> identifiers = new Dictionary<CleanUpType, IList<string>>();
+
         public virtual async Task InitializeAsync()
         {
             string token = await TestBaseUtils.GenerateManagementApiToken();
@@ -18,7 +22,27 @@ namespace Auth0.ManagementApi.IntegrationTests
 
         public virtual async Task DisposeAsync()
         {
-            await ManagementTestBaseUtils.CleanupAndDisposeAsync(ApiClient);
+            await Task.CompletedTask;
+        }
+
+        public void TrackIdentifier(CleanUpType type, string identifier)
+        {
+            if (!identifiers.ContainsKey(type))
+            {
+                identifiers[type] = new List<string>();
+            }
+
+            identifiers[type].Add(identifier);
+        }
+
+        public void UnTrackIdentifier(CleanUpType type, string identifier)
+        {
+            if (!identifiers.ContainsKey(type))
+            {
+                return;
+            }
+
+            identifiers[type].Remove(identifier);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBase.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBase.cs
@@ -8,15 +8,6 @@ namespace Auth0.ManagementApi.IntegrationTests.Testing
     public class ManagementTestBase : TestBase
     {
         protected ManagementApiClient ApiClient;
-        
-        public async Task CleanupAndDisposeAsync(CleanUpType? type = null)
-        {
-            if (ApiClient != null)
-            {
-                await RunCleanUp(type);
-                ApiClient.Dispose();
-            }
-        }
 
         public virtual Task DisposeAsync()
         {
@@ -26,27 +17,6 @@ namespace Auth0.ManagementApi.IntegrationTests.Testing
             }
 
             return Task.CompletedTask;
-        }
-
-        private async Task RunCleanUp(CleanUpType? type)
-        {
-            var strategies = new List<CleanUpStrategy>
-            {
-                new ActionsCleanUpStrategy(ApiClient),
-                new ClientsCleanUpStrategy(ApiClient),
-                new ConnectionsCleanUpStrategy(ApiClient),
-                new HooksCleanUpStrategy(ApiClient),
-                new OrganizationsCleanUpStrategy(ApiClient),
-                new ResourceServersCleanUpStrategy(ApiClient),
-                new UsersCleanUpStrategy(ApiClient)
-            };
-
-            var strategiesToRun = type != null ? strategies.FindAll(s => s.Type == type) : strategies;
-
-            foreach (var cleanUpStrategy in strategiesToRun)
-            {
-                await cleanUpStrategy.Run();
-            }
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -31,10 +31,5 @@ namespace Auth0.ManagementApi.IntegrationTests.Testing
                 await cleanUpStrategy.Run(identifier);
             }
         }
-
-
-        
-
-        
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Auth0.IntegrationTests.Shared.CleanUp;
 
@@ -6,33 +7,34 @@ namespace Auth0.ManagementApi.IntegrationTests.Testing
 {
     public class ManagementTestBaseUtils
     {
-        public static async Task CleanupAndDisposeAsync(ManagementApiClient client, IList<CleanUpType> types = null)
-        {
-            await RunCleanUp(client, types);
-            client.Dispose();
-        }
-        
-
-        private static async Task RunCleanUp(ManagementApiClient client, IList<CleanUpType> types = null)
+        public static async Task CleanupAsync(ManagementApiClient client, CleanUpType type, IList<string> identifiers)
         {
             var strategies = new List<CleanUpStrategy>
             {
                 new ActionsCleanUpStrategy(client),
+                new ClientGrantsCleanUpStrategy(client),
                 new ClientsCleanUpStrategy(client),
                 new ConnectionsCleanUpStrategy(client),
                 new HooksCleanUpStrategy(client),
                 new OrganizationsCleanUpStrategy(client),
                 new ResourceServersCleanUpStrategy(client),
                 new UsersCleanUpStrategy(client),
-                new RulesCleanUpStrategy(client)
+                new RulesCleanUpStrategy(client),
+                new LogStreamsCleanUpStrategy(client),
+                new RolesCleanUpStrategy(client)
             };
 
-            var strategiesToRun = types != null ? strategies.FindAll(s => types.Contains(s.Type)) : strategies;
+            var cleanUpStrategy = strategies.Single(s => s.Type == type);
 
-            foreach (var cleanUpStrategy in strategiesToRun)
+            foreach (var identifier in identifiers)
             {
-                await cleanUpStrategy.Run();
+                await cleanUpStrategy.Run(identifier);
             }
         }
+
+
+        
+
+        
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
@@ -21,6 +21,8 @@ namespace Auth0.ManagementApi.IntegrationTests
 
         public override async Task InitializeAsync()
         {
+            await base.InitializeAsync();
+
             AuthConnection = await ApiClient.Connections.CreateAsync(new ConnectionCreateRequest
             {
                 Name = $"{TestingConstants.ConnectionPrefix}-{TestBaseUtils.MakeRandomName()}",


### PR DESCRIPTION
### Changes

Cleaning up the tests wasn't very optimised and made parallel build fail more easily.

This PR updates the tests to track all the identifiers of the resources created, ensuring they are cleaned up after running the tests without removing other resources (such as those from parallel builds).

This PR makes the total time to run the CI down from +15min to 10min.

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
