### PR TITLE
Support Organization Name

### DIFF
--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
@@ -49,6 +49,10 @@ namespace Auth0.AuthenticationApi.Models
         /// <summary>
         /// Organization for Id Token verification.
         /// </summary>
+        /// <remarks>
+        /// - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
+        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
+        /// </remarks>
         public string Organization { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
@@ -56,6 +56,10 @@ namespace Auth0.AuthenticationApi.Models
         /// <summary>
         /// Organization for Id Token verification.
         /// </summary>
+        /// <remarks>
+        /// - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
+        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
+        /// </remarks>
         public string Organization { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Tokens/Auth0ClaimNames.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/Auth0ClaimNames.cs
@@ -5,6 +5,7 @@
     /// </summary>
     internal static class Auth0ClaimNames
     {
-        internal static string Organization = "org_id"; 
+        internal static string OrganizationId = "org_id";
+        internal static string OrganizationName = "org_name";
     }
 }

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
@@ -94,11 +94,13 @@ namespace Auth0.AuthenticationApi.Tokens
             if (!string.IsNullOrWhiteSpace(required.Organization))
             {
                 var organizationClaim = required.Organization.StartsWith("org_") ? Auth0ClaimNames.OrganizationId : Auth0ClaimNames.OrganizationName;
-                var organization = GetClaimValue(token.Claims, organizationClaim);
+                var organization = organizationClaim == Auth0ClaimNames.OrganizationName ? GetClaimValue(token.Claims, organizationClaim).ToLower() : GetClaimValue(token.Claims, organizationClaim);
+                var expectedOrganization = organizationClaim == Auth0ClaimNames.OrganizationName ? required.Organization.ToLower() : required.Organization;
+
                 if (string.IsNullOrWhiteSpace(organization))
                     throw new IdTokenValidationException($"Organization claim ({organizationClaim}) must be a string present in the ID token.");
-                if (organization != required.Organization)
-                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) mismatch in the ID token; expected \"{required.Organization}\", found \"{organization}\".");
+                if (organization != expectedOrganization)
+                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) mismatch in the ID token; expected \"{expectedOrganization}\", found \"{organization}\".");
             }
 
         }

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
@@ -94,7 +94,7 @@ namespace Auth0.AuthenticationApi.Tokens
             if (!string.IsNullOrWhiteSpace(required.Organization))
             {
                 var organizationClaim = required.Organization.StartsWith("org_") ? Auth0ClaimNames.OrganizationId : Auth0ClaimNames.OrganizationName;
-                var organization = organizationClaim == Auth0ClaimNames.OrganizationName ? GetClaimValue(token.Claims, organizationClaim)?.ToLower() : GetClaimValue(token.Claims, organizationClaim);
+                var organization = organizationClaim == GetClaimValue(token.Claims, organizationClaim);
                 var expectedOrganization = organizationClaim == Auth0ClaimNames.OrganizationName ? required.Organization.ToLower() : required.Organization;
 
                 if (string.IsNullOrWhiteSpace(organization))

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
@@ -94,7 +94,7 @@ namespace Auth0.AuthenticationApi.Tokens
             if (!string.IsNullOrWhiteSpace(required.Organization))
             {
                 var organizationClaim = required.Organization.StartsWith("org_") ? Auth0ClaimNames.OrganizationId : Auth0ClaimNames.OrganizationName;
-                var organization = organizationClaim == Auth0ClaimNames.OrganizationName ? GetClaimValue(token.Claims, organizationClaim).ToLower() : GetClaimValue(token.Claims, organizationClaim);
+                var organization = organizationClaim == Auth0ClaimNames.OrganizationName ? GetClaimValue(token.Claims, organizationClaim)?.ToLower() : GetClaimValue(token.Claims, organizationClaim);
                 var expectedOrganization = organizationClaim == Auth0ClaimNames.OrganizationName ? required.Organization.ToLower() : required.Organization;
 
                 if (string.IsNullOrWhiteSpace(organization))

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
@@ -94,7 +94,7 @@ namespace Auth0.AuthenticationApi.Tokens
             if (!string.IsNullOrWhiteSpace(required.Organization))
             {
                 var organizationClaim = required.Organization.StartsWith("org_") ? Auth0ClaimNames.OrganizationId : Auth0ClaimNames.OrganizationName;
-                var organization = organizationClaim == GetClaimValue(token.Claims, organizationClaim);
+                var organization = GetClaimValue(token.Claims, organizationClaim);
                 var expectedOrganization = organizationClaim == Auth0ClaimNames.OrganizationName ? required.Organization.ToLower() : required.Organization;
 
                 if (string.IsNullOrWhiteSpace(organization))

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenClaimValidator.cs
@@ -93,11 +93,12 @@ namespace Auth0.AuthenticationApi.Tokens
             // Organization
             if (!string.IsNullOrWhiteSpace(required.Organization))
             {
-                var organization = GetClaimValue(token.Claims, Auth0ClaimNames.Organization);
+                var organizationClaim = required.Organization.StartsWith("org_") ? Auth0ClaimNames.OrganizationId : Auth0ClaimNames.OrganizationName;
+                var organization = GetClaimValue(token.Claims, organizationClaim);
                 if (string.IsNullOrWhiteSpace(organization))
-                    throw new IdTokenValidationException("Organization claim must be a string present in the ID token.");
+                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) must be a string present in the ID token.");
                 if (organization != required.Organization)
-                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organization}\".");
+                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) mismatch in the ID token; expected \"{required.Organization}\", found \"{organization}\".");
             }
 
         }

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using Newtonsoft.Json.Linq;
+using System.Security.Claims;
 
 namespace Auth0.AuthenticationApi.Tokens
 {
@@ -41,6 +43,10 @@ namespace Auth0.AuthenticationApi.Tokens
         /// <summary>
         /// Optional organization (org_id / org_name) the token must be for.
         /// </summary>
+        /// <remarks>
+        /// - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
+        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
+        /// </remarks>
         public string Organization;
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/IdTokenRequirements.cs
@@ -39,7 +39,7 @@ namespace Auth0.AuthenticationApi.Tokens
         public TimeSpan Leeway;
 
         /// <summary>
-        /// Optional organization (org_id) the token must be for.
+        /// Optional organization (org_id / org_name) the token must be for.
         /// </summary>
         public string Organization;
 

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenClaimValidatorTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenClaimValidatorTests.cs
@@ -1,7 +1,12 @@
 ﻿using Auth0.AuthenticationApi.Tokens;
 using Auth0.Tests.Shared;
+using Microsoft.IdentityModel.Tokens;
 using System;
+using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
 using Xunit;
 
 namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
@@ -161,6 +166,125 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
 
             var ex = Assert.Throws<IdTokenValidationException>(() => ValidateToken(token));
             Assert.Equal("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (1568023200) is after last auth at 1568008254.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowsWhenNoOrgIdWhileOrgIdRequired()
+        {
+            IdTokenRequirements requirements =
+            new IdTokenRequirements(JwtSignatureAlgorithm.RS256, "https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "org_123"
+            };
+
+            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
+            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
+
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_name", "organizationA") });
+
+            var ex = Assert.Throws<IdTokenValidationException>(() => ValidateToken(token, requirements));
+            Assert.Equal("Organization claim (org_id) must be a string present in the ID token.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowsWhenOrgIdDoesntMatch()
+        {
+            IdTokenRequirements requirements =
+            new IdTokenRequirements(JwtSignatureAlgorithm.RS256, "https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "org_123"
+            };
+
+            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
+            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
+
+            var organization = "abc";
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_id", organization) });
+
+            var ex = Assert.Throws<IdTokenValidationException>(() => ValidateToken(token, requirements));
+            Assert.Equal($"Organization claim (org_id) mismatch in the ID token; expected \"{requirements.Organization}\", found \"{organization}\".", ex.Message);
+        }
+
+        [Fact]
+        public void DoesNotThrowWhenOrgIdMatch()
+        {
+            IdTokenRequirements requirements =
+            new IdTokenRequirements(JwtSignatureAlgorithm.RS256, "https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "org_123"
+            };
+
+            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
+            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_id", "org_123") });
+
+            ValidateToken(token, requirements);
+        }
+
+        [Fact]
+        public void ThrowsWhenNoOrgNameWhileOrgNameRequired()
+        {
+            IdTokenRequirements requirements =
+            new IdTokenRequirements(JwtSignatureAlgorithm.RS256, "https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "organizationA"
+            };
+
+            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
+            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
+
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_id", "org_123") });
+
+            var ex = Assert.Throws<IdTokenValidationException>(() => ValidateToken(token, requirements));
+            Assert.Equal("Organization claim (org_name) must be a string present in the ID token.", ex.Message);
+        }
+
+        [Fact]
+        public void ThrowsWhenOrgNameDoesntMatch()
+        {
+            IdTokenRequirements requirements =
+            new IdTokenRequirements(JwtSignatureAlgorithm.RS256, "https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "organizationA"
+            };
+
+            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
+            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
+
+            var organization = "organization2";
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_name", organization) });
+
+            var ex = Assert.Throws<IdTokenValidationException>(() => ValidateToken(token, requirements));
+            Assert.Equal($"Organization claim (org_name) mismatch in the ID token; expected \"{requirements.Organization}\", found \"{organization}\".", ex.Message);
+        }
+
+        [Fact]
+        public void DoesNotThrowWhenOrgNameMatch()
+        {
+            IdTokenRequirements requirements =
+            new IdTokenRequirements(JwtSignatureAlgorithm.RS256, "https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "organizationA"
+            };
+
+            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
+            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
+
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_name", "organizationA") });
+
+            ValidateToken(token, requirements);
         }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenClaimValidatorTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenClaimValidatorTests.cs
@@ -282,7 +282,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
             var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
             var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
 
-            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_name", "organizationA") });
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_name", "organizationa") });
 
             ValidateToken(token, requirements);
         }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenClaimValidatorTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/IdTokenClaimValidatorTests.cs
@@ -235,7 +235,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
             {
                 Nonce = "a1b2c3d4e5",
                 MaxAge = TimeSpan.FromSeconds(100),
-                Organization = "organizationA"
+                Organization = "organizationa"
             };
 
             var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
@@ -255,7 +255,7 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
             {
                 Nonce = "a1b2c3d4e5",
                 MaxAge = TimeSpan.FromSeconds(100),
-                Organization = "organizationA"
+                Organization = "organizationa"
             };
 
             var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));


### PR DESCRIPTION
### Changes

Adds support for the organization name by extending the ID Token validation as follows:

- If organization is set and has the `org_` prefix, we expect an org_id claim
- If organization is set and does not have the `org_` prefix, we expect an org_name claim

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
