### PR TITLE
added generic get/set metadata methods on UserBase

### DIFF
--- a/src/Auth0.ManagementApi/Models/UserBase.cs
+++ b/src/Auth0.ManagementApi/Models/UserBase.cs
@@ -111,19 +111,14 @@ namespace Auth0.ManagementApi.Models
         /// <typeparam name="T">Type to be returned.</typeparam>
         /// <returns>An instance of T.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public T GetAppMetadata<T>()
+        public T GetAppMetadata<T>() where T : class
         {
-            if (AppMetadata is null)
-            {
-                return default;
-            }
-
             if (AppMetadata is JObject jObject)
             {
                 return jObject.ToObject<T>();
             }
 
-            throw new ArgumentException("Unknown metadata type");
+            return null;
         }
 
         /// <summary>
@@ -132,19 +127,14 @@ namespace Auth0.ManagementApi.Models
         /// <typeparam name="T">Type to be returned.</typeparam>
         /// <returns>An instance of T.</returns>
         /// <exception cref="ArgumentException"></exception>
-        public T GetUserMetadata<T>()
+        public T GetUserMetadata<T>() where T : class
         {
-            if (UserMetadata is null)
-            {
-                return default;
-            }
-
             if (UserMetadata is JObject jObject)
             {
                 return jObject.ToObject<T>();
             }
 
-            throw new ArgumentException("Unknown metadata type");
+            return null;
         }
 
         /// <summary>
@@ -152,7 +142,7 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         /// <typeparam name="T">Metadata type.</typeparam>
         /// <param name="appMetadata">Metadata to set.</param>
-        public void SetAppMetadata<T>(T appMetadata)
+        public void SetAppMetadata<T>(T appMetadata) where T : class
         {
             AppMetadata = JObject.FromObject(appMetadata);
         }
@@ -162,7 +152,7 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         /// <typeparam name="T">Metadata type.</typeparam>
         /// <param name="userMetadata">Metadata to set.</param>
-        public void SetUserMetadata<T>(T userMetadata)
+        public void SetUserMetadata<T>(T userMetadata) where T : class
         {
             UserMetadata = JObject.FromObject(userMetadata);
         }

--- a/src/Auth0.ManagementApi/Models/UserBase.cs
+++ b/src/Auth0.ManagementApi/Models/UserBase.cs
@@ -110,7 +110,6 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         /// <typeparam name="T">Type to be returned.</typeparam>
         /// <returns>An instance of T.</returns>
-        /// <exception cref="ArgumentException"></exception>
         public T GetAppMetadata<T>() where T : class
         {
             if (AppMetadata is JObject jObject)
@@ -126,7 +125,6 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         /// <typeparam name="T">Type to be returned.</typeparam>
         /// <returns>An instance of T.</returns>
-        /// <exception cref="ArgumentException"></exception>
         public T GetUserMetadata<T>() where T : class
         {
             if (UserMetadata is JObject jObject)

--- a/src/Auth0.ManagementApi/Models/UserBase.cs
+++ b/src/Auth0.ManagementApi/Models/UserBase.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 
 namespace Auth0.ManagementApi.Models
 {
@@ -58,7 +60,7 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("username")]
         public string UserName { get; set; }
 
-                /// <summary>
+        /// <summary>
         /// The Nickname of the user.
         /// </summary>
         [JsonProperty("nickname")]
@@ -102,5 +104,67 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("blocked")]
         public bool? Blocked { get; set; }
+
+        /// <summary>
+        /// Returns <see cref="AppMetadata"/> as specific type.
+        /// </summary>
+        /// <typeparam name="T">Type to be returned.</typeparam>
+        /// <returns>An instance of T.</returns>
+        /// <exception cref="ArgumentException"></exception>
+        public T GetAppMetadata<T>()
+        {
+            if (AppMetadata is null)
+            {
+                return default;
+            }
+
+            if (AppMetadata is JObject jObject)
+            {
+                return jObject.ToObject<T>();
+            }
+
+            throw new ArgumentException("Unknown metadata type");
+        }
+
+        /// <summary>
+        /// Returns <see cref="UserMetadata"/> as specific type.
+        /// </summary>
+        /// <typeparam name="T">Type to be returned.</typeparam>
+        /// <returns>An instance of T.</returns>
+        /// <exception cref="ArgumentException"></exception>
+        public T GetUserMetadata<T>()
+        {
+            if (UserMetadata is null)
+            {
+                return default;
+            }
+
+            if (UserMetadata is JObject jObject)
+            {
+                return jObject.ToObject<T>();
+            }
+
+            throw new ArgumentException("Unknown metadata type");
+        }
+
+        /// <summary>
+        /// Set given appMetadata as <see cref="AppMetadata"/>.
+        /// </summary>
+        /// <typeparam name="T">Metadata type.</typeparam>
+        /// <param name="appMetadata">Metadata to set.</param>
+        public void SetAppMetadata<T>(T appMetadata)
+        {
+            AppMetadata = JObject.FromObject(appMetadata);
+        }
+
+        /// <summary>
+        /// Set given userMetadata as <see cref="UserMetadata"/>.
+        /// </summary>
+        /// <typeparam name="T">Metadata type.</typeparam>
+        /// <param name="userMetadata">Metadata to set.</param>
+        public void SetUserMetadata<T>(T userMetadata)
+        {
+            UserMetadata = JObject.FromObject(userMetadata);
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -334,8 +334,8 @@ namespace Auth0.ManagementApi.IntegrationTests
             var newUserResponse = await fixture.ApiClient.Users.CreateAsync(newUserRequest);
             fixture.TrackIdentifier(CleanUpType.Users, newUserResponse.UserId);
             // read metadata
-            var appMetadata = newUserRequest.GetAppMetadata<CustomMetadata>();
-            var userMetadata = newUserRequest.GetUserMetadata<CustomMetadata>();
+            var appMetadata = newUserResponse.GetAppMetadata<CustomMetadata>();
+            var userMetadata = newUserResponse.GetUserMetadata<CustomMetadata>();
 
             Assert.NotNull(appMetadata);
             Assert.Equal(appMetadata.Amount, customAppMetadata.Amount);
@@ -363,8 +363,8 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             // Get the user to ensure the metadata was set
             var user = await fixture.ApiClient.Users.GetAsync(newUserResponse.UserId);
-            appMetadata = newUserRequest.GetAppMetadata<CustomMetadata>();
-            userMetadata = newUserRequest.GetUserMetadata<CustomMetadata>();
+            appMetadata = user.GetAppMetadata<CustomMetadata>();
+            userMetadata = user.GetUserMetadata<CustomMetadata>();
 
             Assert.NotNull(appMetadata);
             Assert.Equal(appMetadata.Amount, customAppMetadata.Amount);

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -51,7 +51,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 await ManagementTestBaseUtils.CleanupAsync(ApiClient, entry.Key, entry.Value);
             }
 
-            ApiClient.Dispose();
+            ApiClient?.Dispose();
         }
     }
 
@@ -221,7 +221,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var users = await fixture.ApiClient.Users.GetAllAsync(new GetUsersRequest(), new PaginationInfo());
-            
+
             // Assert
             Assert.Null(users.Paging);
         }
@@ -231,7 +231,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var users = await fixture.ApiClient.Users.GetAllAsync(new GetUsersRequest(), new PaginationInfo(0, 50, false));
-            
+
             // Assert
             Assert.Null(users.Paging);
         }
@@ -241,7 +241,7 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             // Act
             var users = await fixture.ApiClient.Users.GetAllAsync(new GetUsersRequest(), new PaginationInfo(0, 50, true));
-            
+
             // Assert
             Assert.NotNull(users.Paging);
         }
@@ -304,6 +304,44 @@ namespace Auth0.ManagementApi.IntegrationTests
             await fixture.ApiClient.Users.DeleteAsync(user.UserId);
             fixture.UnTrackIdentifier(CleanUpType.Users, newUserResponse.UserId);
 
+        }
+
+
+        [Fact]
+        public void Can_read_user_metadata_as_type()
+        {
+            // create a user instance
+            var user = new User
+            {
+                Email = $"{Guid.NewGuid():N}{TestingConstants.UserEmailDomain}",
+                EmailVerified = true
+            };
+            var customAppMetadata = new CustomMetadata
+            {
+                Amount = 42,
+                Name = "A name"
+            };
+            var customUserMetadat = new CustomMetadata
+            {
+                Amount = 43,
+                Name = "One off"
+            };
+            
+            // set metadata
+            user.SetAppMetadata(customAppMetadata);
+            user.SetUserMetadata(customUserMetadat);
+
+            // read metadata
+            var appMetadata = user.GetAppMetadata<CustomMetadata>();
+            var userMetadata = user.GetUserMetadata<CustomMetadata>();
+            
+            Assert.NotNull(appMetadata);
+            Assert.Equal(appMetadata.Amount, customAppMetadata.Amount);
+            Assert.Equal(appMetadata.Name, customAppMetadata.Name);
+
+            Assert.NotNull(userMetadata);
+            Assert.Equal(userMetadata.Amount, customUserMetadat.Amount);
+            Assert.Equal(userMetadata.Name, customUserMetadat.Name);
         }
 
         [Fact]
@@ -584,6 +622,12 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             var allAuthenticationMethods3 = await fixture.ApiClient.Users.GetAuthenticationMethodsAsync(fixture.User.UserId);
             allAuthenticationMethods3.Count.Should().Be(0);
+        }
+
+        private class CustomMetadata
+        {
+            public string Name { get; set; }
+            public int Amount { get; set; }
         }
     }
 }


### PR DESCRIPTION
### Changes

Added generic methods to get/set user metadata, e.g.:
`userInstance.getAppMetadata<MyAppMetadata>();`
`userInstance.getUserMetadata<MyUserMetadata>();`
`userInstance.setAppMetadata(myAppMetadata);`
`userInstance.setUserMetadata(myUserMetadata);`

As for now Newtonsoft.Json.Linq.JObject is used as this type seems to be deserialized when reading users.

Auth0.ManagementApi.Models.UserBase
- added new generic get/set methods for AppMetadata and UserMetadata

Auth0.ManagementApi.IntegrationTests.UsersTests:
- added test for read/write user metadata with new generic get/set methods

### References
#645 

### Testing
Retrieve a user with AppMetadata, call getAppMetadata with a matching type and see the filled properties

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not
I'm unable to run the tests as configuration seems missing

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
I'm unable to run the tests as configuration seems missing