### PR TITLE
Adds missing EmailTemplate types

### DIFF
--- a/src/Auth0.ManagementApi/Models/EmailTemplate/EmailTemplateName.cs
+++ b/src/Auth0.ManagementApi/Models/EmailTemplate/EmailTemplateName.cs
@@ -59,6 +59,24 @@ namespace Auth0.ManagementApi.Models
         /// This email will provide the MFA verification code to a user that is using a MFA email verifier. 
         /// </summary>
         [EnumMember(Value = "mfa_oob_code")]
-        MfaOobCode
+        MfaOobCode,
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        [EnumMember(Value = "verify_email_by_code")]
+        VerifyEmailByCode,
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        [EnumMember(Value = "reset_email_by_code")]
+        ResetEmailByCode,
+        
+        /// <summary>
+        /// 
+        /// </summary>
+        [EnumMember(Value = "user_invitation")]
+        UserInvitation
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/EmailTemplatesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/EmailTemplatesTests.cs
@@ -75,20 +75,12 @@ namespace Auth0.ManagementApi.IntegrationTests
                     });
                 }
                 
-
-                // Patch each template
-                foreach (var _emailTemplateName in emailTemplateNames)
+                var updatedTemplate = await fixture.ApiClient.EmailTemplates.PatchAsync(emailTemplate.Template, new EmailTemplatePatchRequest
                 {
-                    // Try and create the template. If it already exisits, we'll just update it
-                    var _emailTemplate = await fixture.ApiClient.EmailTemplates.PatchAsync(_emailTemplateName, new EmailTemplatePatchRequest
-                    {
-                        Enabled = false,
-                        From = "test2@test.com"
-                    });
-                }
+                    Enabled = false,
+                    From = "test2@test.com"
+                });
             }
-
         }
-
     }
 }


### PR DESCRIPTION
### Changes

Added the below missing Email Template Types: 
- `verify_email_by_code`
- `reset_email_by_code`
- `user_invitation`

### References

Initial Request -> [ESD-41983](https://auth0team.atlassian.net/browse/ESD-41983)
JIRA - [SDK-5124](https://auth0team.atlassian.net/browse/SDK-5124)

### Testing

- Extended existing test cases to use the above templates to Create / Update / Patch EmailTemplates.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[ESD-41983]: https://auth0team.atlassian.net/browse/ESD-41983?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-5124]: https://auth0team.atlassian.net/browse/SDK-5124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ