### PR TITLE
Ensure AsyncAgedCache is correctly updated

### DIFF
--- a/src/Auth0.AuthenticationApi/Tokens/AsyncAgedCache.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/AsyncAgedCache.cs
@@ -28,6 +28,9 @@ namespace Auth0.AuthenticationApi.Tokens
                 var cacheExpiresAt = entry.CachedAt.Add(maxAge);
                 if (now < cacheExpiresAt)
                     return entry.Task;
+                
+                // When a cache entry was found, but expired, we want to remove it.
+                cache.TryRemove(key, out _);
             }
 
             var task = valueFactory(key);

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/AsyncAgedCacheTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/AsyncAgedCacheTests.cs
@@ -32,6 +32,28 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
             await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(30));
             Assert.Equal(1, factoryCallCount);
         }
+        
+        [Fact]
+        public async Task CorrectlyUpdatesTheCache()
+        {
+            var factoryCallCount = 0;
+            Task<int> factory(string s) => Task.FromResult(factoryCallCount++);
+            var cache = new AsyncAgedCache<string, int>(factory);
+
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            Assert.Equal(1, factoryCallCount);
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            Assert.Equal(1, factoryCallCount);
+            
+            // Wait 10 sec
+            await Task.Delay(10000);
+            factoryCallCount = 0;
+            
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            Assert.Equal(1, factoryCallCount);
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            Assert.Equal(1, factoryCallCount);
+        }
 
         [Fact]
         public async Task DoesNotCallFactoryWithWrongKey()

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/AsyncAgedCacheTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/AsyncAgedCacheTests.cs
@@ -40,18 +40,18 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Tokens
             Task<int> factory(string s) => Task.FromResult(factoryCallCount++);
             var cache = new AsyncAgedCache<string, int>(factory);
 
-            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(1));
             Assert.Equal(1, factoryCallCount);
-            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(1));
             Assert.Equal(1, factoryCallCount);
             
-            // Wait 10 sec
-            await Task.Delay(10000);
+            // Wait 2 sec
+            await Task.Delay(2000);
             factoryCallCount = 0;
             
-            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(1));
             Assert.Equal(1, factoryCallCount);
-            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(5));
+            await cache.GetOrAddAsync("abc", TimeSpan.FromSeconds(1));
             Assert.Equal(1, factoryCallCount);
         }
 


### PR DESCRIPTION
### Changes

Once an entry in the AsyncAgedCache is expired, it is not correctly updating the cache. Any subsequent calls will bypass the cache.

This PR ensures expired cache entries are removed from the cache.

### References

Closes #692 

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
