### PR TITLE
Organization support for client credentials

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -533,7 +533,7 @@ namespace Auth0.AuthenticationApi
 
         private Uri BuildUri(string path)
         {
-            return Utils.BuildUri(BaseUri.AbsoluteUri, path, null, null);
+            return Utils.BuildUri(BaseUri.AbsoluteUri, path, null, queryStrings:null);
         }
 
         private IDictionary<string, string> BuildHeaders(string accessToken)

--- a/src/Auth0.Core/Utils.cs
+++ b/src/Auth0.Core/Utils.cs
@@ -36,39 +36,25 @@ namespace Auth0.Core.Http
 
         internal static Uri BuildUri(string baseUrl, string resource, IDictionary<string, string> urlSegments, IDictionary<string, string> queryStrings, bool includeEmptyParameters = false)
         {
-            // Replace the URL Segments
-            if (urlSegments != null)
-            {
-                foreach (var urlSegment in urlSegments)
-                {
-                    resource = resource.Replace($"{{{urlSegment.Key}}}", Uri.EscapeDataString(urlSegment.Value ?? String.Empty));
-                }
+            resource = ReplaceUrlSegments(resource, urlSegments);
 
-                // Remove trailing slash
-                resource = resource.TrimEnd('/');
+            var queryString = AddQueryString(queryStrings, includeEmptyParameters);
+
+            // If we have a querystring, append it to the resource
+            if (!string.IsNullOrEmpty(queryString))
+            {
+                resource = resource.Contains("?") ? $"{resource}&{queryString}" : $"{resource}?{queryString}";
             }
 
-            // Add the query strings
-            var queryString = queryStrings?.Aggregate(new StringBuilder(), (sb, kvp) =>
-                {
-                    if (kvp.Value != null)
-                    {
-                        if (sb.Length > 0)
-                            sb = sb.Append("&");
+            resource = CombineUriParts(baseUrl, resource);
 
-                        sb.Append($"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}");
-                    }
-                    else if (includeEmptyParameters)
-                    {
-                        if (sb.Length > 0)
-                            sb = sb.Append("&");
+            return new Uri(resource, UriKind.RelativeOrAbsolute);
+        }
+        internal static Uri BuildUri(string baseUrl, string resource, IDictionary<string, string> urlSegments, IList<Tuple<string, string>> queryStrings, bool includeEmptyParameters = false)
+        {
+            resource = ReplaceUrlSegments(resource, urlSegments);
 
-                        sb.Append(Uri.EscapeDataString(kvp.Key));
-                    }
-
-                    return sb;
-                })
-                .ToString();
+            var queryString = AddQueryString(queryStrings, includeEmptyParameters);
 
             // If we have a querystring, append it to the resource
             if (!string.IsNullOrEmpty(queryString))
@@ -101,6 +87,67 @@ namespace Auth0.Core.Http
             }
             return uri;
         }
+        private static string AddQueryString(IList<Tuple<string, string>> queryStrings, bool includeEmptyParameters)
+        {
+            var sb = new StringBuilder();
+            // Add the query strings
+            foreach (var keyValuePair in queryStrings)
+            {
+                if (keyValuePair.Item2 != null)
+                {
+                    if (sb.Length > 0)
+                        sb = sb.Append("&");
 
+                    sb.Append($"{Uri.EscapeDataString(keyValuePair.Item1)}={Uri.EscapeDataString(keyValuePair.Item2)}");
+                }
+                else if (includeEmptyParameters)
+                {
+                    if (sb.Length > 0)
+                        sb = sb.Append("&");
+
+                    sb.Append(Uri.EscapeDataString(keyValuePair.Item1));
+                }
+            }
+            return sb.ToString();
+        }
+        private static string AddQueryString(IDictionary<string, string> queryStrings, bool includeEmptyParameters)
+        {
+            // Add the query strings
+            var queryString = queryStrings?.Aggregate(new StringBuilder(), (sb, kvp) =>
+                {
+                    if (kvp.Value != null)
+                    {
+                        if (sb.Length > 0)
+                            sb = sb.Append("&");
+
+                        sb.Append($"{Uri.EscapeDataString(kvp.Key)}={Uri.EscapeDataString(kvp.Value)}");
+                    }
+                    else if (includeEmptyParameters)
+                    {
+                        if (sb.Length > 0)
+                            sb = sb.Append("&");
+
+                        sb.Append(Uri.EscapeDataString(kvp.Key));
+                    }
+
+                    return sb;
+                })
+                .ToString();
+            return queryString;
+        }
+        private static string ReplaceUrlSegments(string resource, IDictionary<string, string> urlSegments)
+        {
+            // Replace the URL Segments
+            if (urlSegments == null) return resource;
+            foreach (var urlSegment in urlSegments)
+            {
+                resource = 
+                    resource.Replace($"{{{urlSegment.Key}}}", Uri.EscapeDataString(urlSegment.Value ?? String.Empty));
+            }
+
+            // Remove trailing slash
+            resource = resource.TrimEnd('/');
+            return resource;
+        }
     }
 }

--- a/src/Auth0.Core/Utils.cs
+++ b/src/Auth0.Core/Utils.cs
@@ -50,11 +50,11 @@ namespace Auth0.Core.Http
 
             return new Uri(resource, UriKind.RelativeOrAbsolute);
         }
-        internal static Uri BuildUri(string baseUrl, string resource, IDictionary<string, string> urlSegments, IList<Tuple<string, string>> queryStrings, bool includeEmptyParameters = false)
+        internal static Uri BuildUri(string baseUrl, string resource, IDictionary<string, string> urlSegments, IList<Tuple<string, string>> queryStringsTuple, bool includeEmptyParameters = false)
         {
             resource = ReplaceUrlSegments(resource, urlSegments);
 
-            var queryString = AddQueryString(queryStrings, includeEmptyParameters);
+            var queryString = AddQueryString(queryStringsTuple, includeEmptyParameters);
 
             // If we have a querystring, append it to the resource
             if (!string.IsNullOrEmpty(queryString))

--- a/src/Auth0.ManagementApi/Clients/BaseClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BaseClient.cs
@@ -48,6 +48,11 @@ namespace Auth0.ManagementApi.Clients
         {
             return Utils.BuildUri(BaseUri.AbsoluteUri, resource, null, queryStrings);
         }
+        
+        protected Uri BuildUri(string resource, IList<Tuple<string, string>> queryStrings)
+        {
+            return Utils.BuildUri(BaseUri.AbsoluteUri, resource, null, queryStrings);
+        }
 
         /// <summary>
         /// Encode a value so it can be successfully used in the path.

--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -67,7 +67,8 @@ namespace Auth0.ManagementApi.Clients
                 {"fields", request.Fields},
                 {"include_fields", request.IncludeFields?.ToString().ToLower()},
                 {"is_global", request.IsGlobal?.ToString().ToLower()},
-                {"is_first_party", request.IsFirstParty?.ToString().ToLower()}
+                {"is_first_party", request.IsFirstParty?.ToString().ToLower()},
+                {"q", request.Query?.ToLower()}
             };
 
             if (pagination != null)

--- a/src/Auth0.ManagementApi/Clients/IResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IResourceServersClient.cs
@@ -34,6 +34,16 @@ namespace Auth0.ManagementApi.Clients
     /// <summary>
     /// Gets a list of all the resource servers.
     /// </summary>
+    /// <param name="request">Contains the information required to retrieve the Resource Servers</param>
+    /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="IPagedList{ResourceServer}"/> containing the list of resource servers.</returns>
+    Task<IPagedList<ResourceServer>> GetAllAsync(ResourceServerGetRequest request, PaginationInfo pagination = null,
+      CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a list of all the resource servers.
+    /// </summary>
     /// <param name="pagination">Specifies pagination info to use when requesting paged results.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>A <see cref="IPagedList{ResourceServer}"/> containing the list of resource servers.</returns>

--- a/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ResourceServersClient.cs
@@ -3,6 +3,7 @@ using Auth0.ManagementApi.Paging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -70,11 +71,35 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection.GetAsync<IPagedList<ResourceServer>>(BuildUri("resource-servers",
                 pagination != null ? new Dictionary<string, string>
-                {
+                    {
                     {"page", pagination.PageNo.ToString()},
                     {"per_page", pagination.PerPage.ToString()},
                     {"include_totals", pagination.IncludeTotals.ToString().ToLower()}
                 } : null), DefaultHeaders, converters, cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<ResourceServer>> GetAllAsync(ResourceServerGetRequest request,
+            PaginationInfo pagination = null, CancellationToken cancellationToken = default)
+        {
+            var queryStrings = new List<Tuple<string, string>>();
+
+            if (request?.Identifiers != null)
+            {
+                queryStrings.AddRange(
+                    request.Identifiers.Select(
+                        identifier => new Tuple<string, string>("identifiers", identifier)));
+            }
+            
+            if (pagination != null)
+            {
+                queryStrings.Add(new Tuple<string, string>("page", pagination.PageNo.ToString()));
+                queryStrings.Add(new Tuple<string, string>("per_page", pagination.PerPage.ToString()));
+                queryStrings.Add(new Tuple<string, string>("include_totals", pagination.IncludeTotals.ToString().ToLower()));
+            }
+
+            return Connection.GetAsync<IPagedList<ResourceServer>>(
+                BuildUri("resource-servers", queryStrings), DefaultHeaders, converters, cancellationToken);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Models/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/ClientBase.cs
@@ -199,6 +199,12 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("require_pushed_authorization_requests")]
         public bool? RequirePushedAuthorizationRequests { get; set; }
+        
+        /// <summary>
+        /// Defines the default Organization ID and flows
+        /// </summary>
+        [JsonProperty("default_organization")]
+        public DefaultOrganization DefaultOrganization { get; set; }
     }
 
 }

--- a/src/Auth0.ManagementApi/Models/DefaultOrganization.cs
+++ b/src/Auth0.ManagementApi/Models/DefaultOrganization.cs
@@ -1,0 +1,25 @@
+using System;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Defines the default Organization ID and flows
+    /// </summary>
+    public class DefaultOrganization
+    {
+        /// <summary>
+        /// The default Organization ID to be used
+        /// </summary>
+        [JsonProperty("organization_id")]
+        public string OrganizationId { get; set; }
+        
+        /// <summary>
+        /// The default Organization usage
+        /// </summary>
+        [JsonProperty("flows", ItemConverterType = typeof(StringEnumConverter))]
+        public Flows[] Flows { get; set; }
+        
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flows.cs
+++ b/src/Auth0.ManagementApi/Models/Flows.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The default Organization usage
+    /// </summary>
+    public enum Flows
+    {
+        /// <summary>
+        /// Client-Credentials flow
+        /// </summary>
+        [EnumMember(Value = "client_credentials")]
+        ClientCredentials
+    }
+}

--- a/src/Auth0.ManagementApi/Models/GetClientsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/GetClientsRequest.cs
@@ -29,5 +29,10 @@
         /// Filter on whether or not a client is a first party client.
         /// </summary>
         public bool? IsFirstParty { get; set; } = null;
+        
+        /// <summary>
+        /// Query in <a href ="http://www.lucenetutorial.com/lucene-query-syntax.html">Lucene query string syntax</a> to search for clients.
+        /// </summary>
+        public string Query { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/OrganizationGetClientGrantsRequest.cs
+++ b/src/Auth0.ManagementApi/Models/OrganizationGetClientGrantsRequest.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Auth0.ManagementApi.Models
 {
     public class OrganizationGetClientGrantsRequest
@@ -10,6 +12,11 @@ namespace Auth0.ManagementApi.Models
         /// <summary>
         ///  The Id of a client to filter by. 
         /// </summary>
-        public string ClientId { get; set; }  
+        public string ClientId { get; set; }
+        
+        /// <summary>
+        /// List of GrantIds to filter results on
+        /// </summary>
+        public IList<string> GrantIds { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/ResourceServerGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServerGetRequest.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Request structure for creating a new resource server
+    /// </summary>
+    public class ResourceServerGetRequest
+    {
+        /// <summary>
+        /// List of Identifier IDs to retrieve
+        /// </summary>
+        public IList<string> Identifiers { get; set; }
+    }
+}

--- a/tests/Auth0.Core.UnitTests/UtilsTest.cs
+++ b/tests/Auth0.Core.UnitTests/UtilsTest.cs
@@ -1,0 +1,6 @@
+namespace Auth0.Core.UnitTests;
+
+public class UtilsTest
+{
+    
+}

--- a/tests/Auth0.Core.UnitTests/UtilsTest.cs
+++ b/tests/Auth0.Core.UnitTests/UtilsTest.cs
@@ -1,6 +1,0 @@
-namespace Auth0.Core.UnitTests;
-
-public class UtilsTest
-{
-    
-}

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientGrantTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi.IntegrationTests.Testing;
@@ -191,7 +192,6 @@ namespace Auth0.ManagementApi.IntegrationTests
                 OrganizationUsage = OrganizationUsage.Allow,
                 AllowAnyOrganization = true
             });
-            
             fixture.TrackIdentifier(CleanUpType.ClientGrants, newGrant.Id);
 
             var orgsBefore = await fixture.ApiClient.ClientGrants.GetAllOrganizationsAsync(newGrant.Id);
@@ -223,10 +223,20 @@ namespace Auth0.ManagementApi.IntegrationTests
             
             orgsAfter.Count.Should().Be(1);
             orgGrantsAfter.Count.Should().Be(1);
-
+            
+            // Get client grants using a client-Grants filter
+            var grantsFilter = new List<string>() { newGrant.Id, newGrant.Id };
+            var filteredUsingClientGrants =
+                await fixture.ApiClient.Organizations.GetAllClientGrantsAsync(existingOrgId,
+                    new OrganizationGetClientGrantsRequest()
+                    {
+                        GrantIds = grantsFilter
+                    });
+            
+            filteredUsingClientGrants.Count.Should().Be(1);
+            filteredUsingClientGrants.First().Id.Should().BeEquivalentTo(newGrant.Id);
             await fixture.ApiClient.ClientGrants.DeleteAsync(newGrant.Id);
             fixture.UnTrackIdentifier(CleanUpType.ClientGrants, newGrant.Id);
         }
-
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ManagementApiClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ManagementApiClientTests.cs
@@ -1,5 +1,4 @@
-﻿using Auth0.Core.Http;
-using Auth0.Tests.Shared;
+﻿using Auth0.Tests.Shared;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -23,7 +22,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             management = new ManagementApiClient("fake", GetVariable("AUTH0_MANAGEMENT_API_URL"), grabber);
 
             management.TenantSettings.GetAsync(); // Cause headers to be "sent" to the grabber for testing
-            payload = JObject.Parse(Encoding.ASCII.GetString(Utils.Base64UrlDecode(grabber.LastHeaders["Auth0-Client"])));
+            payload = JObject.Parse(Encoding.ASCII.GetString(Auth0.Core.Http.Utils.Base64UrlDecode(grabber.LastHeaders["Auth0-Client"])));
         }
 
         [Fact]

--- a/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ResourceServerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Auth0.Core.Exceptions;
 using Auth0.IntegrationTests.Shared.CleanUp;
@@ -99,7 +100,22 @@ namespace Auth0.ManagementApi.IntegrationTests
             // Get a single resource server
             var resourceServer = await fixture.ApiClient.ResourceServers.GetAsync(newResourceServerResponse.Id);
             resourceServer.Should().BeEquivalentTo(updateResourceServerRequest, options => options.ExcludingMissingMembers());
-
+            
+            // Get all resource servers with pagination
+            var pagination = new PaginationInfo(0, 10, true);
+            var request = new ResourceServerGetRequest()
+            {
+                Identifiers = new List<string>() { resourceServer.Identifier, resourceServer.Identifier }
+            };
+            var resourceServers = await fixture.ApiClient.ResourceServers.GetAllAsync(request, pagination);
+            resourceServers.Count.Should().Be(1);
+            resourceServers.First().Identifier.Should().BeEquivalentTo(resourceServer.Identifier);
+            
+            // Get all resource servers with pagination
+            pagination = new PaginationInfo(0, 10, true);
+            resourceServers = await fixture.ApiClient.ResourceServers.GetAllAsync(null, pagination);
+            resourceServers.Count.Should().BeGreaterThan(1);
+            
             // Delete the client, and ensure we get exception when trying to fetch client again
             await fixture.ApiClient.ResourceServers.DeleteAsync(resourceServer.Id);
             Func<Task> getFunc = async () => await fixture.ApiClient.ResourceServers.GetAsync(resourceServer.Id);

--- a/tests/Auth0.ManagementApi.IntegrationTests/TestBaseFixture.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TestBaseFixture.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared;
 using Auth0.IntegrationTests.Shared.CleanUp;
 using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.Tests.Shared;
@@ -11,6 +12,8 @@ namespace Auth0.ManagementApi.IntegrationTests
     {
         public ManagementApiClient ApiClient { get; private set; }
 
+        public Utils Utils { get; private set; }
+
         protected IDictionary<CleanUpType, IList<string>> identifiers = new Dictionary<CleanUpType, IList<string>>();
 
         public virtual async Task InitializeAsync()
@@ -18,6 +21,8 @@ namespace Auth0.ManagementApi.IntegrationTests
             string token = await TestBaseUtils.GenerateManagementApiToken();
 
             ApiClient = new ManagementApiClient(token, TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_URL"), new HttpClientManagementConnection(options: new HttpClientManagementConnectionOptions { NumberOfHttpRetries = 9 }));
+            
+            Utils = new Utils(ApiClient);
         }
 
         public virtual async Task DisposeAsync()

--- a/tests/Auth0.ManagementApi.IntegrationTests/Utils.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Utils.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.Models;
+
+namespace Auth0.ManagementApi.IntegrationTests
+{
+    public class Utils
+    {
+        private readonly ManagementApiClient _apiClient;
+
+        public Utils(ManagementApiClient apiClient)
+        {
+            _apiClient = apiClient;
+        }
+
+        internal async Task<Client> CreateClient(ClientCreateRequest request = null)
+        {
+            request ??= new ClientCreateRequest()
+            {
+                Name = "Test client " + Guid.NewGuid(),
+                Description = "This is a dummy client - TBD"
+            };
+
+            var client = await _apiClient.Clients.CreateAsync(request);
+            return client;
+        }
+        
+        internal async Task<Organization> CreateOrganization(OrganizationCreateRequest request = null)
+        {
+            request??= new OrganizationCreateRequest()
+            {
+                Name = "tbd-organisation",
+                DisplayName = "Test organization display name",
+            };
+            
+            var organization = await _apiClient.Organizations.CreateAsync(request);
+            return organization;
+        }
+        
+        internal async Task<ResourceServer> CreateResourceServer(ResourceServerCreateRequest request = null)
+        {
+            var identifier = Guid.NewGuid();
+            request??= new ResourceServerCreateRequest
+            {
+                Identifier = identifier.ToString("N"),
+                Name = $"{TestingConstants.ResourceServerPrefix} {identifier:N}",
+                TokenLifetime = 1,
+                TokenLifetimeForWeb = 1,
+                SigningAlgorithm = SigningAlgorithm.HS256,
+                SigningSecret = "thisismysecret0123456789",
+                Scopes = new List<ResourceServerScope>
+                {
+                    new ResourceServerScope
+                    {
+                        Value = "scope1",
+                        Description = "Scope number 1"
+                    }
+                },
+                AllowOfflineAccess = true,
+                VerificationLocation = "https://abc.auth0.com/def",
+                SkipConsentForVerifiableFirstPartyClients = true,
+            };
+            var resourceServer = await _apiClient.ResourceServers.CreateAsync(request);
+            return resourceServer;
+        }
+    }
+}


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Support for Default Organisation in clients
  1. Added new field `default_organization` to GET/PATCH endpoints /api/v2/clients/{id} 
  2. Added new field `default_organization` to POST endpoints /api/v2/clients/

- Support query param `q` for GET /api/v2/clients
  1. `q=client_grant.organization_id:org_sampleorgid213`
  2. `q=client_grant.allow_any_organization:true`

- Support query param `grant_ids` for GET /api/v2/organizations/{org_id}/client-grants
- Support query param `identifiers` for GET /api/v2/resource-servers

### References
- [Management API Documentation](https://sus.auth0.com/docs/api/management/v2/organizations/post-organizations)
- [Internal Reference](https://oktawiki.atlassian.net/wiki/spaces/IAMPS/pages/3052704289/Organizations+for+Client+Credentials+GA+SDK+Changes) 

### Testing
Added test cases for testing above end-points. 
Tested the implementation manually according to this [internal document](https://oktawiki.atlassian.net/wiki/spaces/IAMPS/pages/3028125865/Demo+-+Default+Organizations)


- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
