### PR TITLE
Adds 'is_signup_enabled' for OrganisationConnection

### DIFF
--- a/src/Auth0.ManagementApi/Models/OrganizationConnection.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnection.cs
@@ -21,6 +21,12 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("show_as_button")]
         public bool ShowAsButton { get; set; }
+        
+        /// <summary>
+        /// Determines whether organization signup should be enabled for this organization connection.
+        /// </summary>
+        [JsonProperty("is_signup_enabled")]
+        public bool IsSignUpEnabled { get; set; }
 
         /// <summary>
         /// Information on the enabled connection

--- a/src/Auth0.ManagementApi/Models/OrganizationConnectionCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnectionCreateRequest.cs
@@ -22,5 +22,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("show_as_button")]
         public bool? ShowAsButton { get; set; }
+        
+        /// <summary>
+        /// Determines whether organization signup should be enabled for this organization connection.
+        /// </summary>
+        [JsonProperty("is_signup_enabled")]
+        public bool? IsSignUpEnabled { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/OrganizationConnectionUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationConnectionUpdateRequest.cs
@@ -15,5 +15,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("show_as_button")]
         public bool? ShowAsButton { get; set; }
+        
+        /// <summary>
+        /// Determines whether organization signup should be enabled for this organization connection.
+        /// </summary>
+        [JsonProperty("is_signup_enabled")]
+        public bool? IsSignUpEnabled { get; set; }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -152,26 +152,31 @@ namespace Auth0.ManagementApi.IntegrationTests
             var createConnectionResponse = await fixture.ApiClient.Organizations.CreateConnectionAsync(ExistingOrganizationId, new OrganizationConnectionCreateRequest
             {
                 ConnectionId = ExistingConnectionId,
-                AssignMembershipOnLogin = true
+                AssignMembershipOnLogin = true,
+                IsSignUpEnabled = true
             });
 
             createConnectionResponse.Should().NotBeNull();
             createConnectionResponse.AssignMembershipOnLogin.Should().Be(true);
+            createConnectionResponse.IsSignUpEnabled.Should().Be(true);
 
             try
             {
                 var updateConnectionResponse = await fixture.ApiClient.Organizations.UpdateConnectionAsync(ExistingOrganizationId, ExistingConnectionId, new OrganizationConnectionUpdateRequest
                 {
-                    AssignMembershipOnLogin = false
+                    AssignMembershipOnLogin = false,
+                    IsSignUpEnabled = false
                 });
 
                 updateConnectionResponse.Should().NotBeNull();
                 updateConnectionResponse.AssignMembershipOnLogin.Should().Be(false);
+                updateConnectionResponse.IsSignUpEnabled.Should().Be(false);
 
                 var connection = await fixture.ApiClient.Organizations.GetConnectionAsync(ExistingOrganizationId, ExistingConnectionId);
 
                 connection.Should().NotBeNull();
                 connection.AssignMembershipOnLogin.Should().Be(false);
+                connection.IsSignUpEnabled.Should().Be(false);
 
                 var connections = await fixture.ApiClient.Organizations.GetAllConnectionsAsync(ExistingOrganizationId, new Paging.PaginationInfo());
                 connections.Count.Should().Be(initialConnections.Count + 1);


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

is_signup_enabled attribute in related to Organisation Connection was not exposed before.
With these changes the users can now :
- Access this attribute in the responses (Create / Update / Get).
- Can use the attribute to set the value during Create and Update.

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
