### PR TITLE
Target .NET Framework 4.6.2 instead of 4.5.2

### DIFF
--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Auth0.AuthenticationApi</AssemblyTitle>
     <AssemblyName>Auth0.AuthenticationApi</AssemblyName>
     <PackageId>Auth0.AuthenticationApi</PackageId>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\Auth0NetStrongName.snk</AssemblyOriginatorKeyFile>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
+++ b/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
@@ -126,8 +126,8 @@ namespace Auth0.AuthenticationApi
 
         private static string CreateAgentString()
         {
-#if NET452
-            var target = "NET452";
+#if NET462
+            var target = "NET462";
 #endif
 #if NETSTANDARD2_0
             var target = "NETSTANDARD2.0";

--- a/src/Auth0.Core/Auth0.Core.csproj
+++ b/src/Auth0.Core/Auth0.Core.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Auth0.Core</AssemblyTitle>
     <AssemblyName>Auth0.Core</AssemblyName>
     <PackageId>Auth0.Core</PackageId>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\Auth0NetStrongName.snk</AssemblyOriginatorKeyFile>
@@ -15,7 +15,7 @@
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>Auth0.ManagementApi</AssemblyTitle>
     <AssemblyName>Auth0.ManagementApi</AssemblyName>
     <PackageId>Auth0.ManagementApi</PackageId>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <NetStandardImplicitPackageVersion>2.0.3</NetStandardImplicitPackageVersion>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\Auth0NetStrongName.snk</AssemblyOriginatorKeyFile>
@@ -12,7 +12,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Auth0.Core\Auth0.Core.csproj" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)'=='net452'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net462'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -275,8 +275,8 @@ namespace Auth0.ManagementApi
 
         private static string CreateAgentString()
         {
-#if NET452
-            var target = "NET452";
+#if NET462
+            var target = "NET462";
 #endif
 #if NETSTANDARD2_0
             var target = "NETSTANDARD2.0";


### PR DESCRIPTION
### Changes

With the lowest .NET framework currently supported being 4.6.2, it makes sense to remove our 4.5.2 support and only ship .NET Standard 2.0, [which supports 4.6.1 and above](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0).

However, as mentioned [here](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting), I makes sense to keep an explicit target for .NET 4.6.2 to improve compatibility.

```
CONSIDER adding a target for net462 when you're offering a netstandard2.0 target.

Using .NET Standard 2.0 from .NET Framework has some issues that were addressed in .NET Framework 4.7.2. 
You can improve the experience for developers that are still on .NET Framework 4.6.2 - 4.7.1 by offering them a binary that's built for .NET Framework 4.6.2.
```

### References

https://learn.microsoft.com/en-us/lifecycle/products/microsoft-net-framework

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
