### PR TITLE
Add support to Update a Custom Domain

### DIFF
--- a/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/CustomDomainsClient.cs
@@ -77,5 +77,11 @@ namespace Auth0.ManagementApi.Clients
         {
             return Connection.SendAsync<CustomDomainVerificationResponse>(HttpMethod.Post, BuildUri($"custom-domains/{EncodePath(id)}/verify"), null, DefaultHeaders, cancellationToken: cancellationToken);
         }
+        
+        /// <inheritdoc />
+        public Task<CustomDomain> UpdateAsync(string id, CustomDomainUpdateRequest request, CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<CustomDomain>(new HttpMethod("PATCH"), BuildUri($"custom-domains/{EncodePath(id)}"), request, DefaultHeaders, cancellationToken: cancellationToken);
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ICustomDomainsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ICustomDomainsClient.cs
@@ -46,5 +46,14 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns>The <see cref="CustomDomainVerification"/> that was requested.</returns>
     Task<CustomDomainVerificationResponse> VerifyAsync(string id, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Update a custom domain.
+    /// </summary>
+    /// <param name="id">The ID of the domain to update.</param>
+    /// <param name="request"><see cref="CustomDomainUpdateRequest"/></param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>Updated <see cref="CustomDomain"/></returns>
+    Task<CustomDomain> UpdateAsync(string id, CustomDomainUpdateRequest request, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainBase.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainBase.cs
@@ -51,5 +51,19 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("verification")]
         public CustomDomainVerification Verification { get; set; }
+        
+        /// <summary>
+        /// Possible values: [recommended, compatible]
+        /// recommended includes TLS 1.2
+        /// </summary>
+        [JsonProperty("tls_policy")]
+        public string TlsPolicy { get; set; }
+        
+        /// <summary>
+        /// Possible values: [true-client-ip, cf-connecting-ip, x-forwarded-for, x-azure-clientip, null]
+        /// HTTP header to fetch client IP header. Ex: CF-Connecting-IP, X-Forwarded-For or True-Client-IP.
+        /// </summary>
+        [JsonProperty("custom_client_ip_header")]
+        public string CustomClientIpHeader { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainCreateRequest.cs
@@ -26,5 +26,19 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("verification_method")]
         public string VerificationMethod { get; set; }
+        
+        /// <summary>
+        /// Possible values: [recommended, compatible]
+        /// recommended includes TLS 1.2
+        /// </summary>
+        [JsonProperty("tls_policy")]
+        public string TlsPolicy { get; set; }
+        
+        /// <summary>
+        /// Possible values: [true-client-ip, cf-connecting-ip, x-forwarded-for, x-azure-clientip, null]
+        /// HTTP header to fetch client IP header. Ex: CF-Connecting-IP, X-Forwarded-For or True-Client-IP.
+        /// </summary>
+        [JsonProperty("custom_client_ip_header")]
+        public string CustomClientIpHeader { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainUpdateRequest.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class CustomDomainUpdateRequest
+    {
+        /// <summary>
+        /// Possible values: [recommended]
+        /// recommended includes TLS 1.2
+        /// </summary>
+        [JsonProperty("tls_policy")]
+        public string TlsPolicy { get; set; }
+        
+        /// <summary>
+        /// Possible values: [true-client-ip, cf-connecting-ip, x-forwarded-for, x-azure-clientip, null]
+        /// HTTP header to fetch client IP header. Ex: CF-Connecting-IP, X-Forwarded-For or True-Client-IP.
+        /// </summary>
+        [JsonProperty("custom_client_ip_header")]
+        public string CustomClientIpHeader { get; set; }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/CustomDomainsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/CustomDomainsTests.cs
@@ -30,6 +30,18 @@ namespace Auth0.ManagementApi.IntegrationTests
                 var domain = await apiClient.CustomDomains.GetAsync(id);
                 domain.Should().NotBeNull();
                 domain.CustomDomainId.Should().Be(id);
+                
+                // Test updating a custom domain
+                var updateRequest = new CustomDomainUpdateRequest()
+                {
+                    TlsPolicy = "recommended",
+                    CustomClientIpHeader = null
+                };
+
+                var updatedCustomDomain = await apiClient.CustomDomains.UpdateAsync(id, updateRequest);
+                updatedCustomDomain.Should().NotBeNull();
+                updatedCustomDomain.CustomClientIpHeader.Should().Be(updateRequest.CustomClientIpHeader);
+                updatedCustomDomain.TlsPolicy.Should().Be(updateRequest.TlsPolicy);
 
                 string non_existent_id = "cd_XXw4P8C04x1Aa9e5";
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- [PATCH  /api/v2/custom-domains/{id}](https://auth0.com/docs/api/management/v2/custom-domains/patch-custom-domains-by-id)
- Added `tls_policy` and `custom_client_ip_header` fields in the models that were missing them.

### References

Please include relevant links supporting this change such as a:
- [SDK-5495](https://auth0team.atlassian.net/browse/SDK-5495)

### Testing
Tests for custom domains are limited. We cannot test full CRUD sequence because the tenants allow for only one custom domain and others depend on that domain.
We are therefore limited in scope to what we can test. 
For now, we have updated the test that we run manually to verify that the basic serialization and the GET methods work properly.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5495]: https://auth0team.atlassian.net/browse/SDK-5495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ