### PR TITLE
Add cross_origin_authentication on Clients

### DIFF
--- a/src/Auth0.ManagementApi/Models/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientBase.cs
@@ -184,6 +184,12 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("organization_require_behavior")]
         [JsonConverter(typeof(StringEnumConverter))]
         public OrganizationRequireBehavior? OrganizationRequireBehavior { get; set; }
+
+        /// <summary>
+        /// Whether this client can be used to make cross-origin authentication requests (true) or it is not allowed to make such requests (false).
+        /// </summary>
+        [JsonProperty("cross_origin_authentication")]
+        public bool? CrossOriginAuthentication { get; set; }
     }
 
 }


### PR DESCRIPTION
### Changes

Adds the missing `cross_origin_authentication` property on Client.

### References

Closes #641 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
