### PR TITLE
Adds support for managing custom-text and partial-prompts

### DIFF
--- a/src/Auth0.ManagementApi/Clients/IPromptsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IPromptsClient.cs
@@ -26,5 +26,39 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>The <see cref="Prompt"/> that was updated.</returns>
     Task<Prompt> UpdateAsync(PromptUpdateRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieve custom text for a specific prompt and language.
+    /// </summary>
+    /// <param name="promptName">Name of the prompt.</param>
+    /// <param name="language">Language to update.</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>An object containing custom dictionaries for a group of screens.</returns>
+    Task<object> GetCustomTextForPromptAsync(string promptName, string language, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Set custom text for a specific prompt. Existing texts will be overwritten.
+    /// </summary>
+    /// <param name="promptName">Name of the prompt.</param>
+    /// <param name="language">Language to update.</param>
+    /// <param name="customText">An object containing custom dictionaries for a group of screens.</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    Task SetCustomTextForPromptAsync(string promptName, string language, object customText, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Get template partials for a prompt
+    /// </summary>
+    /// <param name="promptName">Name of the prompt.</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>An object containing template partials for a group of screens.</returns>
+    Task<object> GetPartialsAsync(string promptName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Set template partials for a prompt
+    /// </summary>
+    /// <param name="promptName">Name of the prompt.</param>
+    /// <param name="partials">An object containing template partials for a group of screens.</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    Task SetPartialsAsync(string promptName, object partials, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Clients/PromptsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/PromptsClient.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Auth0.ManagementApi.Models.Prompts;
 
 namespace Auth0.ManagementApi.Clients
@@ -49,6 +50,63 @@ namespace Auth0.ManagementApi.Clients
         public Task<Prompt> UpdateAsync(PromptUpdateRequest request, CancellationToken cancellationToken = default)
         {
             return Connection.SendAsync<Prompt>(new HttpMethod("PATCH"), BuildUri($"{PromptsBasePath}"), request, DefaultHeaders, cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc cref="IPromptsClient.GetCustomTextForPromptAsync"/>
+        public Task<object> GetCustomTextForPromptAsync(string promptName, string language, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(promptName))
+                throw new ArgumentNullException(nameof(promptName));
+            if (string.IsNullOrEmpty(language))
+                throw new ArgumentNullException(nameof(language));
+            
+            return Connection.GetAsync<object>(
+                BuildUri($"{PromptsBasePath}/{promptName}/custom-text/{language}"),
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc cref="IPromptsClient.SetCustomTextForPromptAsync"/>
+        public Task SetCustomTextForPromptAsync(string promptName, string language, object customText,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(promptName))
+                throw new ArgumentNullException(nameof(promptName));
+            if (string.IsNullOrEmpty(language))
+                throw new ArgumentNullException(nameof(language));
+            
+            return Connection.SendAsync<object>(
+                HttpMethod.Put, 
+                BuildUri($"{PromptsBasePath}/{promptName}/custom-text/{language}"),
+                customText,
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc cref="IPromptsClient.GetPartialsAsync"/>
+        public Task<object> GetPartialsAsync(string promptName, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(promptName))
+                throw new ArgumentNullException(nameof(promptName));
+            
+            return Connection.GetAsync<object>(
+                BuildUri($"{PromptsBasePath}/{promptName}/partials"),
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
+        }
+        
+        /// <inheritdoc cref="IPromptsClient.SetPartialsAsync"/>
+        public Task SetPartialsAsync(string promptName, object partials, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(promptName))
+                throw new ArgumentNullException(nameof(promptName));
+            
+            return Connection.SendAsync<object>(
+                HttpMethod.Put, 
+                BuildUri($"{PromptsBasePath}/{promptName}/partials"),
+                partials,
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/PromptsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/PromptsTests.cs
@@ -1,8 +1,9 @@
-﻿using Auth0.Tests.Shared;
+﻿using System.Collections.Generic;
 using FluentAssertions;
 using System.Threading.Tasks;
 using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models.Prompts;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
@@ -36,6 +37,56 @@ namespace Auth0.ManagementApi.IntegrationTests
             prompts = await ApiClient.Prompts.GetAsync();
             prompts.Should().NotBeNull();
             prompts.UniversalLoginExperience.Should().Be(originalExperience);
+        }
+        
+        [Fact]
+        public async Task Test_set_and_get_custom_text_for_prompt()
+        {
+            var customText = new Dictionary<string, Dictionary<string,string>>()
+            {
+                { "login", new Dictionary<string, string>()
+                    {
+                        { "title", "welcome to auth0" }
+                    } 
+                }
+            };
+            await ApiClient.Prompts.SetCustomTextForPromptAsync("login", "en", customText);
+            
+            var updatedCustomText = await ApiClient.Prompts.GetCustomTextForPromptAsync("login", "en");
+
+            updatedCustomText.Should().NotBeNull();
+            var udpatedCustomTextObject = 
+                JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string,string>>>(
+                    updatedCustomText?.ToString()); 
+            customText.Should().BeEquivalentTo(udpatedCustomTextObject);
+        }
+        
+        [Fact]
+        public async Task Test_set_and_get_partials()
+        {
+            string token = await GenerateBruckeManagementApiToken();
+
+            using (var apiClient = new ManagementApiClient(token, GetVariable("BRUCKE_MANAGEMENT_API_URL")))
+            {
+                var partial = new Dictionary<string, Dictionary<string,string>>()
+                {
+                    { "signup-id", new Dictionary<string, string>()
+                        {
+                            { "form-content-start", "<div>HTML or Liquid</div>" },
+                            { "form-content-end", "<div>HTML or Liquid</div>" }
+                        } 
+                    }
+                };
+                await apiClient.Prompts.SetPartialsAsync("signup-id", partial);
+            
+                var updatedPartials = await apiClient.Prompts.GetPartialsAsync("signup-id");
+
+                updatedPartials.Should().NotBeNull();
+                var updatedPartialsObject = 
+                    JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string,string>>>(
+                        updatedPartials?.ToString()); 
+                partial.Should().BeEquivalentTo(updatedPartialsObject);
+            }
         }
     }
 }


### PR DESCRIPTION
### Changes

Added the following end points for managing custom-text and partial prompts
- [GET  /api/v2/prompts/{prompt}/custom-text/{language}](https://auth0.com/docs/api/management/v2/prompts/get-custom-text-by-language)
- [PUT  /api/v2/prompts/{prompt}/custom-text/{language}](https://auth0.com/docs/api/management/v2/prompts/put-custom-text-by-language)
- [GET  /api/v2/prompts/{prompt}/partials](https://auth0.com/docs/api/management/v2/prompts/get-partials)
- [PUT  /api/v2/prompts/{prompt}/partials](https://auth0.com/docs/api/management/v2/prompts/put-partials)

### References

Please include relevant links supporting this change such as a:
- [Auth0 Management SDK Docs](https://auth0.com/docs/api/management/v2/prompts/put-partials)
- JIRA - [SDK-5183](https://auth0team.atlassian.net/browse/SDK-5183)

### Testing
- Following test cases have been added : 
    - `Test_set_and_get_custom_text_for_prompt` : sets and gets custom-text for `login` prompt
    -  `Test_set_and_get_partials` : sets and gets partials for `signup-id`

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5183]: https://auth0team.atlassian.net/browse/SDK-5183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ