### PR TITLE
Adds support for BYOK end-points

### DIFF
--- a/src/Auth0.ManagementApi/Clients/IKeysClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IKeysClient.cs
@@ -4,6 +4,7 @@ namespace Auth0.ManagementApi.Clients
   using System.Threading;
   using System.Threading.Tasks;
   using Models.Keys;
+  using Paging;
 
   public interface IKeysClient
   {
@@ -36,5 +37,50 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>The revoked key's cert and kid.</returns>
     Task<RevokeSigningKeyResponse> RevokeSigningKeyAsync(string kid, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieve details of all the encryption keys associated with your tenant.
+    /// </summary>
+    /// <param name="pagination"><see cref="PaginationInfo"/></param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>Retrieve details of all the encryption keys associated with your tenant. <see cref="Auth0.ManagementApi.Models.EncryptionKey" />.</returns>
+    Task<IPagedList<EncryptionKey>> GetAllEncryptionKeysAsync(PaginationInfo pagination, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create the new, pre-activated encryption key, without the key material.
+    /// </summary>
+    /// <param name="request"><see cref="EncryptionKeyCreateRequest"/></param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>Newly created pre-activated encryption key <see cref="Auth0.ManagementApi.Models.EncryptionKey" />.</returns>
+    Task<EncryptionKey> CreateEncryptionKeyAsync(EncryptionKeyCreateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieve details of the encryption key with the given ID.
+    /// </summary>
+    /// <param name="request"><see cref="EncryptionKeyGetRequest"/></param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns>Retrieve details of the encryption key associated with the id. <see cref="Auth0.ManagementApi.Models.EncryptionKey" />.</returns>
+    Task<EncryptionKey> GetEncryptionKeyAsync(EncryptionKeyGetRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete the custom provided encryption key with the given ID and move back to using native encryption key.
+    /// </summary>
+    /// <param name="kid">Encryption key ID</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    Task DeleteEncryptionKeyAsync(string kid, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Import wrapped key material and activate encryption key.
+    /// </summary>
+    /// <param name="request"><see cref="EncryptionKeyImportRequest"/></param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    Task<EncryptionKey> ImportEncryptionKeyAsync(EncryptionKeyImportRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Create the public wrapping key to wrap your own encryption key material.
+    /// </summary>
+    /// <param name="request"><see cref="WrappingKeyCreateRequest"/></param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    Task<WrappingKey> CreatePublicWrappingKeyAsync(WrappingKeyCreateRequest request, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Models/Keys/EncryptionKey.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/EncryptionKey.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Net.Security;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Represents and Encryption Key
+    /// </summary>
+    public class EncryptionKey
+    {
+        /// <summary>
+        /// Key ID
+        /// </summary>
+        [JsonProperty("kid")]
+        public string Kid { get; set; }
+
+        /// <inheritdoc cref="EncryptionKeyType"/>
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EncryptionKeyType Type { get; set; }
+
+        /// <inheritdoc cref="EncryptionKeyState"/>
+        [JsonProperty("state")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EncryptionKeyState State { get; set; }
+
+        /// <summary>
+        /// Key creation timestamp
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime CreatedAt { get; set; }
+
+        /// <summary>
+        /// Key update timestamp
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTime UpdatedAt { get; set; }
+
+        /// <summary>
+        /// ID of the parent wrapping key.
+        /// </summary>
+        [JsonProperty("parent_kid")]
+        public string ParentKid { get; set; }
+
+        /// <summary>
+        /// Public key in PEM format
+        /// </summary>
+        [JsonProperty("public_key")]
+        public string PublicKey { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyCreateRequest.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Contains information required for creating an encryption key.
+    /// </summary>
+    public class EncryptionKeyCreateRequest
+    {
+        /// <summary>
+        /// Type of the encryption key to be created.
+        /// Possible values: [customer-provided-root-key, tenant-encryption-key]
+        /// </summary>
+        [JsonProperty("type")]
+        public string Type { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyGetRequest.cs
@@ -1,0 +1,13 @@
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Contains information required for getting an encryption key.
+    /// </summary>
+    public class EncryptionKeyGetRequest
+    {
+        /// <summary>
+        /// Encryption key ID.
+        /// </summary>
+        public string Kid { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyImportRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyImportRequest.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Contains information required for importing an encryption key.
+    /// </summary>
+    public class EncryptionKeyImportRequest
+    {
+        /// <summary>
+        /// Encryption key ID
+        /// </summary>
+        public string Kid { get; set; }
+        
+        /// <summary>
+        /// Base64 encoded ciphertext of key material wrapped by public wrapping key.
+        /// </summary>
+        [JsonProperty("wrapped_key")]
+        public string WrappedKey { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyState.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyState.cs
@@ -1,0 +1,22 @@
+using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Encryption Key State
+    /// </summary>
+    public enum EncryptionKeyState
+    {
+        [EnumMember(Value = "pre-activation")]
+        PreActivation,
+        
+        [EnumMember(Value = "active")]
+        Active,
+        
+        [EnumMember(Value = "deactivated")]
+        Deactivated,
+        
+        [EnumMember(Value = "destroyed")]
+        Destroyed,
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyType.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/EncryptionKeyType.cs
@@ -1,0 +1,22 @@
+using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Encryption Key Type
+    /// </summary>
+    public enum EncryptionKeyType
+    {
+        [EnumMember(Value = "customer-provided-root-key")]
+        CustomerProvidedRootKey,
+        
+        [EnumMember(Value = "environment-root-key")]
+        EnvironmentRootKey,
+        
+        [EnumMember(Value = "tenant-master-key")]
+        TenantMasterKey,
+        
+        [EnumMember(Value = "tenant-encryption-key")]
+        TenantEncryptionKey,
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Keys/WrappingKey.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/WrappingKey.cs
@@ -1,0 +1,22 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Represents the WrappingKey
+    /// </summary>
+    public class WrappingKey
+    {
+        /// <summary>
+        /// Public wrapping key in PEM format
+        /// </summary>
+        [JsonProperty("public_key")]
+        public string PublicKey { get; set; }
+        
+        /// <summary>
+        /// Encryption Algorithm that shall be used to wrap your key material
+        /// </summary>
+        [JsonProperty("algorithm")]
+        public string Algorithm { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Keys/WrappingKeyCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Keys/WrappingKeyCreateRequest.cs
@@ -1,0 +1,13 @@
+namespace Auth0.ManagementApi.Models.Keys
+{
+    /// <summary>
+    /// Contains information required for creating a wrapping key.
+    /// </summary>
+    public class WrappingKeyCreateRequest
+    {
+        /// <summary>
+        /// Encryption key ID
+        /// </summary>
+        public string Kid { get; set; }
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -22,7 +22,8 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Testing
                 new UsersCleanUpStrategy(client),
                 new RulesCleanUpStrategy(client),
                 new LogStreamsCleanUpStrategy(client),
-                new RolesCleanUpStrategy(client)
+                new RolesCleanUpStrategy(client),
+                new EncryptionKeysCleanupStrategy(client)
             };
 
             var cleanUpStrategy = strategies.Single(s => s.Type == type);

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
@@ -12,6 +12,7 @@
         Users,
         Roles,
         Rules,
-        LogStreams
+        LogStreams,
+        EncryptionKeys
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/EncryptionKeysCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/EncryptionKeysCleanUpStrategy.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Models.Actions;
+using Auth0.ManagementApi.Paging;
+using static System.Collections.Specialized.BitVector32;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class EncryptionKeysCleanupStrategy : CleanUpStrategy
+    {
+        public EncryptionKeysCleanupStrategy(ManagementApiClient apiClient) : base(CleanUpType.EncryptionKeys, apiClient)
+        {
+                
+        }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running EncryptionKeysCleanupStrategy");
+            await ApiClient.Keys.DeleteEncryptionKeyAsync(id);
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Auth0.ManagementApi.IntegrationTests.csproj
@@ -23,6 +23,9 @@
     <None Update="Data\GetActionsResponseWithIntegrationData.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Data\ImportEncryptionKeyResponse.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Auth0.ManagementApi.IntegrationTests/Data/ImportEncryptionKeyResponse.json
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Data/ImportEncryptionKeyResponse.json
@@ -1,0 +1,9 @@
+{
+  "kid": "093e36a8-88a1-4c34-8202-e454553ee2dc",
+  "type": "customer-provided-root-key",
+  "state": "destroyed",
+  "created_at": "2024-11-04T15:33:27.535Z",
+  "updated_at": "2024-11-04T15:33:32.274Z",
+  "parent_kid": "a20128c5-9bf5-4209-8c43-b6dfcee60e9b",
+  "public_key": "Random-PUBLIC-KEY"
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -21,7 +21,8 @@ namespace Auth0.ManagementApi.IntegrationTests.Testing
                 new UsersCleanUpStrategy(client),
                 new RulesCleanUpStrategy(client),
                 new LogStreamsCleanUpStrategy(client),
-                new RolesCleanUpStrategy(client)
+                new RolesCleanUpStrategy(client),
+                new EncryptionKeysCleanupStrategy(client)
             };
 
             var cleanUpStrategy = strategies.Single(s => s.Type == type);


### PR DESCRIPTION
### Changes

Added the following end-points : 
- `GET /api/v2/keys/encryption`
- `POST  /api/v2/keys/encryption`
- `GET  /api/v2/keys/encryption/{kid}`
- `DELETE  /api/v2/keys/encryption/{kid}`
- `POST  /api/v2/keys/encryption/{kid}`
- `POST  /api/v2/keys/encryption/{kid}/wrapping-key`

### References
- [/api/v2/keys/encryption](https://auth0.com/docs/api/management/v2/keys/get-encryption-keys)
- [/api/v2/keys/encryption](https://auth0.com/docs/api/management/v2/keys/post-encryption)
- [/api/v2/keys/encryption/{kid}](https://auth0.com/docs/api/management/v2/keys/get-encryption-key)
- [DELETE  /api/v2/keys/encryption/{kid}](https://auth0.com/docs/api/management/v2/keys/delete-encryption-key)
- [/api/v2/keys/encryption/{kid}](https://auth0.com/docs/api/management/v2/keys/post-encryption-key)
- [/api/v2/keys/encryption/{kid}/wrapping-key](https://auth0.com/docs/api/management/v2/keys/post-encryption-wrapping-key)
- JIRA -> [SDK-5122](https://auth0team.atlassian.net/browse/SDK-5122)

### Testing

Added the following test cases : 
- Test_encryption_keys_crud_sequence
    - Creates a encryption key
    - Gets the Created encryption key
    - Gets all the encryption keys present
    - Deletes the newly created encryption key
- Test_import_encrypted_keys
    - Tests that an imported key is parsed successfully.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5122]: https://auth0team.atlassian.net/browse/SDK-5122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ