### PR TITLE
Adds support for CYOK end-points

### DIFF
--- a/src/Auth0.ManagementApi/Clients/IKeysClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IKeysClient.cs
@@ -82,5 +82,11 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="request"><see cref="WrappingKeyCreateRequest"/></param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     Task<WrappingKey> CreatePublicWrappingKeyAsync(WrappingKeyCreateRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Perform rekeying operation on the key hierarchy.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    Task RekeyAsync(CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Clients/KeysClient.cs
+++ b/src/Auth0.ManagementApi/Clients/KeysClient.cs
@@ -160,10 +160,21 @@ namespace Auth0.ManagementApi.Clients
 
             if (string.IsNullOrEmpty(request.Kid))
                 throw new ArgumentNullException(nameof(request.Kid));
-            
+
             return Connection.SendAsync<WrappingKey>(
                 HttpMethod.Post,
                 BuildUri($"keys/encryption/{EncodePath(request.Kid)}/wrapping-key"),
+                body: null,
+                headers: DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc cref="IKeysClient.RekeyAsync"/>
+        public Task RekeyAsync(CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<object>(
+                HttpMethod.Post,
+                BuildUri("keys/encryption/rekey"),
                 body: null,
                 headers: DefaultHeaders,
                 cancellationToken: cancellationToken);


### PR DESCRIPTION
### Changes

The following endpoints are added : 
- `POST  /api/v2/keys/encryption/rekey`

### References

- [/api/v2/keys/encryption/rekey](https://auth0.com/docs/api/management/v2/keys/post-encryption-rekey)
- JIRA -> [SDK-5126](https://auth0team.atlassian.net/browse/SDK-5126)

### Testing
The following scenarios have been tested : 
- `Test_rekey_encrypted_keys` : Perform a rekey operation and ensure the Tenant Master Key is rotated. Additionally ensures the original Tenant Master Key is now destroyed.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5126]: https://auth0team.atlassian.net/browse/SDK-5126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ