### PR TITLE
Add Organizations in Client Credentials

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -1,14 +1,10 @@
 ﻿using Auth0.AuthenticationApi.Models;
 using Auth0.AuthenticationApi.Tokens;
 using Auth0.Core.Http;
-using Microsoft.IdentityModel.Tokens;
 using System;
 using System.Collections.Generic;
 using System.Dynamic;
-using System.IdentityModel.Tokens.Jwt;
 using System.Net.Http;
-using System.Security.Claims;
-using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -188,6 +184,8 @@ namespace Auth0.AuthenticationApi
                 { "grant_type", "client_credentials" },
                 { "client_id", request.ClientId },
                 { "audience", request.Audience } };
+
+            body.AddIfNotEmpty("organization", request.Organization);
 
             ApplyClientAuthentication(request, body);
 

--- a/src/Auth0.AuthenticationApi/Models/ClientCredentialsTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ClientCredentialsTokenRequest.cs
@@ -37,5 +37,13 @@ namespace Auth0.AuthenticationApi.Models
         /// of Id Tokens.
         /// </summary>
         public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+        
+        /// <summary>
+        /// Organization.
+        /// </summary>
+        /// <remarks>
+        /// This can be an Organization Name or ID. When included, the access token returned will include the org_id and org_name claims
+        /// </remarks>
+        public string Organization { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientGrantsClient.cs
@@ -15,6 +15,7 @@ namespace Auth0.ManagementApi.Clients
     public class ClientGrantsClient : BaseClient, IClientGrantsClient
     {
         readonly JsonConverter[] converters = new JsonConverter[] { new PagedListConverter<ClientGrant>("client_grants") };
+        readonly JsonConverter[] organizationsConverters = new JsonConverter[] { new PagedListConverter<Organization>("organizations") };
 
         /// <summary>
         /// Initializes a new instance of <see cref="ClientGrantsClient"/>.
@@ -66,6 +67,8 @@ namespace Auth0.ManagementApi.Clients
                 {"audience", request.Audience},
                 {"client_id", request.ClientId},
             };
+            
+            queryStrings.AddIfNotEmpty("allow_any_organization", request.AllowAnyOrganization?.ToString() ?? string.Empty);
 
             if (pagination != null)
             {
@@ -87,6 +90,65 @@ namespace Auth0.ManagementApi.Clients
         public Task<ClientGrant> UpdateAsync(string id, ClientGrantUpdateRequest request, CancellationToken cancellationToken = default)
         {
             return Connection.SendAsync<ClientGrant>(new HttpMethod("PATCH"), BuildUri($"client-grants/{EncodePath(id)}"), request, DefaultHeaders, cancellationToken: cancellationToken);
+        }
+        
+        /// <summary>
+        /// Get the organizations associated to a client grant
+        /// </summary>
+        /// <param name="id">The identifier of the client grant.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="IPagedList{Organization}"/> containing the organizations requested.</returns>
+        public Task<IPagedList<Organization>> GetAllOrganizationsAsync(string id, CancellationToken cancellationToken = default)
+        {
+            var queryStrings = new Dictionary<string, string>();
+            return Connection.GetAsync<IPagedList<Organization>>(BuildUri($"client-grants/{EncodePath(id)}/organizations", queryStrings), DefaultHeaders, organizationsConverters, cancellationToken);
+            
+        }
+        /// <summary>
+        /// Get the organizations associated to a client grant
+        /// </summary>
+        /// <param name="id">The identifier of the client grant.</param>
+        /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="IPagedList{Organization}"/> containing the organizations requested.</returns>
+        public Task<IPagedList<Organization>> GetAllOrganizationsAsync(string id, PaginationInfo pagination, CancellationToken cancellationToken = default)
+        {
+            if (pagination == null)
+            {
+                throw new ArgumentNullException(nameof(pagination));
+            }
+
+            var queryStrings = new Dictionary<string, string>
+            {
+                ["page"] = pagination.PageNo.ToString(),
+                ["per_page"] = pagination.PerPage.ToString(),
+                ["include_totals"] = pagination.IncludeTotals.ToString().ToLower()
+            };
+            
+            return Connection.GetAsync<IPagedList<Organization>>(BuildUri($"client-grants/{EncodePath(id)}/organizations", queryStrings), DefaultHeaders, organizationsConverters, cancellationToken);
+        }
+        
+        /// <summary>
+        /// Get the organizations associated to a client grant
+        /// </summary>
+        /// <param name="id">The identifier of the client grant.</param>
+        /// <param name="pagination">Specifies <see cref="CheckpointPaginationInfo"/> to use in requesting checkpoint-paginated results.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns>A <see cref="IPagedList{Organization}"/> containing the organizations requested.</returns>
+        public Task<IPagedList<Organization>> GetAllOrganizationsAsync(string id, CheckpointPaginationInfo pagination = null, CancellationToken cancellationToken = default)
+        {
+            if (pagination == null)
+            {
+                throw new ArgumentNullException(nameof(pagination));
+            }
+
+            var queryStrings = new Dictionary<string, string>
+            {
+                ["from"] = pagination.From?.ToString(),
+                ["take"] = pagination.Take.ToString()
+            };
+            
+            return Connection.GetAsync<IPagedList<Organization>>(BuildUri($"client-grants/{EncodePath(id)}/organizations", queryStrings), DefaultHeaders, organizationsConverters, cancellationToken);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/IClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IClientGrantsClient.cs
@@ -40,5 +40,33 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>The <see cref="ClientGrant"/> that has been updated.</returns>
     Task<ClientGrant> UpdateAsync(string id, ClientGrantUpdateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get the organizations associated to a client grant
+    /// </summary>
+    /// <param name="id">The identifier of the client grant.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="IPagedList{Organization}"/> containing the organizations requested.</returns>
+    Task<IPagedList<Organization>> GetAllOrganizationsAsync(string id, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Get the organizations associated to a client grant
+    /// </summary>
+    /// <param name="id">The identifier of the client grant.</param>
+    /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="IPagedList{Organization}"/> containing the organizations requested.</returns>
+    Task<IPagedList<Organization>> GetAllOrganizationsAsync(string id, PaginationInfo pagination,
+      CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get the organizations associated to a client grant
+    /// </summary>
+    /// <param name="id">The identifier of the client grant.</param>
+    /// <param name="pagination">Specifies <see cref="CheckpointPaginationInfo"/> to use in requesting checkpoint-paginated results.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="IPagedList{Organization}"/> containing the organizations requested.</returns>
+    Task<IPagedList<Organization>> GetAllOrganizationsAsync(string id, CheckpointPaginationInfo pagination,
+      CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Clients/IOrganizationsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IOrganizationsClient.cs
@@ -233,5 +233,37 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
     Task DeleteInvitationAsync(string organizationId, string invitationId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get client grants associated with an organization.
+    /// </summary>
+    /// <param name="organizationId">The id of the organization for which you want to retrieve the client grants.</param>
+    /// <param name="request">Specifies criteria to use when querying client grants for the organization.</param>
+    /// <param name="pagination">Specifies <see cref="PaginationInfo"/> to use in requesting paged results.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="IPagedList{ClientGrant}"/> containing the client grants requested.</returns>
+    Task<IPagedList<OrganizationClientGrant>> GetAllClientGrantsAsync(string organizationId,
+      OrganizationGetClientGrantsRequest request, PaginationInfo pagination = null,
+      CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Associate a client grant with an organization
+    /// </summary>
+    /// <param name="organizationId">The id of the organization to which you want to associate the client grant.</param>
+    /// <param name="request">The <see cref="OrganizationCreateClientGrantRequest"/> containing the properties of the Client Grant to associate with the organization.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>The new <see cref="ClientGrant"/> that has been created.</returns>
+    Task<OrganizationClientGrant> CreateClientGrantAsync(string organizationId,
+      OrganizationCreateClientGrantRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Remove a client grant from an organization.
+    /// </summary>
+    /// <param name="organizationId">The id of the organization for which you want to delete the client grant.</param>
+    /// <param name="clientGrantId">The id of the client grant you want to delete from the organization</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
+    Task DeleteClientGrantAsync(string organizationId, string clientGrantId,
+      CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Models/ClientGrantBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientGrantBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Auth0.ManagementApi.Models
 {
@@ -25,5 +26,21 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("scope")]
         public List<string> Scope { get; set; }
+        
+        /// <summary>
+        /// Defines whether organizations can be used with client credentials exchanges for this grant. (defaults to deny when not defined)
+        /// </summary>
+        /// <remarks>
+        /// Possible values: [deny, allow, require]
+        /// </remarks>
+        [JsonProperty("organization_usage")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public OrganizationUsage? OrganizationUsage { get; set; }
+        
+        /// <summary>
+        /// If enabled, any organization can be used with this grant. If disabled (default), the grant must be explicitly assigned to the desired organizations.
+        /// </summary>
+        [JsonProperty("allow_any_organization")]
+        public bool? AllowAnyOrganization { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/ClientGrantUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/ClientGrantUpdateRequest.cs
@@ -14,5 +14,19 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("scope")]
         public List<string> Scope { get; set; }
 
+        /// <summary>
+        /// Defines whether organizations can be used with client credentials exchanges for this grant. (defaults to deny when not defined)
+        /// </summary>
+        /// <remarks>
+        /// Possible values: [deny, allow, require]
+        /// </remarks>
+        [JsonProperty("organization_usage")]
+        public string OrganizationUsage { get; set; }
+        
+        /// <summary>
+        /// If enabled, any organization can be used with this grant. If disabled (default), the grant must be explicitly assigned to the desired organizations.
+        /// </summary>
+        [JsonProperty("allow_any_organization")]
+        public bool? AllowAnyOrganization { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/ClientGrantUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/ClientGrantUpdateRequest.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Auth0.ManagementApi.Models
 {
@@ -21,7 +22,8 @@ namespace Auth0.ManagementApi.Models
         /// Possible values: [deny, allow, require]
         /// </remarks>
         [JsonProperty("organization_usage")]
-        public string OrganizationUsage { get; set; }
+        [JsonConverter(typeof(StringEnumConverter))]
+        public OrganizationUsage? OrganizationUsage { get; set; }
         
         /// <summary>
         /// If enabled, any organization can be used with this grant. If disabled (default), the grant must be explicitly assigned to the desired organizations.

--- a/src/Auth0.ManagementApi/Models/GetClientGrantsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetClientGrantsRequest.cs
@@ -13,6 +13,11 @@
         /// <summary>
         ///  The Id of a client to filter by. 
         /// </summary>
-        public string ClientId { get; set; }    
+        public string ClientId { get; set; }   
+        
+        /// <summary>
+        /// If enabled, any organization can be used with this grant. If disabled (default), the grant must be explicitly assigned to the desired organizations. 
+        /// </summary>
+        public bool? AllowAnyOrganization { get; set; }  
     }
 }

--- a/src/Auth0.ManagementApi/Models/OrganizationClientGrant.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationClientGrant.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class OrganizationClientGrant
+    {
+        /// <summary>
+        /// Gets or sets the identifier for a Client Grant.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the audience
+        /// </summary>
+        [JsonProperty("audience")]
+        public string Audience { get; set; }
+
+        /// <summary>
+        /// Gets or sets the identifier of the <see cref="Client"/>
+        /// </summary>
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of scopes
+        /// </summary>
+        [JsonProperty("scope")]
+        public List<string> Scope { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/OrganizationCreateClientGrantRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationCreateClientGrantRequest.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class OrganizationCreateClientGrantRequest
+    {
+        /// <summary>
+        /// A Client Grant ID to add to the organization. 
+        /// </summary>
+        [JsonProperty("grant_id")]
+        public string GrantId { get; set; } 
+    }
+}

--- a/src/Auth0.ManagementApi/Models/OrganizationGetClientGrantsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationGetClientGrantsRequest.cs
@@ -1,0 +1,15 @@
+namespace Auth0.ManagementApi.Models
+{
+    public class OrganizationGetClientGrantsRequest
+    {
+        /// <summary>
+        ///  URL Encoded audience of a client grant to filter.
+        /// </summary>
+        public string Audience { get; set; }
+
+        /// <summary>
+        ///  The Id of a client to filter by. 
+        /// </summary>
+        public string ClientId { get; set; }  
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
@@ -3,6 +3,8 @@ using Auth0.Tests.Shared;
 using FluentAssertions;
 using Microsoft.IdentityModel.Tokens;
 using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Linq;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Xunit;
@@ -26,6 +28,33 @@ namespace Auth0.AuthenticationApi.IntegrationTests
 
                 // Ensure that we received an access token back
                 token.Should().NotBeNull();
+            }
+        }
+        
+        [Fact]
+        public async Task Can_get_token_using_client_credentials_for_organization()
+        {
+            var existingOrgId = "org_V6ojENVd1ERs5YY1";
+            using (var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL")))
+            {
+                // Get the access token
+                var token = await authenticationApiClient.GetTokenAsync(new ClientCredentialsTokenRequest
+                {
+                    ClientId = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID"),
+                    ClientSecret = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_SECRET"),
+                    Audience = GetVariable("AUTH0_MANAGEMENT_API_AUDIENCE"),
+                    Organization = existingOrgId
+                });
+
+                // Ensure that we received an access token back
+                token.Should().NotBeNull();
+                  
+                var handler = new JwtSecurityTokenHandler();
+                var jwtSecurityToken = handler.ReadJwtToken(token.AccessToken);
+                var orgIdClaim = jwtSecurityToken.Claims.First(claim => claim.Type == "org_id").Value;
+                
+                orgIdClaim.Should().NotBeNull();
+                orgIdClaim.Should().Be(existingOrgId);
             }
         }
 

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TokenTests.cs
@@ -40,9 +40,9 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 // Get the access token
                 var token = await authenticationApiClient.GetTokenAsync(new ClientCredentialsTokenRequest
                 {
-                    ClientId = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID"),
-                    ClientSecret = GetVariable("AUTH0_MANAGEMENT_API_CLIENT_SECRET"),
-                    Audience = GetVariable("AUTH0_MANAGEMENT_API_AUDIENCE"),
+                    ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                    ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                    Audience = "dotnet-testing",
                     Organization = existingOrgId
                 });
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
@@ -221,8 +221,8 @@ namespace Auth0.ManagementApi.IntegrationTests
                 });
             
             
-            orgsBefore.Count.Should().Be(1);
-            orgGrantsBefore.Count.Should().Be(1);
+            orgsAfter.Count.Should().Be(1);
+            orgGrantsAfter.Count.Should().Be(1);
 
             await fixture.ApiClient.ClientGrants.DeleteAsync(newGrant.Id);
             fixture.UnTrackIdentifier(CleanUpType.ClientGrants, newGrant.Id);


### PR DESCRIPTION
### Changes

- Adds organization parameter to GetTokenAsync when using ClientCredentials.
- Adds endpoints to get Client Grants for Organizations
- Adds endpoints to get Organizations for ClientGrants

CI won't succeed until the neccesary feature flag is enabled on the testing tenant.

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
