### PR TITLE
Add external_id on Job

### DIFF
--- a/playground/Auth0.NET6/Properties/launchSettings.json
+++ b/playground/Auth0.NET6/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
@@ -19,13 +19,13 @@
     },
     "Auth0.NET6": {
       "commandName": "Project",
-      "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "dotnetRunMessages": "true"
     }
   }
 }

--- a/playground/Auth0.NETCore3/Properties/launchSettings.json
+++ b/playground/Auth0.NETCore3/Properties/launchSettings.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,

--- a/src/Auth0.ManagementApi/Models/Job.cs
+++ b/src/Auth0.ManagementApi/Models/Job.cs
@@ -88,7 +88,7 @@ namespace Auth0.ManagementApi.Models
         }
 
         /// <summary>
-        /// The external ID used to correlate multiple jobs
+        /// Customer-defined id.
         /// </summary>
         [JsonProperty("external_id")]
         public int ExternalId { get; set; }

--- a/src/Auth0.ManagementApi/Models/Job.cs
+++ b/src/Auth0.ManagementApi/Models/Job.cs
@@ -86,5 +86,11 @@ namespace Auth0.ManagementApi.Models
             get { return TimeSpan.FromSeconds(TimeLeftSeconds); }
             set { TimeLeftSeconds = (int)value.TotalSeconds; }
         }
+
+        /// <summary>
+        /// The external ID used to correlate multiple jobs
+        /// </summary>
+        [JsonProperty("external_id")]
+        public int ExternalId { get; set; }
     }
 }


### PR DESCRIPTION
### Changes

Adds the `external_id` property on Job, which can be send when importing users, see https://github.com/auth0/auth0.net/blob/master/src/Auth0.ManagementApi/Clients/JobsClient.cs#L64

### References

Closes #653

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
