### PR TITLE
Add customize_mfa_in_postlogin_action to TenantSettings

### DIFF
--- a/src/Auth0.ManagementApi/Models/TenantSettingsBase.cs
+++ b/src/Auth0.ManagementApi/Models/TenantSettingsBase.cs
@@ -124,5 +124,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("session_cookie")]
         public SessionCookie SessionCookie { get; set; }
+        
+        /// <summary>
+        /// Whether to enable flexible factors for MFA in the PostLogin action
+        /// </summary>
+        [JsonProperty("customize_mfa_in_postlogin_action")]
+        public bool? CustomizeMfaInPostLoginAction { get; set; } = null;
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
@@ -23,7 +23,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 // Update the tenant settings - do not set some properties as the tenant is pre-configured
                 // to allow all the right logout urls etc.
                 var settingsUpdateRequest = new TenantSettingsUpdateRequest
-                {
+                {      
                     ChangePassword = new TenantChangePassword
                     {
                         Enabled = true,
@@ -53,7 +53,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                         DisableClickjackProtectionHeaders = true,
                         EnableAPIsSection = true,
                         EnableClientConnections = false,
-                        EnablePipeline2 = true
+                        EnablePipeline2 = true,
                     },
                     DeviceFlow = new TenantDeviceFlow()
                     {
@@ -63,7 +63,8 @@ namespace Auth0.ManagementApi.IntegrationTests
                     SessionCookie = new SessionCookie { Mode = "persistent" },
                     AllowedLogoutUrls = new string[] { "https://app.com/logout", "http://localhost/logout" },
                     SessionLifetime = 1080,
-                    IdleSessionLifetime = 720
+                    IdleSessionLifetime = 720,
+                    CustomizeMfaInPostLoginAction = true
                 };
 
                 var settingsUpdateResponse = await apiClient.TenantSettings.UpdateAsync(settingsUpdateRequest);
@@ -79,6 +80,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 settingsUpdateResponse.Flags.EnableAPIsSection.Should().BeTrue();
                 settingsUpdateResponse.Flags.EnableClientConnections.Should().BeFalse();
                 settingsUpdateResponse.Flags.EnablePipeline2.Should().BeTrue();
+                settingsUpdateResponse.CustomizeMfaInPostLoginAction.Should().BeTrue();
                 settingsUpdateResponse.SessionCookie.Mode.Should().Be("persistent");
 
                 var resetUpdateRequest = new TenantSettingsUpdateRequest


### PR DESCRIPTION
### Changes

Adds the new `customize_mfa_in_postlogin_action` tenant setting.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
