### PR TITLE
Ensure external_id is defined as string instead of int

### DIFF
--- a/src/Auth0.ManagementApi/Models/Job.cs
+++ b/src/Auth0.ManagementApi/Models/Job.cs
@@ -91,6 +91,6 @@ namespace Auth0.ManagementApi.Models
         /// Customer-defined id.
         /// </summary>
         [JsonProperty("external_id")]
-        public int ExternalId { get; set; }
+        public string ExternalId { get; set; }
     }
 }


### PR DESCRIPTION
### Changes

external_id should be a string, not an int.

### References

https://auth0.com/docs/manage-users/user-migration/bulk-user-imports#request-bulk-user-import

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
