### PR TITLE
Adds support for CIBA

### DIFF
--- a/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
+++ b/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
@@ -87,10 +87,15 @@ namespace Auth0.AuthenticationApi
 
                 var content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
-                return typeof(T) == typeof(string)
-                    ? (T)(object)content
-                    : JsonConvert.DeserializeObject<T>(content, jsonSerializerSettings);
+                return DeserializeContent<T>(content);
             }
+        }
+
+        internal T DeserializeContent<T>(string content)
+        {
+            return typeof(T) == typeof(string)
+                ? (T)(object)content
+                : JsonConvert.DeserializeObject<T>(content, jsonSerializerSettings);
         }
 
         private void ApplyHeaders(HttpRequestMessage request, IDictionary<string, string> headers)

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Auth0.AuthenticationApi.Models.Ciba;
 
 namespace Auth0.AuthenticationApi
 {
@@ -180,5 +181,27 @@ namespace Auth0.AuthenticationApi
         /// a <see cref="PushedAuthorizationRequestResponse" /> with the details of the response.</returns>
         Task<PushedAuthorizationRequestResponse> PushedAuthorizationRequestAsync(PushedAuthorizationRequest request,
             CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Initiates a Client Initiated Backchannel Authorization flow.
+        /// </summary>
+        /// <param name="request"><see cref="ClientInitiatedBackchannelAuthorizationRequest"/></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns><see cref="Task"/> representing the async operation containing 
+        /// a <see cref="ClientInitiatedBackchannelAuthorizationResponse" /> with the details of the response.</returns>
+        Task<ClientInitiatedBackchannelAuthorizationResponse> ClientInitiatedBackchannelAuthorization(ClientInitiatedBackchannelAuthorizationRequest request,
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Requests an Access Token using the CIBA flow
+        /// </summary>
+        /// <param name="request"><see cref="ClientInitiatedBackchannelAuthorizationTokenRequest"/></param>
+        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+        /// <returns><see cref="Task"/> representing the async operation containing 
+        /// a <see cref="ClientInitiatedBackchannelAuthorizationTokenResponse" /> with the requested tokens.</returns>
+        /// <remarks>
+        /// This must be polled while the user is completing their part of the flow at an interval no more frequent than that returned by <see cref="ClientInitiatedBackchannelAuthorizationResponse"/>.
+        /// </remarks>
+        Task<ClientInitiatedBackchannelAuthorizationTokenResponse> GetTokenAsync(ClientInitiatedBackchannelAuthorizationTokenRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationRequest.cs
@@ -1,0 +1,53 @@
+using System.Collections.Generic;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AuthenticationApi.Models.Ciba
+{
+    /// <summary>
+    /// Contains information required for initiating a CIBA authorization request.
+    /// </summary>
+    public class ClientInitiatedBackchannelAuthorizationRequest : IClientAuthentication
+    {
+        /// <inheritdoc cref="IClientAuthentication.ClientId"/>
+        public string ClientId { get; set; }
+        
+        /// <inheritdoc cref="IClientAuthentication.ClientSecret"/>
+        public string ClientSecret { get; set; }
+        
+        /// <inheritdoc cref="IClientAuthentication.ClientAssertionSecurityKey"/>
+        public SecurityKey ClientAssertionSecurityKey { get; set; }
+        
+        /// <inheritdoc cref="IClientAuthentication.ClientAssertionSecurityKeyAlgorithm"/>
+        public string ClientAssertionSecurityKeyAlgorithm { get; set; }
+        
+        /// <summary>
+        /// A human-readable string intended to be displayed on both the device calling /bc-authorize and
+        /// the user’s authentication device (e.g. phone) to ensure the user is approving the correct request.
+        /// For example: “ABC-123-XYZ”.
+        /// </summary>
+        public string BindingMessage { get; set; }
+        
+        /// <inheritdoc cref="Ciba.LoginHint"/>
+        public LoginHint LoginHint { get; set; }
+        
+        /// <summary>
+        /// A space-separated list of OIDC and custom API scopes.
+        /// </summary>
+        public string Scope { get; set; }
+        
+        /// <summary>
+        /// If you require an access token for an API, pass the unique identifier of the target API you want to access here
+        /// </summary>
+        public string Audience { get; set; }
+        
+        /// <summary>
+        /// Used to configure a custom expiry time for this request.
+        /// </summary>
+        public int? RequestExpiry { get; set; }
+        
+        /// <summary>
+        /// Any additional properties to use.
+        /// </summary>
+        public IDictionary<string, string> AdditionalProperties { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationResponse.cs
@@ -1,0 +1,28 @@
+using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models.Ciba
+{
+    /// <summary>
+    /// Contains information about the client initiated backchannel authorization (CIBA) response.
+    /// </summary>
+    public class ClientInitiatedBackchannelAuthorizationResponse
+    {
+        /// <summary>
+        /// Unique id of the authorization request. Can be used further to poll for /oauth/token.
+        /// </summary>
+        [JsonProperty("auth_req_id")]
+        public string AuthRequestId { get; set; }
+        
+        /// <summary>
+        /// Tells you how many seconds we have until the authentication request expires. 
+        /// </summary>
+        [JsonProperty("expires_in")]
+        public int ExpiresIn { get; set; }
+        
+        /// <summary>
+        /// Tells how many seconds you must leave between poll requests.
+        /// </summary>
+        [JsonProperty("interval")]
+        public int Interval { get; set; }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenRequest.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AuthenticationApi.Models.Ciba
+{
+    /// <summary>
+    /// Contains information required for request token using CIBA.
+    /// </summary>
+    public class ClientInitiatedBackchannelAuthorizationTokenRequest : IClientAuthentication
+    {
+        /// <inheritdoc cref="IClientAuthentication.ClientId"/>
+        public string ClientId { get; set; }
+
+        /// <inheritdoc cref="IClientAuthentication.ClientSecret"/>
+        public string ClientSecret { get; set; }
+        
+        /// <inheritdoc cref="IClientAuthentication.ClientAssertionSecurityKey"/>
+        public SecurityKey ClientAssertionSecurityKey { get; set; }
+        
+        /// <inheritdoc cref="IClientAuthentication.ClientAssertionSecurityKeyAlgorithm"/>
+        public string ClientAssertionSecurityKeyAlgorithm { get; set; }
+
+        /// <summary>
+        /// Unique identifier of the authorization request. This value will be returned from the call to /bc-authorize.
+        /// </summary>
+        public string AuthRequestId { get; set; }
+        
+        /// <summary>
+        /// Any additional properties to use.
+        /// </summary>
+        public IDictionary<string, string> AdditionalProperties { get; set; } = new Dictionary<string, string>();
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenResponse.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models.Ciba
+{
+    public class ClientInitiatedBackchannelAuthorizationTokenResponse : AccessTokenResponse
+    {
+        [JsonProperty("scope")]
+        public string Scope { get; set; }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Models/Ciba/LoginHint.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/LoginHint.cs
@@ -1,0 +1,24 @@
+using Newtonsoft.Json;
+
+namespace Auth0.AuthenticationApi.Models.Ciba
+{
+    /// <summary>
+    /// Contains information about the user to contact for authentication.
+    /// </summary>
+    public class LoginHint
+    {
+        [JsonProperty("format")]
+        public string Format { get; set; }
+        
+        [JsonProperty("iss")]
+        public string Issuer { get; set; }
+        
+        [JsonProperty("sub")]
+        public string Subject { get; set; }
+
+        public override string ToString()
+        {
+            return JsonConvert.SerializeObject(this);
+        }
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using FluentAssertions;
+using Auth0.AuthenticationApi.Models.Ciba;
+using Auth0.Core.Exceptions;
+using Auth0.Tests.Shared;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests;
+
+public class ClientInitiatedBackchannelAuthorizationTests : TestBase
+{
+    [Fact]
+    public async void Ciba_request_should_succeed()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var mockResponse = new ClientInitiatedBackchannelAuthorizationResponse()
+        {
+            AuthRequestId = "Random-Guid",
+            ExpiresIn = 300
+        };
+        
+        var mockTokenResponse = new ClientInitiatedBackchannelAuthorizationTokenResponse()
+        {
+            AccessToken = "This is a mock access_token",
+            IdToken = "This is a mock ID token",
+            ExpiresIn = 300,
+            Scope = "openid"
+        };
+        var domain = GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        
+        SetupMockWith(mockHandler,$"https://{domain}/bc-authorize", JsonConvert.SerializeObject(mockResponse));
+        SetupMockWith(mockHandler,$"https://{domain}/oauth/token", JsonConvert.SerializeObject(mockTokenResponse));
+        
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var response = await authenticationApiClient.ClientInitiatedBackchannelAuthorization(
+            new ClientInitiatedBackchannelAuthorizationRequest()
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                Scope = "openid profile",
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                BindingMessage = "BindingMessage",
+                LoginHint = new LoginHint()
+                {
+                    Format = "iss_sub",
+                    Issuer = "https://dx-sdks-testing.us.auth0.com/",
+                    Subject = "auth0|6746de965777c7fc70547a11"
+                }
+            }
+        );
+
+        response.ExpiresIn.Should().Be(300);
+        response.AuthRequestId.Should().Be("Random-Guid");
+
+        var cibaTokenResponse = await authenticationApiClient.GetTokenAsync(
+            new ClientInitiatedBackchannelAuthorizationTokenRequest()
+            {
+                AuthRequestId = "Random-Guid",
+                ClientId = "ClientId",
+                ClientSecret = "ClientSecret"
+            }
+        );
+        cibaTokenResponse.Should().BeEquivalentTo(cibaTokenResponse);
+        mockHandler.VerifyAll();
+    }
+    
+    [Fact]
+    public async void Ciba_request_in_pending_state()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var mockResponse = new ClientInitiatedBackchannelAuthorizationResponse()
+        {
+            AuthRequestId = "Random-Guid",
+            ExpiresIn = 300
+        };
+
+        var mockTokenResponse =
+            "{\"error\": \"authorization_pending\",\n\"error_description\": \"The end-user authorization is pending\"\n}";
+        
+        var domain = GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        
+        SetupMockWith(mockHandler,$"https://{domain}/bc-authorize", JsonConvert.SerializeObject(mockResponse));
+        SetupMockWith(mockHandler,$"https://{domain}/oauth/token", JsonConvert.SerializeObject(mockTokenResponse), HttpStatusCode.BadRequest);
+        
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var response = await authenticationApiClient.ClientInitiatedBackchannelAuthorization(
+            new ClientInitiatedBackchannelAuthorizationRequest()
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                Scope = "openid profile",
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                BindingMessage = "BindingMessage",
+                LoginHint = new LoginHint()
+                {
+                    Format = "iss_sub",
+                    Issuer = "https://dx-sdks-testing.us.auth0.com/",
+                    Subject = "auth0|6746de965777c7fc70547a11"
+                }
+            }
+        );
+
+        response.ExpiresIn.Should().Be(300);
+        response.AuthRequestId.Should().Be("Random-Guid");
+
+        var ex = await Assert.ThrowsAsync<ErrorApiException>(() => authenticationApiClient.GetTokenAsync(
+            new ClientInitiatedBackchannelAuthorizationTokenRequest()
+            {
+                AuthRequestId = "Random-Guid",
+                ClientId = "ClientId",
+                ClientSecret = "ClientSecret"
+            }
+        ));
+        mockHandler.VerifyAll();
+    }
+    
+    [Fact]
+    public async void Ciba_request_in_expired_or_rejected_state()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var mockResponse = new ClientInitiatedBackchannelAuthorizationResponse()
+        {
+            AuthRequestId = "Random-Guid",
+            ExpiresIn = 300
+        };
+
+        var mockTokenResponse =
+            "{\n\"error\": \"access_denied\",\n\"error_description\": \"The end-user denied the authorization request or it\nhas been expired\"\n}";
+        
+        var domain = GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        
+        SetupMockWith(mockHandler,$"https://{domain}/bc-authorize", JsonConvert.SerializeObject(mockResponse));
+        SetupMockWith(mockHandler,$"https://{domain}/oauth/token", JsonConvert.SerializeObject(mockTokenResponse), HttpStatusCode.BadRequest);
+        
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var response = await authenticationApiClient.ClientInitiatedBackchannelAuthorization(
+            new ClientInitiatedBackchannelAuthorizationRequest()
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                Scope = "openid profile",
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                BindingMessage = "BindingMessage",
+                LoginHint = new LoginHint()
+                {
+                    Format = "iss_sub",
+                    Issuer = "https://dx-sdks-testing.us.auth0.com/",
+                    Subject = "auth0|6746de965777c7fc70547a11"
+                }
+            }
+        );
+
+        response.ExpiresIn.Should().Be(300);
+        response.AuthRequestId.Should().Be("Random-Guid");
+
+        var ex = await Assert.ThrowsAsync<ErrorApiException>(() => authenticationApiClient.GetTokenAsync(
+            new ClientInitiatedBackchannelAuthorizationTokenRequest()
+            {
+                AuthRequestId = "Random-Guid",
+                ClientId = "ClientId",
+                ClientSecret = "ClientSecret"
+            }
+        ));
+        mockHandler.VerifyAll();
+    }
+
+    private static void SetupMockWith(Mock<HttpMessageHandler> mockHandler, string domain, string stringContent, HttpStatusCode code = HttpStatusCode.OK)
+    {
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == domain),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = code,
+                Content = new StringContent(stringContent, Encoding.UTF8, "application/json"),
+            });
+    }
+}


### PR DESCRIPTION
### Changes

- Added support for Client Initiated Backchannel Authorization.
- A new end-point added for this purpose
   - `/bc-authorize`
   - A new variant of `GetTokenAsync` Added for fetching the CIBA response.

### References
- JIRA -> [SDK-5208](https://auth0team.atlassian.net/browse/SDK-5208)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5208]: https://auth0team.atlassian.net/browse/SDK-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ