### PR TITLE
Add support for Pushed Authorization Request

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -469,13 +469,13 @@ namespace Auth0.AuthenticationApi
                 throw new ArgumentNullException(nameof(request));
 
             var body = new Dictionary<string, string> {
-                { "client_id", request.ClientId }
+                { "client_id", request.ClientId },
+                { "response_type", request.ResponseType.ToStringValue() },
+                { "redirect_uri", request.RedirectUri }
             };
             
-            body.AddIfNotEmpty("redirect_uri", request.RedirectUri);
             body.AddIfNotEmpty("state", request.State);
             body.AddIfNotEmpty("nonce", request.Nonce);
-            body.AddIfNotEmpty("response_type", request.ResponseType?.ToStringValue());
             body.AddIfNotEmpty("response_mode", request.ResponseMode?.ToStringValue());
             body.AddIfNotEmpty("organization", request.Organization);
             body.AddIfNotEmpty("invitation", request.Invitation);

--- a/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
@@ -13,13 +13,6 @@ namespace Auth0.AuthenticationApi.Builders
     /// </remarks>
     public class AuthorizationUrlBuilder : UrlBuilderBase<AuthorizationUrlBuilder>
     {
-        private static readonly Dictionary<AuthorizationResponseType, string> Map = new Dictionary<AuthorizationResponseType, string>
-        {
-            { AuthorizationResponseType.Code, "code" },
-            { AuthorizationResponseType.IdToken, "id_token" },
-            { AuthorizationResponseType.Token, "token" }
-        };
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthorizationUrlBuilder"/> class.
         /// </summary>
@@ -87,9 +80,16 @@ namespace Auth0.AuthenticationApi.Builders
         {
             return WithValue("response_type",
                 string.Join(" ", responseType
-                    .Select(r => Map.TryGetValue(r, out var value)
-                        ? value
-                        : throw new ArgumentException("Unknown AuthorizationResponseType.", nameof(responseType)))));
+                    .Select(r =>
+                    {
+                        var value = r.ToStringValue();
+                        if (value == null)
+                        {
+                            throw new ArgumentException("Unknown AuthorizationResponseType.", nameof(responseType));
+                        }
+
+                        return value;
+                    })));
         }
 
         /// <summary>

--- a/src/Auth0.AuthenticationApi/ExtensionMethods.cs
+++ b/src/Auth0.AuthenticationApi/ExtensionMethods.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Auth0.AuthenticationApi.Models;
 
 namespace Auth0.AuthenticationApi
 {
@@ -18,6 +19,61 @@ namespace Auth0.AuthenticationApi
         {
             if (!string.IsNullOrEmpty(value))
                 dictionary.Add(key, value);
+        }
+        
+        /// <summary>
+        /// Adds all items from the source to the target dictionary.
+        /// </summary>
+        /// <param name="targetDictionary">Dictionary to add the items to.</param>
+        /// <param name="sourceDictionary">Dictionary whose items you want to add to the target.</param>
+        public static void AddAll(this IDictionary<string, string> targetDictionary, IDictionary<string, string> sourceDictionary)
+        {
+            foreach (var keyValuePair in sourceDictionary)
+            {
+                if (targetDictionary.ContainsKey(keyValuePair.Key))
+                {
+                    targetDictionary[keyValuePair.Key] = keyValuePair.Value;
+                }
+                else
+                {
+                    targetDictionary.Add(keyValuePair);
+                }
+            }
+        }
+        
+        /// <summary>
+        /// Get the string value for the corresponding <see cref="AuthorizationResponseMode"/>.
+        /// </summary>
+        /// <param name="responseMode">The <see cref="AuthorizationResponseMode"/>. for which you want to get the string value.</param>
+        /// <returns>The corresponding string value.</returns>
+        public static string ToStringValue(this AuthorizationResponseMode responseMode)
+        {
+            if (responseMode == AuthorizationResponseMode.FormPost)
+            {
+                return "form_post";
+            }
+
+            return null;
+        }
+        
+        /// <summary>
+        /// Get the string value for the corresponding <see cref="AuthorizationResponseType"/>.
+        /// </summary>
+        /// <param name="responseType">The <see cref="AuthorizationResponseType"/> for which you want to get the string value.</param>
+        /// <returns>The corresponding string value.</returns>
+        public static string ToStringValue(this AuthorizationResponseType responseType)
+        {
+            switch (responseType)
+            {
+                case AuthorizationResponseType.Code:
+                    return "code";
+                case AuthorizationResponseType.IdToken:
+                    return "id_token";
+                case AuthorizationResponseType.Token:
+                    return "token";
+                default:
+                    return null;
+            }
         }
     }
 }

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -170,5 +170,15 @@ namespace Auth0.AuthenticationApi
         /// <returns><see cref="Task"/> representing the async operation containing 
         /// a <see cref="DeviceCodeResponse" /> with the details of the request.</returns>
         Task<DeviceCodeResponse> StartDeviceFlowAsync(DeviceCodeRequest request, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Starts a new Pushed Authorization Request flow.
+        /// </summary>
+        /// <param name="request"><see cref="PushedAuthorizationRequest"/> containing information to start the Pushed Authorization Request.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns><see cref="Task"/> representing the async operation containing 
+        /// a <see cref="PushedAuthorizationRequestResponse" /> with the details of the response.</returns>
+        Task<PushedAuthorizationRequestResponse> PushedAuthorizationRequestAsync(PushedAuthorizationRequest request,
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
@@ -26,7 +26,7 @@ namespace Auth0.AuthenticationApi.Models
         /// <summary>
         /// <see cref="AuthorizationResponseType"/> the client expects.
         /// </summary>
-        public AuthorizationResponseType? ResponseType { get; set; }
+        public AuthorizationResponseType ResponseType { get; set; }
         
         /// <summary>
         /// Response mode to use.

--- a/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    public class PushedAuthorizationRequest : IClientAuthentication
+    {
+        /// <summary>
+        /// Client ID of the application.
+        /// </summary>
+        public string ClientId { get; set; }
+        
+        /// <summary>
+        /// URI to redirect to.
+        /// </summary>
+        public string RedirectUri { get; set; }
+        
+        /// <summary>
+        /// Client secret of the application.
+        /// </summary>
+        /// <remarks>
+        /// Optional except when using <see cref="AuthorizationCodeRequestBase"/>.
+        /// </remarks>
+        public string ClientSecret { get; set; }
+        
+        /// <summary>
+        /// <see cref="AuthorizationResponseType"/> the client expects.
+        /// </summary>
+        public AuthorizationResponseType? ResponseType { get; set; }
+        
+        /// <summary>
+        /// Response mode to use.
+        /// </summary>
+        public AuthorizationResponseMode? ResponseMode { get; set; }
+        
+        /// <summary>
+        /// The nonce.
+        /// </summary>
+        public string Nonce { get; set; }
+
+        /// <summary>
+        /// Security Key to use with Client Assertion
+        /// </summary>
+        public SecurityKey ClientAssertionSecurityKey { get; set; }
+
+        /// <summary>
+        /// Algorithm for the Security Key to use with Client Assertion
+        /// </summary>
+        public string ClientAssertionSecurityKeyAlgorithm { get; set; }
+        
+        /// <summary>
+        /// State value to be passed back on successful authorization.
+        /// </summary>
+        public string State { get; set; }
+        
+        /// <summary>
+        /// Name of the connection.
+        /// </summary>
+        public string Connection { get; set; }
+        
+        /// <summary>
+        /// Scopes to request.
+        /// </summary>
+        /// <remarks>
+        /// Multiple scopes must be separated by a space character.
+        /// </remarks>
+        public string Scope { get; set; }
+        
+        /// <summary>
+        /// Audience to request API access for.
+        /// </summary>
+        public string Audience { get; set; }
+        
+        /// <summary>
+        /// The organization to log the user in to.
+        /// </summary>
+        public string Organization { get; set; }
+        
+        /// <summary>
+        /// The Id of an invitation to accept. 
+        /// </summary>
+        /// <remarks>
+        /// This is available from the URL that is given when participating in a user invitation flow.
+        /// </remarks>
+        public string Invitation { get; set; }
+
+        /// <summary>
+        /// Any additional properties to use.
+        /// </summary>
+        public IDictionary<string, string> AdditionalProperties { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequestResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequestResponse.cs
@@ -1,0 +1,27 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models
+{
+    /// <summary>
+    /// Represents a Pushed Authorization Request response.
+    /// </summary>
+    public class PushedAuthorizationRequestResponse
+    {
+        /// <summary>
+        /// The request URI corresponding to the authorization request posted.
+        /// </summary>
+        /// <remarks>
+        /// This URI is a single-use reference to the respective request data in the subsequent authorization request.
+        /// </remarks>
+        [JsonProperty("request_uri")]
+        public Uri RequestUri { get; set; }
+
+        /// <summary>
+        /// A number that represents the lifetime of the request URI in seconds as a positive integer.
+        /// </summary>
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+
+    }
+}

--- a/src/Auth0.ManagementApi/Models/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientBase.cs
@@ -190,6 +190,12 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("cross_origin_authentication")]
         public bool? CrossOriginAuthentication { get; set; }
+        
+        /// <summary>
+        /// Makes the use of Pushed Authorization Requests mandatory for this client.
+        /// </summary>
+        [JsonProperty("require_pushed_authorization_requests")]
+        public bool? RequirePushedAuthorizationRequests { get; set; }
     }
 
 }

--- a/src/Auth0.ManagementApi/Models/TenantFlags.cs
+++ b/src/Auth0.ManagementApi/Models/TenantFlags.cs
@@ -126,5 +126,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("revoke_refresh_token_grant")]
         public bool? RevokeRefreshTokenGrant { get; set; } = null;
+        
+        /// <summary>
+        /// Makes the use of Pushed Authorization Requests mandatory for all clients across the tenant.
+        /// </summary>
+        [JsonProperty("require_pushed_authorization_requests")]
+        public bool? RequirePushedAuthorizationRequests { get; set; } = null;
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/PushedAuthorizationRequestTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/PushedAuthorizationRequestTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Auth0.AuthenticationApi.Models;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests;
+
+public class PushedAuthorizationRequestTests
+{
+    [Fact]
+    public async void Should_Call_OAuth_Par_With_Client_Secret()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_secret", TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET") }
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+    
+    [Fact]
+    public async void Should_Call_OAuth_Par_With_Client_Assertion()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" },
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+        
+        var provider = new RSACryptoServiceProvider(2048);
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientAssertionSecurityKey = new RsaSecurityKey(provider),
+            ClientAssertionSecurityKeyAlgorithm = SecurityAlgorithms.RsaSha256
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+    
+    [Fact]
+    public async void Should_Throw_When_No_Secret_Set()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => authenticationApiClient.PushedAuthorizationRequestAsync(
+            new PushedAuthorizationRequest()
+            {
+                ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            }));
+
+        exception.Message.Should().Be("Both Client Secret and Client Assertion can not be null.");
+    }
+
+    [Fact]
+    public async void Should_Throw_When_Both_Secrets_Set()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+        
+        var provider = new RSACryptoServiceProvider();
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => authenticationApiClient.PushedAuthorizationRequestAsync(
+            new PushedAuthorizationRequest()
+            {
+                ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+                ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+                ClientAssertionSecurityKey = new RsaSecurityKey(provider),
+                ClientAssertionSecurityKeyAlgorithm = SecurityAlgorithms.RsaSha256
+            }));
+
+        exception.Message.Should().Be("Both Client Secret and Client Assertion can not be set at the same time.");
+
+    }
+  
+    [Fact]
+    public async void Should_Call_OAuth_Par_With_Arguments()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_secret", TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET") },
+            { "connection", "TEST_CONNECTION" },
+            { "audience", "TEST_AUDIENCE" },
+            { "state", "TEST_STATE" },
+            { "nonce", "TEST_NONCE" },
+            { "organization", "TEST_ORGANIZATION" },
+            { "invitation", "TEST_INVITATION" },
+            { "scope", "TEST_SCOPE" },
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+            Connection = "TEST_CONNECTION",
+            Audience = "TEST_AUDIENCE",
+            State = "TEST_STATE",
+            Nonce = "TEST_NONCE",
+            Organization = "TEST_ORGANIZATION",
+            Invitation = "TEST_INVITATION",
+            Scope = "TEST_SCOPE"
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+
+    [Fact]
+    public async void Should_Call_OAuth_Par_With_AdditionalProperties()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_secret", TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET") },
+            { "foo", "bar" },
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+            AdditionalProperties = new Dictionary<string, string>
+            {
+                { "foo", "bar" }
+            }
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+
+    
+    private bool ValidateRequestContent(HttpRequestMessage content, Dictionary<string, string> contentParams)
+    {
+        string jsonContent = content.Content.ReadAsStringAsync().Result;
+        var result = jsonContent.Split("&").ToDictionary(keyValue => keyValue.Split("=")[0], keyValue => HttpUtility.UrlDecode(keyValue.Split("=")[1]));
+
+        return contentParams.Aggregate(true, (acc, keyValue) => acc && result.GetValueOrDefault(keyValue.Key) == keyValue.Value);
+    }
+}


### PR DESCRIPTION
### Changes

Adds support for doing a Pushed Authorization Request in the AuthenticationApiClient, while also adding support for the necessary ManagementApiClient changes.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
