### PR TITLE
Fixes issue where SendInvitationEmail is not defaulting to True

### DIFF
--- a/src/Auth0.ManagementApi/Models/OrganizationCreateInvitationRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationCreateInvitationRequest.cs
@@ -33,13 +33,13 @@ namespace Auth0.ManagementApi.Models
         public string ClientId { get; set; }
 
         /// <summary>
-        /// Contains app meta data. The user has read/write access to this.
+        /// Contains app metadata. The user has read/write access to this.
         /// </summary>
         [JsonProperty("app_metadata")]
         public dynamic AppMetadata { get; set; }
 
         /// <summary>
-        /// Contains user meta data. The user has read/write access to this.
+        /// Contains user metadata. The user has read/write access to this.
         /// </summary>
         [JsonProperty("user_metadata")]
         public dynamic UserMetadata { get; set; }
@@ -51,13 +51,13 @@ namespace Auth0.ManagementApi.Models
         /// If unspecified or set to 0, this value defaults to 604800 seconds (7 days). Max value: 2592000 seconds (30 days).
         /// </remarks>
         [JsonProperty("ttl_sec")]
-        public int TimeToLive { get; set; }
+        public int? TimeToLive { get; set; }
 
         /// <summary>
         /// Whether the user will receive an invitation email (true) or no email (false), true by default
         /// </summary>
         [JsonProperty("send_invitation_email")]
-        public bool SendInvitationEmail { get; set; }
+        public bool? SendInvitationEmail { get; set; }
 
         /// <summary>
         /// List of role IDs to associated with the user.

--- a/src/Auth0.ManagementApi/Models/OrganizationInvitation.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationInvitation.cs
@@ -31,7 +31,7 @@ namespace Auth0.ManagementApi.Models
         public OrganizationInvitationInvitee Invitee { get; set; }
 
         /// <summary>
-        /// The invitation URL to be send to the invitee.
+        /// The invitation URL to be sent to the invitee.
         /// </summary>
         [JsonProperty("invitation_url")]
         public string InvitationUrl { get; set; }
@@ -61,13 +61,13 @@ namespace Auth0.ManagementApi.Models
         public string ClientId { get; set; }
 
         /// <summary>
-        /// Contains app meta data. The user has read/write access to this.
+        /// Contains app metadata. The user has read/write access to this.
         /// </summary>
         [JsonProperty("app_metadata")]
         public dynamic AppMetadata { get; set; }
 
         /// <summary>
-        /// Contains user meta data. The user has read/write access to this.
+        /// Contains user metadata. The user has read/write access to this.
         /// </summary>
         [JsonProperty("user_metadata")]
         public dynamic UserMetadata { get; set; }

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -367,7 +367,7 @@ namespace Auth0.ManagementApi.IntegrationTests
 
             try
             {
-                var createdInvitation = await fixture.ApiClient.Organizations.CreateInvitationAsync(ExistingOrganizationId, new OrganizationCreateInvitationRequest
+                var invitationRequest = new OrganizationCreateInvitationRequest
                 {
                     ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
                     ConnectionId = ExistingConnectionId,
@@ -378,10 +378,11 @@ namespace Auth0.ManagementApi.IntegrationTests
                     Invitee = new OrganizationInvitationInvitee
                     {
                         Email = "jane.doe@auth0.com"
-                    },
-                    TimeToLive = 360,
-                    SendInvitationEmail = false
-                });
+                    }
+                };
+                
+                var createdInvitation = 
+                    await fixture.ApiClient.Organizations.CreateInvitationAsync(ExistingOrganizationId, invitationRequest);
 
                 createdInvitation.Should().NotBeNull();
                 createdInvitation.InvitationUrl.Should().NotBeNull();


### PR DESCRIPTION
### Changes

Ensured the default value for `OrganizationCreateInvitationRequest.SendInvitationEmail` to `True`

### References

Please include relevant links supporting this change such as a:

Refer #727 for more details.

[Auth0 Docs for CreateInvitations End-point](https://auth0.com/docs/api/management/v2/organizations/post-invitations)
### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
