### PR TITLE
[SDK-4773] Support JWT Access Token Profile values in TokenDialect

### DIFF
--- a/src/Auth0.ManagementApi/Models/TokenDialect.cs
+++ b/src/Auth0.ManagementApi/Models/TokenDialect.cs
@@ -8,6 +8,12 @@ namespace Auth0.ManagementApi.Models
         AccessToken,
 
         [EnumMember(Value = "access_token_authz")]
-        AccessTokenAuthZ
+        AccessTokenAuthZ,
+        
+        [EnumMember(Value = "rfc9068_profile")]
+        Rfc9068Profile,
+        
+        [EnumMember(Value = "rfc9068_profile_authz")]
+        Rfc9068ProfileAuthz
     }
 }


### PR DESCRIPTION
### Changes

This PR adds support for new JWT Access Token Profile values in the `/api/v2/resource-servers` endpoint.

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
