### PR TITLE
Add show_as_button to organizations connection

### DIFF
--- a/src/Auth0.ManagementApi/Models/OrganizationConnection.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnection.cs
@@ -17,6 +17,12 @@ namespace Auth0.ManagementApi.Models
         public bool AssignMembershipOnLogin { get; set; }
 
         /// <summary>
+        /// Determines whether a connection should be displayed on this organization’s login prompt.
+        /// </summary>
+        [JsonProperty("show_as_button")]
+        public bool ShowAsButton { get; set; }
+
+        /// <summary>
         /// Information on the enabled connection
         /// </summary>
         [JsonProperty("connection")]

--- a/src/Auth0.ManagementApi/Models/OrganizationConnectionCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnectionCreateRequest.cs
@@ -21,6 +21,6 @@ namespace Auth0.ManagementApi.Models
         /// Determines whether a connection should be displayed on this organization’s login prompt.
         /// </summary>
         [JsonProperty("show_as_button")]
-        public bool ShowAsButton { get; set; }
+        public bool? ShowAsButton { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/OrganizationConnectionCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnectionCreateRequest.cs
@@ -17,5 +17,10 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("assign_membership_on_login")]
         public bool AssignMembershipOnLogin { get; set; }
 
+        /// <summary>
+        /// Determines whether a connection should be displayed on this organization’s login prompt.
+        /// </summary>
+        [JsonProperty("show_as_button")]
+        public bool ShowAsButton { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/OrganizationConnectionUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnectionUpdateRequest.cs
@@ -14,6 +14,6 @@ namespace Auth0.ManagementApi.Models
         /// Determines whether a connection should be displayed on this organization’s login prompt.
         /// </summary>
         [JsonProperty("show_as_button")]
-        public bool ShowAsButton { get; set; }
+        public bool? ShowAsButton { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/OrganizationConnectionUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnectionUpdateRequest.cs
@@ -9,5 +9,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("assign_membership_on_login")]
         public bool AssignMembershipOnLogin { get; set; }
+
+        /// <summary>
+        /// Determines whether a connection should be displayed on this organization’s login prompt.
+        /// </summary>
+        [JsonProperty("show_as_button")]
+        public bool ShowAsButton { get; set; }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -164,12 +164,11 @@ namespace Auth0.ManagementApi.IntegrationTests
                 var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
                 {
                     AssignMembershipOnLogin = false,
-                    ShowAsButton = false,
                 });
 
                 updateConnectionResponse.Should().NotBeNull();
                 updateConnectionResponse.AssignMembershipOnLogin.Should().Be(false);
-                updateConnectionResponse.ShowAsButton.Should().Be(false);
+                updateConnectionResponse.ShowAsButton.Should().Be(true);
 
                 var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -152,26 +152,31 @@ namespace Auth0.ManagementApi.IntegrationTests
             var createConnectionResponse = await fixture.ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
             {
                 ConnectionId = ExistingConnectionId,
-                AssignMembershipOnLogin = true
+                AssignMembershipOnLogin = true,
+                ShowAsButton = true
             });
 
             createConnectionResponse.Should().NotBeNull();
             createConnectionResponse.AssignMembershipOnLogin.Should().Be(true);
+            createConnectionResponse.ShowAsButton.Should().Be(true);
 
             try
             {
                 var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
                 {
-                    AssignMembershipOnLogin = false
+                    AssignMembershipOnLogin = false,
+                    ShowAsButton = false,
                 });
 
                 updateConnectionResponse.Should().NotBeNull();
                 updateConnectionResponse.AssignMembershipOnLogin.Should().Be(false);
+                updateConnectionResponse.ShowAsButton.Should().Be(false);
 
                 var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
 
                 connection.Should().NotBeNull();
                 connection.AssignMembershipOnLogin.Should().Be(false);
+                connection.ShowAsButton.Should().Be(false);
 
                 var connections = await fixture.ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
                 connections.Count.Should().Be(initialConnections.Count + 1);

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -163,7 +163,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             {
                 var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
                 {
-                    AssignMembershipOnLogin = false,
+                    AssignMembershipOnLogin = false
                 });
 
                 updateConnectionResponse.Should().NotBeNull();
@@ -174,7 +174,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
                 connection.Should().NotBeNull();
                 connection.AssignMembershipOnLogin.Should().Be(false);
-                connection.ShowAsButton.Should().Be(false);
+                connection.ShowAsButton.Should().Be(true);
 
                 var connections = await fixture.ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
                 connections.Count.Should().Be(initialConnections.Count + 1);

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -193,6 +193,40 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
 
         [Fact]
+        public async Task Test_organization_connections_show_as_button_crud_sequence()
+        {
+            var createConnectionResponse = await fixture.ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
+            {
+                ConnectionId = ExistingConnectionId,
+                ShowAsButton = false
+            });
+
+            createConnectionResponse.Should().NotBeNull();
+            createConnectionResponse.ShowAsButton.Should().Be(false);
+
+            try
+            {
+                var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
+                {
+                    ShowAsButton = true
+                });
+
+                updateConnectionResponse.Should().NotBeNull();
+                updateConnectionResponse.ShowAsButton.Should().Be(true);
+
+                var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
+
+                connection.Should().NotBeNull();
+                connection.ShowAsButton.Should().Be(true);
+            }
+            finally
+            {
+                // Unlink Connection
+                await fixture.ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
+            }
+        }
+
+        [Fact]
         public async Task Test_organization_members_crud_sequence()
         {
             var user = await fixture.ApiClient.Users.CreateAsync(new UserCreateRequest

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -157,25 +157,21 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             createConnectionResponse.Should().NotBeNull();
             createConnectionResponse.AssignMembershipOnLogin.Should().Be(true);
-            createConnectionResponse.ShowAsButton.Should().Be(true);
 
             try
             {
                 var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
                 {
-                    AssignMembershipOnLogin = false,
-                    ShowAsButton = false
+                    AssignMembershipOnLogin = false
                 });
 
                 updateConnectionResponse.Should().NotBeNull();
                 updateConnectionResponse.AssignMembershipOnLogin.Should().Be(false);
-                updateConnectionResponse.ShowAsButton.Should().Be(false);
 
                 var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
 
                 connection.Should().NotBeNull();
                 connection.AssignMembershipOnLogin.Should().Be(false);
-                connection.ShowAsButton.Should().Be(false);
 
                 var connections = await fixture.ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
                 connections.Count.Should().Be(initialConnections.Count + 1);

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -163,18 +163,19 @@ namespace Auth0.ManagementApi.IntegrationTests
             {
                 var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
                 {
-                    AssignMembershipOnLogin = false
+                    AssignMembershipOnLogin = false,
+                    ShowAsButton = false
                 });
 
                 updateConnectionResponse.Should().NotBeNull();
                 updateConnectionResponse.AssignMembershipOnLogin.Should().Be(false);
-                updateConnectionResponse.ShowAsButton.Should().Be(true);
+                updateConnectionResponse.ShowAsButton.Should().Be(false);
 
                 var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
 
                 connection.Should().NotBeNull();
                 connection.AssignMembershipOnLogin.Should().Be(false);
-                connection.ShowAsButton.Should().Be(true);
+                connection.ShowAsButton.Should().Be(false);
 
                 var connections = await fixture.ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
                 connections.Count.Should().Be(initialConnections.Count + 1);
@@ -184,40 +185,6 @@ namespace Auth0.ManagementApi.IntegrationTests
                 Func<Task> getFunc = async () => await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
                 getFunc.Should().Throw<ErrorApiException>().And.Message.Should().Be("No connection found by that id");
 
-            }
-            finally
-            {
-                // Unlink Connection
-                await fixture.ApiClient.Organizations.DeleteConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
-            }
-        }
-
-        [Fact]
-        public async Task Test_organization_connections_show_as_button_crud_sequence()
-        {
-            var createConnectionResponse = await fixture.ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
-            {
-                ConnectionId = ExistingConnectionId,
-                ShowAsButton = false
-            });
-
-            createConnectionResponse.Should().NotBeNull();
-            createConnectionResponse.ShowAsButton.Should().Be(false);
-
-            try
-            {
-                var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
-                {
-                    ShowAsButton = true
-                });
-
-                updateConnectionResponse.Should().NotBeNull();
-                updateConnectionResponse.ShowAsButton.Should().Be(true);
-
-                var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
-
-                connection.Should().NotBeNull();
-                connection.ShowAsButton.Should().Be(true);
             }
             finally
             {

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -152,8 +152,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             var createConnectionResponse = await fixture.ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
             {
                 ConnectionId = ExistingConnectionId,
-                AssignMembershipOnLogin = true,
-                ShowAsButton = true
+                AssignMembershipOnLogin = true
             });
 
             createConnectionResponse.Should().NotBeNull();


### PR DESCRIPTION
### Changes

Adds `show_as_button` to `OrganizationConnection`, `OrganizationConnectionCreateRequest` and `OrganizationConnectionUpdateRequest`. 

### References

This property is documented here:

- [Get connections enabled for an organization](https://auth0.com/docs/api/management/v2/organizations/get-enabled-connections)
- [Add connections to an organization](https://auth0.com/docs/api/management/v2/organizations/post-enabled-connections)
- [Modify an organizations connection](https://auth0.com/docs/api/management/v2/organizations/patch-enabled-connections-by-connection-id)

### Testing

I have attempted to add a unit test by following the pattern used for `AssignMembershipOnLogin`, however I was not able to run the tests to validate that they passed.

- [ ] This change adds unit test coverage

- [X] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
