### PR TITLE
Do not crash when User.Locale and UserInfo.Locale are an object

### DIFF
--- a/src/Auth0.AuthenticationApi/Models/UserInfo.cs
+++ b/src/Auth0.AuthenticationApi/Models/UserInfo.cs
@@ -2,6 +2,7 @@
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using Auth0.Core.Serialization;
 
 namespace Auth0.AuthenticationApi.Models
 {
@@ -158,6 +159,7 @@ namespace Auth0.AuthenticationApi.Models
         /// ISO 3166-1 Alpha-2 country code in uppercase, separated by a dash. 
         /// </remarks>
         [JsonProperty("locale")]
+        [JsonConverter(typeof(StringOrObjectAsStringConverter))]
         public string Locale { get; set; }
 
         /// <summary>

--- a/src/Auth0.Core/Serialization/StringOrObjectAsStringConverter.cs
+++ b/src/Auth0.Core/Serialization/StringOrObjectAsStringConverter.cs
@@ -1,0 +1,37 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Auth0.Core.Serialization
+{
+    internal class StringOrObjectAsStringConverter : JsonConverter
+    {
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            var instance = "";
+            
+            if (reader.TokenType == JsonToken.String)
+            {
+                instance =  reader.Value?.ToString();
+            } 
+            else if (reader.TokenType == JsonToken.StartObject)
+            {
+                instance = JObject.Load(reader).ToString();
+            }
+
+            return instance;
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/User.cs
+++ b/src/Auth0.ManagementApi/Models/User.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Auth0.Core.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -47,6 +48,7 @@ namespace Auth0.ManagementApi.Models
         /// Returned for the Facebook, Google, and Microsoft social providers.
         /// </remarks>
         [JsonProperty("locale")]
+        [JsonConverter(typeof(StringOrObjectAsStringConverter))]
         public string Locale { get; set; }
 
         /// <summary>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/UserInfoDeserializationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/UserInfoDeserializationTests.cs
@@ -72,6 +72,25 @@ namespace Auth0.AuthenticationApi.IntegrationTests
         }
 
         [Fact]
+        public void Can_read_custom_locale_claim()
+        {
+            var jsonPayload = @"{
+   'sub': '123456',
+   'locale': {
+        'country': 'US',
+        'language': 'en'
+   },
+   'updated_at': 1233233333
+}";
+            var userInfo = GetUserInfoFromJsonPayload(jsonPayload);
+
+            userInfo.UserId.Should().Be("123456");
+            userInfo.Locale.Should().NotBeNull();
+            JObject.Parse(userInfo.Locale).GetValue("country")!.Value<string>().Should().Be("US");
+            JObject.Parse(userInfo.Locale).GetValue("language")!.Value<string>().Should().Be("en");
+        }
+        
+        [Fact]
         public void Missing_values_are_null()
         {
             var jsonPayload = @"{ 'sub': '123456'}";

--- a/tests/Auth0.Core.UnitTests/StringOrObjectAsStringConverterTests.cs
+++ b/tests/Auth0.Core.UnitTests/StringOrObjectAsStringConverterTests.cs
@@ -1,0 +1,44 @@
+using Auth0.Core.Serialization;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Auth0.Core.UnitTests;
+
+public class StringOrObjectAsStringConverterTests
+{
+    internal class StringOrObjectAsStringConverterData
+    {
+        [JsonProperty("value")]
+        [JsonConverter(typeof(StringOrObjectAsStringConverter))]
+        public string Value { get; set; }
+    }
+    [Fact]
+    public void Should_deserialize_string()
+    {
+        var content = "{ 'value': 'test' }";
+
+        var parsed = JsonConvert.DeserializeObject<StringOrObjectAsStringConverterData>(content);
+
+        Assert.Equal("test", parsed.Value);
+    }
+        
+    [Fact]
+    public void Should_deserialize_object_as_string()
+    {
+        var content = "{ 'value': { 'innerValue': 'test' } }";
+
+        var parsed = JsonConvert.DeserializeObject<StringOrObjectAsStringConverterData>(content);
+
+        Assert.Equal("{\n  \"innerValue\": \"test\"\n}", parsed.Value);
+    }
+    
+    [Fact]
+    public void Should_deserialize_when_omitted()
+    {
+        var content = "{}";
+
+        var parsed = JsonConvert.DeserializeObject<StringOrObjectAsStringConverterData>(content);
+
+        Assert.Null(parsed.Value);
+    }
+}


### PR DESCRIPTION
### Changes

Locale is undocumented, and can be a string or an object.
Currently, our SDK defines it as a string, failing deserialisation when an object is provided.

This PR ensures no exception is thrown and deserialization works, but the locale will be a stringified version of the object.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
