### PR TITLE
Adds CnameApiKey to CustomDomainVerificationResponse (#757)

### DIFF
--- a/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainVerificationResponse.cs
+++ b/src/Auth0.ManagementApi/Models/CustomDomain/CustomDomainVerificationResponse.cs
@@ -1,10 +1,16 @@
-﻿namespace Auth0.ManagementApi.Models
+﻿using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
 {
     /// <summary>
     /// Response when requesting a custom domain verification
     /// </summary>
     public class CustomDomainVerificationResponse : CustomDomainBase
     {
-        
+        /// <summary>
+        /// The CNAME API key header value.
+        /// </summary>
+        [JsonProperty("cname_api_key")]
+        public string CnameApiKey { get; set; }
     }
 }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. 

- Added `CnameApiKey` property to `CustomDomainVerificationResponse` class to support _self-managed certificates_

### References

- #757
- [POST /custom-domains/:id/verify](https://auth0.com/docs/api/management/v2/custom-domains/post-verify#response-schemas)

### Testing

Custom domain tests are limited, as described by the [existing tests](https://github.com/auth0/auth0.net/blob/ee4bc1982f26d36585716d9c7a12bf9216f5e8d6/tests/Auth0.ManagementApi.IntegrationTests/CustomDomainsTests.cs), which must be run manually.  Since no other tests exist to test rudimentary serialization, no tests were added.

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
