### PR TITLE
Added support for CheckpointPagingInformation on Connections.GetAllAsync

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -114,13 +114,16 @@ namespace Auth0.ManagementApi.Clients
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
+            
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
 
             var queryStrings = new Dictionary<string, string>();
             queryStrings["page"] = pagination.PageNo.ToString();
             queryStrings["per_page"] = pagination.PerPage.ToString();
             queryStrings["include_totals"] = pagination.IncludeTotals.ToString().ToLower();
 
-            return GetAllAsync(request, new Dictionary<string, string>(), cancellationToken);
+            return GetAllAsync(request, queryStrings, cancellationToken);
         }
 
         /// <summary>
@@ -134,6 +137,9 @@ namespace Auth0.ManagementApi.Clients
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));
+            
+            if (pagination == null)
+                throw new ArgumentNullException(nameof(pagination));
 
             var queryStrings = new Dictionary<string, string>();
             queryStrings["take"] = pagination.Take.ToString();
@@ -142,7 +148,7 @@ namespace Auth0.ManagementApi.Clients
                 queryStrings["from"] = pagination.From.ToString();
             }
 
-            return GetAllAsync(request, new Dictionary<string, string>(), cancellationToken);
+            return GetAllAsync(request, queryStrings, cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -92,7 +92,7 @@ namespace Auth0.ManagementApi.Clients
         /// <param name="request">Specifies criteria to use when querying connections.</param>
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>An <see cref="IPagedList{Connection}"/> containing the list of connections.</returns>
-        private Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, CancellationToken cancellationToken = default)
+        public Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, CancellationToken cancellationToken = default)
         {
             if (request == null)
                 throw new ArgumentNullException(nameof(request));

--- a/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
@@ -52,7 +52,7 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>An <see cref="IPagedList{Connection}"/> containing the list of connections.</returns>
-    Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default);
+    Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, BasePaginationInfo pagination = null, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Updates a connection.

--- a/src/Auth0.ManagementApi/Paging/BasePaginationInfo.cs
+++ b/src/Auth0.ManagementApi/Paging/BasePaginationInfo.cs
@@ -1,0 +1,9 @@
+﻿namespace Auth0.ManagementApi.Paging
+{
+    /// <summary>
+    /// This base class is needed to support both offset and checkpoint pagination with default constructors
+    /// </summary>
+    public abstract class BasePaginationInfo
+    {
+    }
+}

--- a/src/Auth0.ManagementApi/Paging/CheckpointPaginationInfo.cs
+++ b/src/Auth0.ManagementApi/Paging/CheckpointPaginationInfo.cs
@@ -3,7 +3,7 @@ namespace Auth0.ManagementApi.Paging
     /// <summary>
     /// Specifies checkpoint pagination info to use when requesting paged results.
     /// </summary>
-    public class CheckpointPaginationInfo
+    public class CheckpointPaginationInfo : BasePaginationInfo
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="CheckpointPaginationInfo"/> class.

--- a/src/Auth0.ManagementApi/Paging/PaginationInfo.cs
+++ b/src/Auth0.ManagementApi/Paging/PaginationInfo.cs
@@ -3,11 +3,14 @@
     /// <summary>
     /// Specifies pagination info to use when requesting paged results.
     /// </summary>
-    public class PaginationInfo
+    public class PaginationInfo : BasePaginationInfo
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PaginationInfo"/> class.
+        /// Initializes a new instance of the <see cref="PaginationInfo"/> class for offset pagination.
         /// </summary>
+        /// <remarks>
+        /// If you need to retrieve >1000 items use the overload for checkpoint pagination instead.
+        /// </remarks>
         /// <param name="pageNo">Page index of the results to return. First page is 0.</param>
         /// <param name="perPage">Number of results per page.</param>
         /// <param name="includeTotals">Whether to return the complete total result count (true) or not (false).</param>

--- a/src/Auth0.ManagementApi/Paging/PaginationInfo.cs
+++ b/src/Auth0.ManagementApi/Paging/PaginationInfo.cs
@@ -8,9 +8,6 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="PaginationInfo"/> class for offset pagination.
         /// </summary>
-        /// <remarks>
-        /// If you need to retrieve >1000 items use the overload for checkpoint pagination instead.
-        /// </remarks>
         /// <param name="pageNo">Page index of the results to return. First page is 0.</param>
         /// <param name="perPage">Number of results per page.</param>
         /// <param name="includeTotals">Whether to return the complete total result count (true) or not (false).</param>


### PR DESCRIPTION
Added support for CheckpointPagingInformation on Connections.GetAllAsync to support the management api feature according to the docs (https://auth0.com/docs/api/management/v2/connections/get-connections). Added a base function with overloads and extra documentation for clarification. These changes allow the retrieval of all connections on tenants with >1000 connections. To test just try to receive connections on a tenant with all three overloads.