### PR TITLE
Support providing Organization when resetting password

### DIFF
--- a/src/Auth0.AuthenticationApi/Models/ChangePasswordRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ChangePasswordRequest.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+
 namespace Auth0.AuthenticationApi.Models
 {
     /// <summary>
@@ -5,5 +7,10 @@ namespace Auth0.AuthenticationApi.Models
     /// </summary>
     public class ChangePasswordRequest : UserMaintenanceRequestBase
     {
+        /// <summary>
+        /// The organization of the user.
+        /// </summary>
+        [JsonProperty("organization")]
+        public string Organization { get; set; }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/ChangePasswordRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ChangePasswordRequest.cs
@@ -8,7 +8,7 @@ namespace Auth0.AuthenticationApi.Models
     public class ChangePasswordRequest : UserMaintenanceRequestBase
     {
         /// <summary>
-        /// The organization of the user.
+        /// The organization_id of the Organization associated with the user.
         /// </summary>
         [JsonProperty("organization")]
         public string Organization { get; set; }


### PR DESCRIPTION
### Changes

We should be able to sent the Organization parameter when calling `ChangePasswordAsync`.

### References

No documentation on this available yet.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
