### PR TITLE
Bump dependencies to fix vulnerabilities in tests

### DIFF
--- a/playground/Auth0.NET6/Auth0.NET6.csproj
+++ b/playground/Auth0.NET6/Auth0.NET6.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/Auth0.NETCore3/Auth0.NETCore3.csproj
+++ b/playground/Auth0.NETCore3/Auth0.NETCore3.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Auth0.AuthenticationApi" Version="7.5.1" />
-    <PackageReference Include="Auth0.ManagementApi" Version="7.5.1" />
+    <PackageReference Include="Auth0.AuthenticationApi" Version="7.23.1" />
+    <PackageReference Include="Auth0.ManagementApi" Version="7.23.1" />
   </ItemGroup>
 
 

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -12,7 +12,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
+++ b/tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj
@@ -8,7 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
@@ -21,7 +21,9 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Moq" Version="4.14.7" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
### Changes

Adds explicit depenencies for known vulnerable dependencies to ensure we use versions that are fixed.

### References

```
✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60045] in System.Net.Http@4.3.0
    introduced by Moq@4.14.7 > Castle.Core@4.4.0 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0 and 4 other path(s)
  This issue was fixed in versions: 4.1.2, 4.3.2
  ✗ Improper Certificate Validation [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60046] in System.Net.Http@4.3.0
    introduced by Moq@4.14.7 > Castle.Core@4.4.0 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0 and 4 other path(s)
  This issue was fixed in versions: 4.1.2, 4.3.2
  ✗ Privilege Escalation [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60047] in System.Net.Http@4.3.0
    introduced by Moq@4.14.7 > Castle.Core@4.4.0 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0 and 4 other path(s)
  This issue was fixed in versions: 4.1.2, 4.3.2
  ✗ Authentication Bypass [Medium Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-60048] in System.Net.Http@4.3.0
    introduced by Moq@4.14.7 > Castle.Core@4.4.0 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0 and 4 other path(s)
  This issue was fixed in versions: 4.1.2, 4.3.2
  ✗ Information Exposure [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMNETHTTP-72439] in System.Net.Http@4.3.0
    introduced by Moq@4.14.7 > Castle.Core@4.4.0 > NETStandard.Library@1.6.1 > System.Net.Http@4.3.0 and 4 other path(s)
  This issue was fixed in versions: 2.0.20710, 4.0.1-beta-23225, 4.1.4, 4.3.4
  ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-174708] in System.Text.RegularExpressions@4.3.0
    introduced by Moq@4.14.7 > Castle.Core@4.4.0 > NETStandard.Library@1.6.1 > System.Text.RegularExpressions@4.3.0 and 15 other path(s)
  This issue was fixed in versions: 4.3.1
```

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
