### PR TITLE
Fix test cases failing due to Hooks and Rules becoming Read-Only

### DIFF
--- a/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/RulesTests.cs
@@ -35,7 +35,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             this.fixture = fixture;
         }
 
-        [Fact]
+        [Fact(Skip = "Rules have been deprecated as on 18th November 2024")]
         public async Task Test_rules_crud_sequence()
         {
             // Get all rules
@@ -111,7 +111,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             Assert.NotNull(rules.Paging);
         }
 
-        [Fact]
+        [Fact(Skip = "Rules have been deprecated as on 18th November 2024")]
         public async Task Test_without_paging()
         {
             // Add a new rule


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:
- From 18th November 2024, Hooks and Rules have become read-only for all customers following the deprecation of Hooks and Rules.
- We have modified the test cases, to work with existing hooks/rules since we cannot create new ones. 

### References

- [Hooks and Rules End Of Life (EOL)](https://auth0.com/docs/rules-best-practices)

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
