### PR TITLE
Add OIDC back channel logout

### DIFF
--- a/src/Auth0.ManagementApi/Models/BackchannelLogoutInitiators.cs
+++ b/src/Auth0.ManagementApi/Models/BackchannelLogoutInitiators.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
 
 namespace Auth0.ManagementApi.Models
 {
@@ -7,13 +8,14 @@ namespace Auth0.ManagementApi.Models
         /// <summary>
         /// The mode property determines the configuration method for enabling initiators.
         /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty("mode")]
         public LogoutInitiatorModes Mode { get; set; }
 
         /// <summary>
         /// The Selected Initiators are the logout initiators to be enabled for the client.
         /// </summary>
-        [JsonProperty("selected_initiators")]
+        [JsonProperty("selected_initiators", ItemConverterType = typeof(StringEnumConverter))]
         public LogoutInitiators[] SelectedInitiators { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/BackchannelLogoutInitiators.cs
+++ b/src/Auth0.ManagementApi/Models/BackchannelLogoutInitiators.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BackchannelLogoutInitiators
+    {
+        /// <summary>
+        /// The mode property determines the configuration method for enabling initiators.
+        /// </summary>
+        [JsonProperty("mode")]
+        public LogoutInitiatorModes Mode { get; set; }
+
+        /// <summary>
+        /// The Selected Initiators are the logout initiators to be enabled for the client.
+        /// </summary>
+        [JsonProperty("selected_initiators")]
+        public LogoutInitiators[] SelectedInitiators { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientBase.cs
@@ -150,6 +150,9 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("oidc_conformant")]
         public bool? OidcConformant { get; set; }
 
+        [JsonProperty("oidc_logout")]
+        public OidcLogoutConfig OidcLogout { get; set; }
+
         /// <summary>
         /// A list of resource servers (APIs) that the client is authorized to request access tokens for, using the Client Credentials exchange.
         /// </summary>

--- a/src/Auth0.ManagementApi/Models/ClientResourceServerAssociation.cs
+++ b/src/Auth0.ManagementApi/Models/ClientResourceServerAssociation.cs
@@ -15,6 +15,5 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("scopes")]
         public string[] Scopes { get; set; }
-
     }
 }

--- a/src/Auth0.ManagementApi/Models/LogoutInitiatorModes.cs
+++ b/src/Auth0.ManagementApi/Models/LogoutInitiatorModes.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    public enum LogoutInitiatorModes
+    {
+        /// <summary>
+        /// All initiators are enabled.
+        /// </summary>
+        [EnumMember(Value = "all")]
+        All,
+
+        /// <summary>
+        /// Specific initiators are enabled.
+        /// </summary>
+        [EnumMember(Value = "custom")]
+        Custom
+    }
+}

--- a/src/Auth0.ManagementApi/Models/LogoutInitiators.cs
+++ b/src/Auth0.ManagementApi/Models/LogoutInitiators.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    public enum LogoutInitiators
+    {
+        /// <summary>
+        /// Request was initiated by a relying party (RP).
+        /// </summary>
+        [EnumMember(Value = "rp-logout")]
+        RpLogout,
+
+        /// <summary>
+        /// Request was initiated by an external identity provider (IdP).
+        /// </summary>
+        [EnumMember(Value = "idp-logout")]
+        IdpLogout,
+
+        /// <summary>
+        /// Request was initiated by a password change.
+        /// </summary>
+        [EnumMember(Value = "password-changed")]
+        PasswordChanged,
+
+        /// <summary>
+        /// Request was initiated when a session expires.
+        /// </summary>
+        [EnumMember(Value = "session-expired")]
+        SessionExpired
+    }
+}

--- a/src/Auth0.ManagementApi/Models/OidcLogoutConfig.cs
+++ b/src/Auth0.ManagementApi/Models/OidcLogoutConfig.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class OidcLogoutConfig
+    {
+        /// <summary>
+        /// The supported backchannel logout URLs for the client.
+        /// </summary>
+        [JsonProperty("backchannel_logout_urls")]
+        public string[] BackchannelLogoutUrls { get; set; }
+
+        /// <summary>
+        /// The OIDC Back-Channel Logout Initiators for the client.
+        /// </summary>
+        [JsonProperty("backchannel_logout_initiators")]
+        public BackchannelLogoutInitiators BackchannelLogoutInitiators { get; set; }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBase.cs
@@ -24,6 +24,7 @@ namespace Auth0.Tests.Shared
                 .AddJsonFile("client-secrets.json", true)
                 .AddEnvironmentVariables()
                 .Build();
+
         private readonly Regex _alphaNumeric = new Regex("[^a-zA-Z0-9]");
 
         protected string MakeRandomName()


### PR DESCRIPTION
### Changes

Support for setting Back-Channel Logout URI's and initiators on all clients.

### References

Implement support for Auth0 API endpoints here:

[Back-Channel Logout URI
](https://auth0.com/docs/authenticate/login/logout/back-channel-logout)

### Testing

I have tested the changes to the SDK and validated they generate valid JSON, i.e.

{"app_type":"native","token_endpoint_auth_method":"client_secret_post","client_metadata":{"Prop1":"1","Prop2":"2"},"is_first_party":true,"name":"int-test C9qIfV3RKUueJGflFsptA","oidc_logout":{"backchannel_logout_urls":["https://logout.com"],"backchannel_logout_initiators":{"mode":"custom","selected_initiators":["rp-logout","idp-logout"]}}}

And

{"app_type":"native","token_endpoint_auth_method":"client_secret_post","client_metadata":{"Prop1":"1","Prop2":"2"},"is_first_party":true,"name":"int-test GxRjxrHRhkqGpr1QZNGgBA","oidc_logout":{"backchannel_logout_urls":["https://logout.com"],"backchannel_logout_initiators":{"mode":"all"}}}

I have tested this JSON directly against the Auth0 management API.

I am unable to run the tests locally as the documentation is not clear, creating client-secrets.json does not result in values being read from that file. A clearer read me would be appreciated. 

### Checklist

- [X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X ] All existing and new tests complete without errors
