### PR TITLE
Adds support for HRI

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -482,6 +482,8 @@ namespace Auth0.AuthenticationApi
             body.AddIfNotEmpty("connection", request.Connection);
             body.AddIfNotEmpty("scope", request.Scope);
             body.AddIfNotEmpty("audience", request.Audience);
+            body.AddIfNotEmpty("request", request.Request);
+            body.AddIfNotEmpty("authorization_details", request.AuthorizationDetails);
             
             body.AddAll(request.AdditionalProperties);
 

--- a/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
+++ b/src/Auth0.AuthenticationApi/Builders/AuthorizationUrlBuilder.cs
@@ -196,5 +196,15 @@ namespace Auth0.AuthenticationApi.Builders
         {
             return WithValue("invitation", invitation);
         }
+        
+        /// <summary>
+        /// Adds the `request` query string parameter.
+        /// </summary>
+        /// <param name="request">Signed JWT request</param>
+        /// <returns>Current <see cref="AuthorizationUrlBuilder"/> to allow fluent configuration.</returns>
+        public AuthorizationUrlBuilder WithRequest(string request)
+        {
+            return WithValue("request", request);
+        }
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
@@ -88,5 +88,17 @@ namespace Auth0.AuthenticationApi.Models
         /// Any additional properties to use.
         /// </summary>
         public IDictionary<string, string> AdditionalProperties { get; set; } = new Dictionary<string, string>();
+        
+        /// <summary>
+        /// Allows JWT-Secured Authorization Request (JAR), when JAR & PAR request are used together.
+        /// </summary>
+        public string Request { get; set; }
+        
+        /// <summary>
+        /// A JSON stringified array of objects.
+        /// It can carry fine-grained authorization data in OAuth messages as part of Rich Authorization Requests (RAR)
+        /// <see href="https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar">reference</see>
+        /// </summary>
+        public string AuthorizationDetails { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/Client/Client.cs
+++ b/src/Auth0.ManagementApi/Models/Client/Client.cs
@@ -40,39 +40,15 @@ namespace Auth0.ManagementApi.Models
         public TokenEndpointAuthMethod TokenEndpointAuthMethod { get; set; }
 
         /// <summary>
-        /// The client's authentication methods
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.ClientAuthenticationMethods"/>
         /// </summary>
         [JsonProperty("client_authentication_methods")]
         public ClientAuthenticationMethods ClientAuthenticationMethods { get; set; }
-    }
-
-    /// <summary>
-    /// Structure for a client's authentication methods
-    /// </summary>
-    public class ClientAuthenticationMethods
-    {
-        [JsonProperty("private_key_jwt")]
-        public PrivateKeyJwt PrivateKeyJwt { get; set; }
-    }
-
-    /// <summary>
-    /// Structure for credentials using Private Key JWT
-    /// </summary>
-    public class PrivateKeyJwt
-    {
-        [JsonProperty("credentials")]
-        public IList<CredentialId> Credentials { get; set; }
-    }
-
-    /// <summary>
-    /// Structure for a client's credential.
-    /// </summary>
-    /// <remarks>
-    /// Only contains the credential's id.
-    /// </remarks>
-    public class CredentialId
-    {
-        [JsonProperty("id")]
-        public string Id { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.SignedRequestObject"/>
+        /// </summary>
+        [JsonProperty("signed_request_object")]
+        public SignedRequestObject SignedRequestObject { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/Client/ClientAuthenticationMethods.cs
+++ b/src/Auth0.ManagementApi/Models/Client/ClientAuthenticationMethods.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Structure for a client's authentication methods
+    /// </summary>
+    public class ClientAuthenticationMethods
+    {
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.PrivateKeyJwt"/> 
+        /// </summary>
+        [JsonProperty("private_key_jwt")]
+        public PrivateKeyJwt PrivateKeyJwt { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.TlsClientAuth"/> 
+        /// </summary>
+        [JsonProperty("tls_client_auth")]
+        public TlsClientAuth TlsClientAuth { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.SelfSignedTlsClientAuth"/> 
+        /// </summary>
+        [JsonProperty("self_signed_tls_client_auth")]
+        public SelfSignedTlsClientAuth SelfSignedTlsClientAuth { get; set; }
+    }
+
+    /// <summary>
+    /// Defines private_key_jwt client authentication method. If this property is defined,
+    /// the client is enabled to use the Private Key JWT authentication method.
+    /// </summary>
+    public class PrivateKeyJwt
+    {
+        [JsonProperty("credentials")]
+        public IList<CredentialId> Credentials { get; set; }
+    }
+    
+    /// <summary>
+    /// Defines tls_client_auth client authentication method. If the property is defined,
+    /// the client is configured to use CA-based mTLS authentication method.
+    /// </summary>
+    public class TlsClientAuth
+    {
+        [JsonProperty("credentials")]
+        public IList<CredentialId> Credentials { get; set; }
+    }
+    
+    /// <summary>
+    /// Defines self_signed_tls_client_auth client authentication method. If the property is defined,
+    /// the client is configured to use mTLS authentication method utilizing self-signed certificate.
+    /// </summary>
+    public class SelfSignedTlsClientAuth
+    {
+        [JsonProperty("credentials")]
+        public IList<CredentialId> Credentials { get; set; }
+    }
+
+    /// <summary>
+    /// Structure for a client's credential.
+    /// </summary>
+    /// <remarks>
+    /// Only contains the credential's id.
+    /// </remarks>
+    public class CredentialId
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Client/ClientBase.cs
+++ b/src/Auth0.ManagementApi/Models/Client/ClientBase.cs
@@ -205,7 +205,17 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("default_organization")]
         public DefaultOrganization DefaultOrganization { get; set; }
+        
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.ComplianceLevel"/>
+        [JsonProperty("compliance_level")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ComplianceLevel? ComplianceLevel { get; set; }
+        
+        /// <summary>
+        /// Makes the use of Proof-of-Possession mandatory for this client
+        /// </summary>
+        [JsonProperty("require_proof_of_possession")]
+        public bool? RequireProofOfPossession { get; set; }
     }
-
 }
 

--- a/src/Auth0.ManagementApi/Models/Client/ClientCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Client/ClientCreateRequest.cs
@@ -36,23 +36,30 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("client_authentication_methods")]
         public CreateClientAuthenticationMethods ClientAuthenticationMethods { get; set; }
+        
+        /// <summary>
+        /// JWT-secured Authorization Requests (JAR) settings.
+        /// </summary>
+        [JsonProperty("signed_request_object")]
+        public CreateSignedRequestObject SignedRequestObject { get; set; }
     }
-
+    
     /// <summary>
-    /// Structure for creating new client authentication methods
+    /// Structure for creating a new SignedRequestObject
     /// </summary>
-    public class CreateClientAuthenticationMethods
+    public class CreateSignedRequestObject
     {
-        [JsonProperty("private_key_jwt")]
-        public CreatePrivateKeyJwt PrivateKeyJwt { get; set; }
-    }
-
-    /// <summary>
-    /// Structure for creating a new client credential using Private Key JWT
-    /// </summary>
-    public class CreatePrivateKeyJwt
-    {
+        
+        /// <summary>
+        /// Indicates whether the JAR requests are mandatory
+        /// </summary>
+        [JsonProperty("required")]
+        public bool? Required { get; set; }
+        
+        /// <summary>
+        /// List of <see cref="Credentials"/> for the JAR requests
+        /// </summary>
         [JsonProperty("credentials")]
-        public IList<ClientCredentialCreateRequest> Credentials { get; set; }
+        public IList<CredentialsCreateRequest> Credentials { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/Client/ClientUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Client/ClientUpdateRequest.cs
@@ -27,5 +27,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("client_authentication_methods")]
         public ClientAuthenticationMethods ClientAuthenticationMethods { get; set; }
+        
+        /// <summary>
+        /// JWT-secured Authorization Requests (JAR) settings.
+        /// </summary>
+        [JsonProperty("signed_request_object")]
+        public SignedRequestObject SignedRequestObject { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/Client/ComplianceLevel.cs
+++ b/src/Auth0.ManagementApi/Models/Client/ComplianceLevel.cs
@@ -1,0 +1,28 @@
+using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Defines the compliance level for this client, which may restrict it's capabilities
+    /// </summary>
+    public enum ComplianceLevel
+    {
+        /// <summary>
+        /// Compliance Level 'none'
+        /// </summary>
+        [EnumMember(Value = "none")]
+        NONE,
+        
+        /// <summary>
+        /// Compliance Level 'fapi1_adv_pkj_par'
+        /// </summary>
+        [EnumMember(Value = "fapi1_adv_pkj_par")]
+        FAPI1_ADV_PKJ_PAR,
+        
+        /// <summary>
+        /// Compliance Level 'fapi1_adv_mtls_par'
+        /// </summary>
+        [EnumMember(Value = "fapi1_adv_mtls_par")]
+        FAPI1_ADV_MTLS_PAR
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Client/CreateClientAuthenticationMethods.cs
+++ b/src/Auth0.ManagementApi/Models/Client/CreateClientAuthenticationMethods.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Structure for creating new client authentication methods
+    /// </summary>
+    public class CreateClientAuthenticationMethods
+    {
+        [JsonProperty("private_key_jwt")]
+        public CreatePrivateKeyJwt PrivateKeyJwt { get; set; }
+        
+        [JsonProperty("tls_client_auth")]
+        public CreateTlsClientAuth TlsClientAuthMethod { get; set; }
+        
+        [JsonProperty("self_signed_tls_client_auth")]
+        public CreateSelfSignedTlsClientAuth SelfSignedTlsClientAuthMethod { get; set; }
+    }
+
+    /// <summary>
+    /// Structure for creating a new client credential using Private Key JWT
+    /// </summary>
+    public class CreatePrivateKeyJwt
+    {
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.ClientCredentialCreateRequest"/>
+        /// </summary>
+        [JsonProperty("credentials")]
+        public IList<ClientCredentialCreateRequest> Credentials { get; set; }
+    }
+    
+    /// <summary>
+    /// Structure for creating a new client credential using TLS Client Auth. 
+    /// </summary>
+    public class CreateTlsClientAuth
+    {
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.CreateTlsClientAuthCredentials"/>
+        /// </summary>
+        [JsonProperty("credentials")]
+        public IList<CreateTlsClientAuthCredentials> Credentials { get; set; }
+    }
+    
+    /// <summary>
+    /// Structure for creating a new client credential using Self Signed TLS Client Auth. 
+    /// </summary>
+    public class CreateSelfSignedTlsClientAuth
+    {
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.CreateSelfSignedTlsClientAuthCredentials"/>
+        /// </summary>
+        [JsonProperty("credentials")]
+        public IList<CreateSelfSignedTlsClientAuthCredentials> Credentials { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Client/CreateSelfSignedTlsClientAuthCredentials.cs
+++ b/src/Auth0.ManagementApi/Models/Client/CreateSelfSignedTlsClientAuthCredentials.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Structure for creating a new client credential using Self Signed TLS Client Auth. 
+    /// </summary>
+    public class CreateSelfSignedTlsClientAuthCredentials
+    {
+        /// <summary>
+        /// Possible values: [x509_cert]
+        /// </summary>
+        [JsonProperty("credential_type")]
+        public string CredentialType { get; set; }
+        
+        /// <summary>
+        /// The name of the credential
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// PEM-formatted X509 certificate. Must be JSON escaped. Mutually exclusive with subject_dn property.
+        /// </summary>
+        [JsonProperty("pem")]
+        public string Pem { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Client/CreateTlsClientAuthCredentials.cs
+++ b/src/Auth0.ManagementApi/Models/Client/CreateTlsClientAuthCredentials.cs
@@ -1,0 +1,34 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Structure for creating a new client credential using TLS Client Auth. 
+    /// </summary>
+    public class CreateTlsClientAuthCredentials
+    {
+        /// <summary>
+        /// Possible values: [cert_subject_dn]
+        /// </summary>
+        [JsonProperty("credential_type")]
+        public string CredentialType { get; set; }
+        
+        /// <summary>
+        /// The name of the credential
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// PEM-formatted X509 certificate. Must be JSON escaped. Mutually exclusive with subject_dn property.
+        /// </summary>
+        [JsonProperty("pem")]
+        public string Pem { get; set; }
+        
+        /// <summary>
+        /// Subject Distinguished Name. Mutually exclusive with pem property.
+        /// </summary>
+        [JsonProperty("subject_dn")]
+        public string SubjectDistinguishedName { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Client/Credentials.cs
+++ b/src/Auth0.ManagementApi/Models/Client/Credentials.cs
@@ -1,0 +1,18 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    
+    /// <summary>
+    /// Credentials for the JAR requests
+    /// </summary>
+    public class Credentials
+    {
+        /// <summary>
+        /// Credential ID
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Client/CredentialsCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Client/CredentialsCreateRequest.cs
@@ -1,0 +1,49 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Structure for creating a new Credential for JAR request
+    /// </summary>
+    public class CredentialsCreateRequest
+    {
+        /// <summary>
+        /// Credential type. Supported types: public_key.
+        /// </summary>
+        [JsonProperty("credential_type")]
+        public string CredentialType { get; set; }
+
+        /// <summary>
+        /// Friendly name for a credential.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// PEM-formatted public key (SPKI and PKCS1) or X509 certificate. Must be JSON escaped.
+        /// </summary>
+        [JsonProperty("pem")]
+        public string Pem { get; set; }
+
+        /// <summary>
+        /// Algorithm which will be used with the credential. Can be one of RS256, RS384, PS256.
+        /// If not specified, RS256 will be used.
+        /// </summary>
+        [JsonProperty("alg")]
+        public string Algorithm { get; set; }
+
+        /// <summary>
+        /// Parse expiry from x509 certificate. If true, attempts to parse the expiry date from the provided PEM.
+        /// </summary>
+        [JsonProperty("parse_expiry_from_cert")]
+        public bool ParseExpiryFromCert { get; set; }
+
+        /// <summary>
+        /// The ISO 8601 formatted date representing the expiration of the credential.
+        /// If not specified (not recommended), the credential never expires.
+        /// </summary>
+        [JsonProperty("expires_at")]
+        public DateTime? ExpiresAt { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Client/SignedRequestObject.cs
+++ b/src/Auth0.ManagementApi/Models/Client/SignedRequestObject.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    
+    /// <summary>
+    /// JWT-secured Authorization Requests (JAR) settings.
+    /// </summary>
+    public class SignedRequestObject
+    {
+        /// <summary>
+        /// Indicates whether the JAR requests are mandatory
+        /// </summary>
+        [JsonProperty("required")]
+        public bool? Required { get; set; }
+        
+        /// <summary>
+        /// List of <see cref="Credentials"/> for the JAR requests
+        /// </summary>
+        [JsonProperty("credentials")]
+        public IList<Credentials> Credentials { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/JwtConfiguration.cs
+++ b/src/Auth0.ManagementApi/Models/JwtConfiguration.cs
@@ -26,6 +26,7 @@ namespace Auth0.ManagementApi.Models
 
         /// <summary>
         /// The algorithm used to sign the JsonWebToken. Possible values are 'HS256' or 'RS256'.
+        /// 'PS256' available via addon.
         /// </summary>
         [JsonProperty("alg")]
         public string SigningAlgorithm { get; set; }

--- a/src/Auth0.ManagementApi/Models/ResourceServer/ConsentPolicy.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServer/ConsentPolicy.cs
@@ -1,0 +1,16 @@
+using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Possible values: [transactional-authorization-with-mfa, null]
+    /// </summary>
+    public enum ConsentPolicy
+    {
+        /// <summary>
+        /// Compliance Policy 'transactional-authorization-with-mfa'
+        /// </summary>
+        [EnumMember(Value = "transactional-authorization-with-mfa")]
+        TransactionalAuthorizationWithMfa,
+    }
+}

--- a/src/Auth0.ManagementApi/Models/ResourceServer/Mechanism.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServer/Mechanism.cs
@@ -1,0 +1,16 @@
+using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Intended mechanism for Proof-of-Possession
+    /// </summary>
+    public enum Mechanism
+    {
+        /// <summary>
+        /// Mechanism 'mtls'
+        /// </summary>
+        [EnumMember(Value = "mtls")]
+        Mtls,
+    }
+}

--- a/src/Auth0.ManagementApi/Models/ResourceServer/ProofOfPossession.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServer/ProofOfPossession.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Proof-of-Possession configuration for access tokens
+    /// </summary>
+    public class ProofOfPossession
+    {
+        /// <summary>
+        /// Whether the use of Proof-of-Possession is required for the resource server
+        /// </summary>
+        [JsonProperty("required")]
+        public bool? Required { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.Mechanism"/>
+        /// </summary>
+        [JsonProperty("mechanism")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public Mechanism Mechanism { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/ResourceServer/ResourceServerAuthorizationDetail.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServer/ResourceServerAuthorizationDetail.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// The valid authorization_detail definition
+    /// </summary>
+    public class ResourceServerAuthorizationDetail
+    {
+        /// <summary>
+        /// The authorization_detail type identifier
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; } 
+    }
+}

--- a/src/Auth0.ManagementApi/Models/ResourceServer/ResourceServerBase.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServer/ResourceServerBase.cs
@@ -25,7 +25,7 @@ namespace Auth0.ManagementApi.Models
         public List<ResourceServerScope> Scopes { get; set; }
 
         /// <summary>
-        /// The algorithm used to sign tokens
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.SigningAlgorithm"/>
         /// </summary>
         [JsonConverter(typeof(StringEnumConverter))]
         [JsonProperty("signing_alg")]
@@ -80,5 +80,30 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("enforce_policies")]
         public bool? EnforcePolicies { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.ConsentPolicy"/>
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("consent_policy")]
+        public ConsentPolicy? ConsentPolicy { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="ResourceServerAuthorizationDetail"/>
+        /// </summary>
+        [JsonProperty("authorization_details")]
+        public IList<ResourceServerAuthorizationDetail> AuthorizationDetails { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.TokenEncryption"/>
+        /// </summary>
+        [JsonProperty("token_encryption")]
+        public TokenEncryption TokenEncryption { get; set; }
+
+        /// <summary>
+        /// <inheritdoc cref="Auth0.ManagementApi.Models.ProofOfPossession"/>
+        /// </summary>
+        [JsonProperty("proof_of_possession")]
+        public ProofOfPossession ProofOfPossession { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/ResourceServer/TokenEncryption.cs
+++ b/src/Auth0.ManagementApi/Models/ResourceServer/TokenEncryption.cs
@@ -1,0 +1,68 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Token Encryption
+    /// </summary>
+    public class TokenEncryption
+    {
+        /// <summary>
+        /// <inheritdoc cref="TokenFormat"/> 
+        /// </summary>
+        [JsonProperty("format")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TokenFormat Format { get; set; }
+        
+        /// <summary>
+        /// <inheritdoc cref="TokenEncryptionKey"/>
+        /// </summary>
+        [JsonProperty("encryption_key")]
+        public TokenEncryptionKey EncryptionKey { get; set; }
+    }
+
+    /// <summary>
+    /// Format of the encrypted JWT payload.
+    /// </summary>
+    public enum TokenFormat
+    {
+        /// <summary>
+        /// Token Format 'compact-nested-jwe'
+        /// </summary>
+        [EnumMember(Value = "compact-nested-jwe")]
+        CompactNestedJwe,
+    }
+
+    /// <summary>
+    /// Encryption Key
+    /// </summary>
+    public class TokenEncryptionKey
+    {
+        /// <summary>
+        /// Name of the encryption key.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// Algorithm used to encrypt the token.
+        /// Possible values: [RSA-OAEP-256, RSA-OAEP-384, RSA-OAEP-512]
+        /// </summary>
+        [JsonProperty("alg")]
+        public string Algorithm { get; set; }
+        
+        /// <summary>
+        /// Key ID.
+        /// </summary>
+        [JsonProperty("kid")]
+        public string Kid { get; set; }
+        
+        /// <summary>
+        /// PEM-formatted public key. Must be JSON escaped.
+        /// </summary>
+        [JsonProperty("pem")]
+        public string Pem { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/SigningAlgorithm.cs
+++ b/src/Auth0.ManagementApi/Models/SigningAlgorithm.cs
@@ -1,7 +1,7 @@
 ﻿namespace Auth0.ManagementApi.Models
 {
     /// <summary>
-    /// Alogithm a token can be signed with.
+    /// Algorithm used to sign JWTs. Can be HS256 or RS256. PS256 available via addon.
     /// </summary>
     public enum SigningAlgorithm
     {
@@ -13,6 +13,11 @@
         /// <summary>
         /// RS256 asymmetrical (requires access to JWKS public keys)
         /// </summary>
-        RS256
+        RS256,
+        
+        /// <summary>
+        /// PS256 available via addon. 
+        /// </summary>
+        PS256
     }
 }

--- a/src/Auth0.ManagementApi/Models/Tenant/TenantFlags.cs
+++ b/src/Auth0.ManagementApi/Models/Tenant/TenantFlags.cs
@@ -132,5 +132,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("require_pushed_authorization_requests")]
         public bool? RequirePushedAuthorizationRequests { get; set; } = null;
+        
+        /// <summary>
+        /// Removes alg property from jwks .well-known endpoint
+        /// </summary>
+        [JsonProperty("remove_alg_from_jwks")]
+        public bool? RemoveAlgFromJwks { get; set; } = null;
     }
 }

--- a/src/Auth0.ManagementApi/Models/Tenant/TenantMtls.cs
+++ b/src/Auth0.ManagementApi/Models/Tenant/TenantMtls.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// mTLS configuration.
+    /// </summary>
+    public class TenantMtls
+    {
+        /// <summary>
+        /// If true, enables mTLS endpoint aliases
+        /// </summary>
+        [JsonProperty("enable_endpoint_aliases")]
+        public bool? EnableEndpointAliases { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Tenant/TenantSettingsBase.cs
+++ b/src/Auth0.ManagementApi/Models/Tenant/TenantSettingsBase.cs
@@ -130,5 +130,23 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("customize_mfa_in_postlogin_action")]
         public bool? CustomizeMfaInPostLoginAction { get; set; } = null;
+        
+        /// <summary>
+        /// Supported ACR values
+        /// </summary>
+        [JsonProperty("acr_values_supported")]
+        public string[] AcrValuesSupported { get; set; }
+        
+        /// <summary>
+        /// Enables the use of Pushed Authorization Requests
+        /// </summary>
+        [JsonProperty("pushed_authorization_requests_supported")]
+        public bool? PushedAuthorizationRequestsSupported { get; set; }
+
+        /// <summary>
+        /// mTLS configuration.
+        /// </summary>
+        [JsonProperty("mtls")]
+        public TenantMtls Mtls { get; set; }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Builders/UriBuildersTests.cs
@@ -303,5 +303,18 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Builders
 
             wsfedUrl.Should().Be(@"https://dx-sdks-testing.us.auth0.com/wsfed?wctx=xcrf%3Dabc%26ru%3D%2Ffoo");
         }
+        
+        [Fact]
+        public void Can_build_with_request()
+        {
+            var authenticationApiClient = new AuthenticationApiClient(GetVariable("AUTH0_AUTHENTICATION_API_URL"));
+
+            var wsfedUrl = authenticationApiClient.BuildAuthorizationUrl()
+                .WithClient("client-id")
+                .WithRequest("this-is-a-sample-jwt-request")
+                .Build();
+
+            wsfedUrl.Should().Be(@"https://dx-sdks-testing.us.auth0.com/authorize?client_id=client-id&request=this-is-a-sample-jwt-request");
+        }
     }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/PushedAuthorizationRequestTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/PushedAuthorizationRequestTests.cs
@@ -158,6 +158,8 @@ public class PushedAuthorizationRequestTests
             { "organization", "TEST_ORGANIZATION" },
             { "invitation", "TEST_INVITATION" },
             { "scope", "TEST_SCOPE" },
+            { "request", "TEST_REQUEST_JWT"},
+            { "authorization_details", "TEST_AUTHORIZATION_DETAILS"}
         };
 
         mockHandler.Protected()
@@ -185,7 +187,9 @@ public class PushedAuthorizationRequestTests
             Nonce = "TEST_NONCE",
             Organization = "TEST_ORGANIZATION",
             Invitation = "TEST_INVITATION",
-            Scope = "TEST_SCOPE"
+            Scope = "TEST_SCOPE",
+            Request = "TEST_REQUEST_JWT",
+            AuthorizationDetails = "TEST_AUTHORIZATION_DETAILS"
         });
 
         tokenReponse.Should().NotBeNull();

--- a/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TenantSettingsTests.cs
@@ -54,6 +54,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                         EnableAPIsSection = true,
                         EnableClientConnections = false,
                         EnablePipeline2 = true,
+                        RemoveAlgFromJwks = true
                     },
                     DeviceFlow = new TenantDeviceFlow()
                     {
@@ -64,7 +65,10 @@ namespace Auth0.ManagementApi.IntegrationTests
                     AllowedLogoutUrls = new string[] { "https://app.com/logout", "http://localhost/logout" },
                     SessionLifetime = 1080,
                     IdleSessionLifetime = 720,
-                    CustomizeMfaInPostLoginAction = true
+                    CustomizeMfaInPostLoginAction = true,
+                    AcrValuesSupported = new []{"value1", "value2"},
+                    PushedAuthorizationRequestsSupported = true,
+                    Mtls = new TenantMtls() { EnableEndpointAliases = true },
                 };
 
                 var settingsUpdateResponse = await apiClient.TenantSettings.UpdateAsync(settingsUpdateRequest);
@@ -80,6 +84,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 settingsUpdateResponse.Flags.EnableAPIsSection.Should().BeTrue();
                 settingsUpdateResponse.Flags.EnableClientConnections.Should().BeFalse();
                 settingsUpdateResponse.Flags.EnablePipeline2.Should().BeTrue();
+                settingsUpdateResponse.Flags.RemoveAlgFromJwks.Should().BeTrue();
                 settingsUpdateResponse.CustomizeMfaInPostLoginAction.Should().BeTrue();
                 settingsUpdateResponse.SessionCookie.Mode.Should().Be("persistent");
 
@@ -100,10 +105,17 @@ namespace Auth0.ManagementApi.IntegrationTests
                         Html = null,
                         Enabled = false,
                     },
+                    Flags = new TenantFlags()
+                    {
+                        RemoveAlgFromJwks = false
+                    },
                     FriendlyName = "Auth0.NET SDK integration test",
                     PictureUrl = "",
                     SupportEmail = "sdks@auth0.com",
                     SupportUrl = "",
+                    AcrValuesSupported = null,
+                    PushedAuthorizationRequestsSupported = false,
+                    Mtls = null,
                 };
 
                 await apiClient.TenantSettings.UpdateAsync(resetUpdateRequest);


### PR DESCRIPTION
### Changes

#### Management SDK changes :
##### Tenant level settings (`/api/v2/tenants/settings`)
  - Added support for `acr_values_supported` in `PATCH | GET`
  - Added support for `pushed_authorization_requests_supported` in `PATCH | GET`
  - Added support for below in `PATCH | GET`
```
"flags": {
    "remove_alg_from_jwks": true
}

```
- Added support for below in `PATCH | GET`
```
 "mtls": {
   "enable_endpoint_aliases": true
 }
```

##### Client Level settings
- Added support for `require_pushed_authorization_requests` in `POST /api/v2/clients` and `PATCH|GET /api/v2/clients/:id`
- Added support for `signed_request_object ` in `POST /api/v2/clients` and `PATCH|GET /api/v2/clients/:id`
- Added support for below in `POST PATCH|GET /api/v2/clients` and `PATCH|GET /api/v2/clients/:id`
```
	 "jwt_configuration": {
		 "alg": "PS256"
	 }
```
- Added support for `compliance_level` in `POST /api/v2/clients` and `PATCH|GET /api/v2/clients/:id` with the below possible values. 
  -  null
  - `none`
  - `fapi1_adv_pkj_par`
  - `fapi1_adv_mtls_par`
- Added support for new Client Authentication Methods `tls_client_auth` and `self_signed_tls_client_auth` in `POST /api/v2/clients` and `PATCH|GET /api/v2/clients/:id`
- Added support for `require_proof_of_possession` in `POST /api/v2/clients` and `PATCH|GET /api/v2/clients/:id`

##### Resource Level Settings in `POST /api/v2/resource-servers` and `PATCH|GET /api/v2/resource-servers/:id`
- Added support for `consent_policy` with `null` and `transactional-authorization-with-mfa` as possible values.
- Added support for `authorization_details`
- Added support to allow setting `PS256` in `signing_alg`
- Added support for `token_encryption`
- Added support for `proof_of_possession`

#### Authentication SDK changes
- Added support for JAR and RAR
- JAR with PAR

### References 📖 

- [Tenant Level Settings](https://auth0.com/docs/api/management/v2/tenants/tenant-settings-route) 
- [Client Level Settings](https://auth0.com/docs/api/management/v2/clients/get-clients)
- [Resource Level Settings](https://auth0.com/docs/api/management/v2/resource-servers/get-resource-servers)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
