### PR TITLE
Add ClientId to EmailVerificationTicket

### DIFF
--- a/src/Auth0.ManagementApi/Models/EmailVerificationTicketRequest.cs
+++ b/src/Auth0.ManagementApi/Models/EmailVerificationTicketRequest.cs
@@ -43,6 +43,15 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("organization_id")]
         public string OrganizationId { get; set; }
+
+        /// <summary>
+        /// ID of the client.
+        /// If provided for tenants using the New Universal Login experience, 
+        /// the user will be prompted to redirect to the default login route of the corresponding application once the ticket is used.
+        /// See <see href="https://auth0.com/docs/universal-login/configure-default-login-routes">Configuring Default Login Routes</see> for more details.
+        /// </summary>
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
     }
 
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
@@ -137,5 +137,17 @@ namespace Auth0.ManagementApi.IntegrationTests
             verificationTicketResponse.Should().NotBeNull();
             verificationTicketResponse.Value.Should().NotBeNull();
         }
+
+        [Fact]
+        public async Task Can_send_verification_email_with_client_id()
+        {
+            var verificationTicketResponse = await fixture.ApiClient.Tickets.CreateEmailVerificationTicketAsync(new EmailVerificationTicketRequest
+            {
+                UserId = fixture.EmailUser.UserId,
+                ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID")
+            });
+            verificationTicketResponse.Should().NotBeNull();
+            verificationTicketResponse.Value.Should().NotBeNull();
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
@@ -143,7 +143,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var verificationTicketResponse = await fixture.ApiClient.Tickets.CreateEmailVerificationTicketAsync(new EmailVerificationTicketRequest
             {
-                UserId = fixture.EmailUser.UserId,
+                UserId = fixture.Auth0User.UserId,
                 ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID")
             });
             verificationTicketResponse.Should().NotBeNull();


### PR DESCRIPTION
### Changes

The `ClientId` property was added to the `EmailVerificationTicketRequest.cs` class. This will allow the correct app name to be displayed in the "Go back to <app name>" button once the link has been clicked rather than showing the name "All Applications".

### References

- The issue that I created describing this issue:  #628 

### Testing

I have added a small integration test based on what was already in the `TicketTests` class. I was able to run the unit tests locally and they all passed but unfortunately I was unable to get the integration tests running. I'm hoping that the integration tests are run in CI/CD though, so we can check that all the tests pass there.

- [ ] This change adds unit test coverage

- [x] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
