### PR TITLE
Add support to manage /flows endpoints

### DIFF
--- a/src/Auth0.ManagementApi/Clients/FlowsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/FlowsClient.cs
@@ -1,0 +1,295 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Newtonsoft.Json;
+
+using Auth0.ManagementApi.Models.Flow;
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.ManagementApi.Clients
+{
+    public class FlowsClient : BaseClient, IFlowsClient
+    {
+        private readonly JsonConverter[] _flowsConverters = { new PagedListConverter<Flow>("flows") };
+        private readonly JsonConverter[] _flowVaultConnectionConverters = 
+            { new PagedListConverter<FlowVaultConnection>("connections") };
+        private readonly JsonConverter[] _paginationFlowExecutionConverters = { new PagedListConverter<FlowExecution>("executions") };
+        private readonly JsonConverter[] _checkpointPaginationFlowExecutionConverters = { new CheckpointPagedListConverter<FlowExecution>("executions") };
+        
+        /// <summary>
+        /// Initializes a new instance of <see cref="FlowsClient"/>
+        /// </summary>
+        /// <param name="connection"><see cref="IManagementConnection"/></param>
+        /// <param name="baseUri"><see cref="Uri"/></param>
+        /// <param name="defaultHeaders">Default headers</param>
+        public FlowsClient(
+            IManagementConnection connection, Uri baseUri, IDictionary<string, string> defaultHeaders) : base(
+            connection, baseUri, defaultHeaders)
+        {
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<Flow>> GetAllAsync(FlowGetRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var queryStrings = new Dictionary<string, string>();
+
+            if (request.Hydrate != null && request.Hydrate.Any())
+            {
+                var hydrateValues = string.Join(",",  request.Hydrate.Select( x => x.ToString().ToLower()));
+                queryStrings["hydrate"] = hydrateValues;
+            }
+
+            if (request.PaginationInfo != null)
+            {
+                queryStrings["page"] = request.PaginationInfo.PageNo.ToString();
+                queryStrings["per_page"] = request.PaginationInfo.PerPage.ToString();
+                queryStrings["include_totals"] = request.PaginationInfo.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<Flow>>(
+                BuildUri("flows", queryStrings),
+                DefaultHeaders,
+                _flowsConverters,
+                cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<Flow> CreateAsync(FlowCreateRequest request, CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<Flow>(
+                HttpMethod.Post,
+                BuildUri("flows"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+        
+        /// <inheritdoc />
+        public Task<Flow> GetAsync(FlowGetRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            
+            if (string.IsNullOrEmpty(request.Id))
+                throw new ArgumentNullException(nameof(request.Id));
+            
+            var queryStrings = new Dictionary<string, string>();
+
+            if (request.Hydrate != null && request.Hydrate.Any())
+            {
+                var hydrateValues = string.Join(",",  request.Hydrate.Select( x => x.ToString().ToLower()));
+                queryStrings["hydrate"] = hydrateValues;
+            }
+
+            return Connection.GetAsync<Flow>(
+                BuildUri($"flows/{EncodePath(request.Id)}", queryStrings),
+                DefaultHeaders,
+                null,
+                cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<Flow> UpdateAsync(
+            string id, FlowUpdateRequest request, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection.SendAsync<Flow>(
+                new HttpMethod("PATCH"),
+                BuildUri($"flows/{EncodePath(id)}"),
+                request, 
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task DeleteAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection.SendAsync<object>(
+                HttpMethod.Delete,
+                BuildUri($"flows/{EncodePath(id)}"),
+                null,
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<IPagedList<FlowVaultConnection>> GetAllFlowVaultConnectionsAsync(
+            FlowVaultConnectionGetRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+
+            var queryStrings = new Dictionary<string, string>();
+            
+            if (request.PaginationInfo != null)
+            {
+                queryStrings["page"] = request.PaginationInfo.PageNo.ToString();
+                queryStrings["per_page"] = request.PaginationInfo.PerPage.ToString();
+                queryStrings["include_totals"] = request.PaginationInfo.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<FlowVaultConnection>>(
+                BuildUri("flows/vault/connections", queryStrings),
+                DefaultHeaders,
+                _flowVaultConnectionConverters,
+                cancellationToken);        
+        }
+
+        /// <inheritdoc />
+        public Task<FlowVaultConnection> CreateVaultConnectionAsync(
+            FlowVaultConnectionCreateRequest request, CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<FlowVaultConnection>(
+                HttpMethod.Post,
+                BuildUri("flows/vault/connections"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<FlowVaultConnection> GetFlowVaultConnectionAsync(
+            FlowVaultConnectionGetRequest request, CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            
+            if (string.IsNullOrEmpty(request.Id))
+                throw new ArgumentNullException(nameof(request.Id));
+
+            return Connection.GetAsync<FlowVaultConnection>(
+                BuildUri($"flows/vault/connections/{EncodePath(request.Id)}"),
+                DefaultHeaders,
+                null,
+                cancellationToken);        
+        }
+
+        /// <inheritdoc />
+        public Task<FlowVaultConnection> UpdateFlowVaultConnectionAsync(
+            string id,
+            FlowVaultConnectionUpdateRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection.SendAsync<FlowVaultConnection>(
+                new HttpMethod("PATCH"),
+                BuildUri($"flows/vault/connections/{EncodePath(id)}"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+        
+        /// <inheritdoc />
+        public Task DeleteFlowVaultConnectionAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection.SendAsync<object>(
+                HttpMethod.Delete,
+                BuildUri($"flows/vault/connections/{EncodePath(id)}"),
+                null,
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
+        }
+        
+        /// <inheritdoc />
+        public Task<IPagedList<FlowExecution>> GetAllFlowExecutionsAsync(string flowId, PaginationInfo paginationInfo,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(flowId))
+                throw new ArgumentNullException(nameof(flowId));
+
+            var queryStrings = new Dictionary<string, string>();
+
+            if (paginationInfo != null)
+            {
+                queryStrings["page"] = paginationInfo.PageNo.ToString();
+                queryStrings["per_page"] = paginationInfo.PerPage.ToString();
+                queryStrings["include_totals"] = paginationInfo.IncludeTotals.ToString().ToLower();
+            }
+
+            return Connection.GetAsync<IPagedList<FlowExecution>>(
+                BuildUri($"flows/{EncodePath(flowId)}/executions", queryStrings),
+                DefaultHeaders,
+                _paginationFlowExecutionConverters,
+                cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<ICheckpointPagedList<FlowExecution>> GetAllFlowExecutionsAsync(string flowId,
+            CheckpointPaginationInfo paginationInfo,
+            CancellationToken cancellationToken = default)
+        {
+            var queryStrings = new Dictionary<string, string>();
+            
+            if(paginationInfo != null)
+            {
+                queryStrings["from"] = paginationInfo.From?.ToString();
+                queryStrings["take"] = paginationInfo.Take.ToString();
+            };
+            return Connection.GetAsync<ICheckpointPagedList<FlowExecution>>(
+                BuildUri($"flows/{EncodePath(flowId)}/executions", queryStrings),
+                DefaultHeaders,
+                _checkpointPaginationFlowExecutionConverters, 
+                cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<FlowExecution> GetFlowExecutionAsync(
+            string flowId, string executionId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(flowId))
+                throw new ArgumentNullException(nameof(flowId));
+            
+            if (string.IsNullOrEmpty(executionId))
+                throw new ArgumentNullException(nameof(executionId));
+
+            return Connection.GetAsync<FlowExecution>(
+                BuildUri($"flows/{EncodePath(flowId)}/executions/{EncodePath(executionId)}"),
+                DefaultHeaders,
+                null,
+                cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task DeleteFlowExecutionAsync(
+            string flowId, string executionId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(flowId))
+                throw new ArgumentNullException(nameof(flowId));
+            
+            if (string.IsNullOrEmpty(executionId))
+                throw new ArgumentNullException(nameof(executionId));
+            
+            return Connection.SendAsync<object>(
+                HttpMethod.Delete,
+                BuildUri($"flows/{EncodePath(flowId)}/executions/{EncodePath(executionId)}"),
+                null,
+                DefaultHeaders, 
+                cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Clients/IFlowsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IFlowsClient.cs
@@ -1,0 +1,143 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Auth0.ManagementApi.Models.Flow;
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.ManagementApi.Clients
+{
+    public interface IFlowsClient
+    {
+        /// <summary>
+        /// Get <see cref="Flow"/>s
+        /// </summary>
+        /// <param name="request"><see cref="FlowGetRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns><see cref="IPagedList{T}"/> of <see cref="Flow"/></returns>
+        Task<IPagedList<Flow>> GetAllAsync(FlowGetRequest request, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Create a <see cref="Flow"/>.
+        /// </summary>
+        /// <param name="request"><see cref="FlowCreateRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns>A <see cref="Flow"/></returns>
+        Task<Flow> CreateAsync(FlowCreateRequest request, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Get a <see cref="Flow"/>.
+        /// </summary>
+        /// <param name="request"><see cref="FlowGetRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns>A <see cref="Flow"/></returns>
+        Task<Flow> GetAsync(FlowGetRequest request, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update a <see cref="Flow"/>
+        /// </summary>
+        /// <param name="id">Identifier of the flow to be updated</param>
+        /// <param name="request"><see cref="FlowUpdateRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns>Updated <see cref="Flow"/></returns>
+        Task<Flow> UpdateAsync(string id, FlowUpdateRequest request, CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Delete a <see cref="Flow"/>
+        /// </summary>
+        /// <param name="id">Identifier of the flow to delete</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        Task DeleteAsync(string id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get <see cref="FlowVaultConnection"/> list
+        /// </summary>
+        /// <param name="request"><see cref="FlowVaultConnectionGetRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns><see cref="IPagedList{T}"/> of <see cref="FlowVaultConnection"/></returns>
+        Task<IPagedList<FlowVaultConnection>> GetAllFlowVaultConnectionsAsync(
+            FlowVaultConnectionGetRequest request,
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Create a Flows Vault connection
+        /// </summary>
+        /// <param name="request"><see cref="FlowVaultConnectionCreateRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns>A <see cref="FlowVaultConnection"/></returns>
+        Task<FlowVaultConnection> CreateVaultConnectionAsync(
+            FlowVaultConnectionCreateRequest request,
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Get a <see cref="FlowVaultConnection"/>.
+        /// </summary>
+        /// <param name="request"><see cref="FlowVaultConnectionGetRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns>A <see cref="FlowVaultConnection"/></returns>
+        Task<FlowVaultConnection> GetFlowVaultConnectionAsync(
+            FlowVaultConnectionGetRequest request,
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Update a <see cref="Flow"/>
+        /// </summary>
+        /// <param name="id">Identifier of the flow to be updated</param>
+        /// <param name="request"><see cref="FlowVaultConnectionUpdateRequest"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns>Updated <see cref="FlowVaultConnection"/></returns>
+        Task<FlowVaultConnection> UpdateFlowVaultConnectionAsync(
+            string id,
+            FlowVaultConnectionUpdateRequest request,
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Delete a <see cref="FlowVaultConnection"/>
+        /// </summary>
+        /// <param name="id">Identifier of the flow to delete</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        Task DeleteFlowVaultConnectionAsync(string id, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get <see cref="Flow"/> executions.
+        /// </summary>
+        /// <param name="flowId">Flow identifier for which we need to fetch the executions</param>
+        /// <param name="paginationInfo"><see cref="PaginationInfo"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns><see cref="IPagedList{T}"/> list of <see cref="FlowExecution"/></returns>
+        Task<IPagedList<FlowExecution>> GetAllFlowExecutionsAsync(
+            string flowId,
+            PaginationInfo paginationInfo, 
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Get <see cref="Flow"/> executions.
+        /// </summary>
+        /// <param name="flowId">Flow identifier for which we need to fetch the executions</param>
+        /// <param name="paginationInfo"><see cref="CheckpointPaginationInfo"/></param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns><see cref="ICheckpointPagedList{T}"/>"/> list of <see cref="FlowExecution"/></returns>
+        Task<ICheckpointPagedList<FlowExecution>> GetAllFlowExecutionsAsync(
+            string flowId,
+            CheckpointPaginationInfo paginationInfo, 
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Get a <see cref="FlowExecution"/>.
+        /// </summary>
+        /// <param name="flowId">Flow identifier for which we need to fetch the execution</param>
+        /// <param name="executionId">Flow execution ID</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        /// <returns><see cref="FlowExecution"/></returns>
+        Task<FlowExecution> GetFlowExecutionAsync(
+            string flowId,
+            string executionId,
+            CancellationToken cancellationToken = default);
+        
+        /// <summary>
+        /// Delete a <see cref="FlowExecution"/>
+        /// </summary>
+        /// <param name="flowId">Flow identifier for which we need to fetch the execution</param>
+        /// <param name="executionId">Flow execution ID</param>
+        /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+        Task DeleteFlowExecutionAsync(string flowId, string executionId, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Auth0.ManagementApi/IManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/IManagementApiClient.cs
@@ -172,6 +172,11 @@ namespace Auth0.ManagementApi
     IFormsClient FormsClient { get; }
 
     /// <summary>
+    /// Contains all the methods to call the /flows endpoints.
+    /// </summary>
+    IFlowsClient FlowsClient { get; }
+    
+    /// <summary>
     /// Update the Access Token used with every request.
     /// </summary>
     /// <param name="token">The new and valid Auth0 Management API v2 token.</param>

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -176,6 +176,9 @@ namespace Auth0.ManagementApi
         /// <inheritdoc cref="Auth0.ManagementApi.IManagementApiClient.FormsClient"/>
         public IFormsClient FormsClient { get; }
 
+        /// <inheritdoc cref="Auth0.ManagementApi.IManagementApiClient.FlowsClient"/>
+        public IFlowsClient FlowsClient { get; }
+
         private Dictionary<string, string> DefaultHeaders { get; set; }
 
         /// <summary>
@@ -230,6 +233,7 @@ namespace Auth0.ManagementApi
             Sessions = new SessionsClient(managementConnection, baseUri, DefaultHeaders);
             SelfServiceProfilesClient = new SelfServiceProfilesClient(managementConnection, baseUri, DefaultHeaders);
             FormsClient = new FormsClient(managementConnection, baseUri, DefaultHeaders);
+            FlowsClient = new FlowsClient(managementConnection, baseUri, DefaultHeaders);
         }
 
         /// <summary>

--- a/src/Auth0.ManagementApi/Models/Flow/Flow.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/Flow.cs
@@ -1,0 +1,32 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    /// <summary>
+    /// Represents a Flow
+    /// </summary>
+    public class Flow
+    {
+        /// <summary>
+        /// format:flow-id
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        [JsonProperty("actions")]
+        public dynamic Actions { get; set; }
+        
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+        
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+        
+        [JsonProperty("executed_at")]
+        public DateTime? ExecutedAt { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowCreateRequest.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    /// <summary>
+    /// Contains information required for creating a new flow
+    /// </summary>
+    public class FlowCreateRequest
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        [JsonProperty("actions")]
+        public dynamic Actions { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowExecution.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowExecution.cs
@@ -1,0 +1,62 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    public class FlowExecution
+    {
+        /// <summary>
+        /// Flow execution identifier
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        
+        /// <summary>
+        /// Trace ID
+        /// </summary>
+        [JsonProperty("trace_id")]
+        public string TraceId { get; set; }
+        
+        /// <summary>
+        /// Journey ID
+        /// </summary>
+        [JsonProperty("journey_id")]
+        public string JourneyId { get; set; }
+        
+        /// <summary>
+        /// Execution Status
+        /// </summary>
+        [JsonProperty("status")]
+        public string Status { get; set; }
+        
+        /// <summary>
+        /// Flow execution debug.
+        /// </summary>
+        [JsonProperty("debug")]
+        public dynamic Debug { get; set; }
+        
+        /// <summary>
+        /// The ISO 8601 formatted date when this flow execution was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+        
+        /// <summary>
+        /// The ISO 8601 formatted date when this flow execution was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+        
+        /// <summary>
+        /// The ISO 8601 formatted date when this flow execution started.
+        /// </summary>
+        [JsonProperty("started_at")]
+        public DateTime? StartedAt { get; set; }
+        
+        /// <summary>
+        /// The ISO 8601 formatted date when this flow execution ended.
+        /// </summary>
+        [JsonProperty("ended_at")]
+        public DateTime? EndedAt { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowExecutionGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowExecutionGetRequest.cs
@@ -1,0 +1,21 @@
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    public class FlowExecutionGetRequest
+    {
+        public string FlowId { get; set; }
+        
+        public string ExecutionId { get; set; }
+        
+        /// <summary>
+        /// Hydration param
+        /// Possible values: [debug]
+        /// </summary>
+        public Hydrate[] Hydrate { get; set; }
+        
+        public PaginationInfo PaginationInfo { get; set; }
+        
+        public CheckpointPaginationInfo CheckpointPaginationInfo { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowGetRequest.cs
@@ -1,0 +1,28 @@
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    /// <summary>
+    /// Contains information required for getting a flow
+    /// </summary>
+    public class FlowGetRequest
+    {
+        public PaginationInfo PaginationInfo { get; set; }
+        
+        /// <summary>
+        /// Hydration param
+        /// Possible values: [form_count]
+        /// </summary>
+        public Hydrate[] Hydrate { get; set; }
+        
+        /// <summary>
+        /// Flag to filter by sync/async flows
+        /// </summary>
+        public bool? Synchronous { get; set; }
+        
+        /// <summary>
+        /// Flow identifier
+        /// </summary>
+        public string Id { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowUpdateRequest.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    /// <summary>
+    /// Contains information required for updating a flow
+    /// </summary>
+    public class FlowUpdateRequest
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        [JsonProperty("actions")]
+        public dynamic Actions { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnection.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnection.cs
@@ -1,0 +1,59 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    public class FlowVaultConnection
+    {
+        /// <summary>
+        /// Flows Vault Connection identifier.
+        /// </summary>
+        [JsonProperty("id")]
+        public string Id { get; set; }
+        
+        /// <summary>
+        /// Flows Vault Connection app identifier.
+        /// </summary>
+        [JsonProperty("app_id")]
+        public string AppId { get; set; }
+        
+        /// <summary>
+        /// Flows Vault Connection name.
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        /// <summary>
+        /// Flows Vault Connection custom account name.
+        /// </summary>
+        [JsonProperty("account_name")]
+        public string AccountName { get; set; }
+        
+        /// <summary>
+        /// Whether the Flows Vault Connection is configured.
+        /// </summary>
+        [JsonProperty("ready")]
+        public bool? Ready { get; set; }
+        
+        /// <summary>
+        /// The ISO 8601 formatted date when this Flows Vault Connection was created.
+        /// </summary>
+        [JsonProperty("created_at")]
+        public DateTime? CreatedAt { get; set; }
+        
+        /// <summary>
+        /// The ISO 8601 formatted date when this Flows Vault Connection was updated.
+        /// </summary>
+        [JsonProperty("updated_at")]
+        public DateTime? UpdatedAt { get; set; }
+        
+        /// <summary>
+        /// The ISO 8601 formatted date when this Flows Vault Connection was refreshed.
+        /// </summary>
+        [JsonProperty("refreshed_at")]
+        public DateTime? RefreshedAt { get; set; }
+        
+        [JsonProperty("fingerprint")]
+        public string Fingerprint { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnectionCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnectionCreateRequest.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    public class FlowVaultConnectionCreateRequest
+    {
+        [JsonProperty("app_id")]
+        public string AppId { get; set; }
+        
+        [JsonProperty("setup")]
+        public dynamic Setup { get; set; }
+        
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnectionGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnectionGetRequest.cs
@@ -1,0 +1,20 @@
+using Auth0.ManagementApi.Paging;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    /// <summary>
+    /// Contains information required for getting <see cref="FlowVaultConnection"/>
+    /// </summary>
+    public class FlowVaultConnectionGetRequest
+    {
+        /// <summary>
+        /// Flow Vault Connection identifier, to be mentioned when we want to fetch a specific flow vault connection.
+        /// </summary>
+        public string Id { get; set; }
+        
+        /// <summary>
+        /// <see cref="PaginationInfo"/>
+        /// </summary>
+        public PaginationInfo PaginationInfo { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnectionUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/FlowVaultConnectionUpdateRequest.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    public class FlowVaultConnectionUpdateRequest
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+        
+        [JsonProperty("setup")]
+        public dynamic Setup { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Flow/Hydrate.cs
+++ b/src/Auth0.ManagementApi/Models/Flow/Hydrate.cs
@@ -1,0 +1,17 @@
+using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models.Flow
+{
+    /// <summary>
+    /// Hydration param
+    /// </summary>
+    public enum Hydrate
+    {
+        [EnumMember(Value = "form_count")]
+        FORM_COUNT,
+        
+        [EnumMember(Value = "debug")]
+        DEBUG,
+        
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -26,7 +26,8 @@ namespace Auth0.AuthenticationApi.IntegrationTests.Testing
                 new RolesCleanUpStrategy(client),
                 new EncryptionKeysCleanupStrategy(client),
                 new SelfServiceProviderCleanUpStrategy(client),
-                new FormsCleanUpStrategy(client)
+                new FormsCleanUpStrategy(client),
+                new FlowsCleanUpStrategy(client)
             };
 
             var cleanUpStrategy = strategies.Single(s => s.Type == type);

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/CleanUpType.cs
@@ -15,6 +15,7 @@
         LogStreams,
         EncryptionKeys,
         SelfServiceProvider,
-        Forms
+        Forms,
+        Flows
     }
 }

--- a/tests/Auth0.IntegrationTests.Shared/CleanUp/FlowsCleanUpStrategy.cs
+++ b/tests/Auth0.IntegrationTests.Shared/CleanUp/FlowsCleanUpStrategy.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+using Auth0.ManagementApi;
+
+namespace Auth0.IntegrationTests.Shared.CleanUp
+{
+    public class FlowsCleanUpStrategy : CleanUpStrategy
+    {
+        public FlowsCleanUpStrategy(ManagementApiClient apiClient) : base(CleanUpType.Flows, apiClient)
+        {
+
+        }
+
+        public override async Task Run(string id)
+        {
+            System.Diagnostics.Debug.WriteLine("Running FlowsCleanup");
+            await ApiClient.FlowsClient.DeleteAsync(id);
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/FlowsTest.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/FlowsTest.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+using Xunit;
+
+using Auth0.IntegrationTests.Shared.CleanUp;
+using Auth0.ManagementApi.IntegrationTests.Testing;
+using Auth0.ManagementApi.Models.Flow;
+using Auth0.ManagementApi.Paging;
+using Auth0.IntegrationTests.Shared;
+using Auth0.Tests.Shared;
+
+namespace Auth0.ManagementApi.IntegrationTests;
+
+public class FlowsTestFixture : TestBaseFixture
+{
+    public override async Task DisposeAsync()
+    {
+        foreach (KeyValuePair<CleanUpType, IList<string>> entry in identifiers)
+        {
+            await ManagementTestBaseUtils.CleanupAsync(ApiClient, entry.Key, entry.Value);
+        }
+
+        ApiClient.Dispose();
+    }
+}
+
+public class FlowsTest : IClassFixture<FlowsTestFixture>
+{
+    FlowsTestFixture fixture;
+
+    public FlowsTest(FlowsTestFixture fixture)
+    {
+        this.fixture = fixture;
+    }
+
+    [Fact]
+    public async void Test_get_all_flows_throws_when_request_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.ApiClient.FlowsClient.GetAllAsync(null));
+    }
+    
+    [Fact]
+    public async void Test_get_flows_throws_when_request_is_null_when_id_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.ApiClient.FlowsClient.GetAsync(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.ApiClient.FlowsClient.GetAsync(new FlowGetRequest()));
+    }
+    
+    [Fact]
+    public async void Test_update_flows_throws_when_id_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.UpdateAsync(null, null));
+    }
+    
+    [Fact]
+    public async void Test_delete_flow_throws_when_id_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => fixture.ApiClient.FlowsClient.DeleteAsync(null));
+    }
+    
+    [Fact]
+    public async void Test_get_all_flow_vault_connections_throws_when_request_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.GetAllFlowVaultConnectionsAsync(null));
+    }
+    
+    [Fact]
+    public async void Test_get_flow_vault_connections_throws_when_request_is_null_id_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.GetFlowVaultConnectionAsync(null));
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.GetFlowVaultConnectionAsync(new FlowVaultConnectionGetRequest()));
+    }
+    
+    [Fact]
+    public async void Test_update_flow_vault_connection_throws_when_id_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.UpdateFlowVaultConnectionAsync(
+                null, new FlowVaultConnectionUpdateRequest()));
+    }
+    
+    [Fact]
+    public async void Test_delete_flow_vault_connection_throws_when_id_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.DeleteFlowVaultConnectionAsync(null));
+    }
+    
+    [Fact]
+    public async void Test_get_all_flow_executions_throws_when_request_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.GetAllFlowExecutionsAsync(null, new PaginationInfo()));
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.GetAllFlowExecutionsAsync(null, new CheckpointPaginationInfo()));
+    }
+    
+    [Fact]
+    public async void Test_get_flow_executions_throws_when_id_execution_id_is_null()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.GetFlowExecutionAsync(null, "executionId"));
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => fixture.ApiClient.FlowsClient.GetFlowExecutionAsync("flowId", null));
+    }
+    
+    [Fact]
+    public async void Test_flows_crud_sequence()
+    {
+        // Create a Flow
+        var createRequest = new FlowCreateRequest()
+        {
+            Name = "Test Flow",
+            Actions = System.Array.Empty<object>()
+        };
+
+        var flow = await fixture.ApiClient.FlowsClient.CreateAsync(createRequest);
+        flow.Should().NotBeNull();
+        flow.Name.Should().Be(createRequest.Name);
+
+        // Update flow
+        var updateRequest = new FlowUpdateRequest()
+        {
+            Actions = null
+        };
+        var updatedFlow = await fixture.ApiClient.FlowsClient.UpdateAsync(flow.Id, updateRequest);
+        updatedFlow.Should().NotBeNull();
+
+        // Get a Flow 
+        var getFlow = await fixture.ApiClient.FlowsClient.GetAsync(new FlowGetRequest { Id = flow.Id, Hydrate = new []
+            {
+                Hydrate.FORM_COUNT
+            }}
+        );
+        getFlow.Should().NotBeNull();
+
+        // Delete a flow
+        await fixture.ApiClient.FlowsClient.DeleteAsync(flow.Id);
+    }
+
+    [Fact]
+    public async void Test_flow_vault_connection_crud_sequence()
+    {
+        var createRequest = new FlowVaultConnectionCreateRequest()
+        {
+            AppId = "AUTH0",
+            Setup = new Dictionary<string, string>()
+            {
+                { "type", "OAUTH_APP" },
+                { "domain", TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_URL")},
+                { "client_id", TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_CLIENT_ID") },
+                { "client_secret", TestBaseUtils.GetVariable("AUTH0_MANAGEMENT_API_CLIENT_SECRET") }
+            },
+            Name = "Auth0-test-connection"
+        };
+        
+        var createdFlowVaultConnection = await fixture.ApiClient.FlowsClient.CreateVaultConnectionAsync(createRequest);
+        createdFlowVaultConnection.Should().NotBeNull();
+
+        // Update the flow vault connection
+        var updateRequest = new FlowVaultConnectionUpdateRequest()
+        {
+            Name = "Updated Name"
+        };
+
+        var updatedVaultConnection = 
+            await fixture.ApiClient.FlowsClient.UpdateFlowVaultConnectionAsync(createdFlowVaultConnection.Id, updateRequest);
+        updatedVaultConnection.Should().NotBeNull();
+        updatedVaultConnection.Name.Should().Be("Updated Name");
+
+        // Get all vault connections
+        var allFlowVaultConnections =
+            await fixture.ApiClient.FlowsClient.GetAllFlowVaultConnectionsAsync(new FlowVaultConnectionGetRequest());
+        allFlowVaultConnections.Select( x => x.Id == createdFlowVaultConnection.Id).Should().NotBeNull();
+        
+        // Get the newly created vault connection
+        var getRequest = new FlowVaultConnectionGetRequest()
+        {
+            Id = createdFlowVaultConnection.Id
+        };
+
+        var vaultConnection = await fixture.ApiClient.FlowsClient.GetFlowVaultConnectionAsync(getRequest);
+        vaultConnection.Should().NotBeNull();
+        vaultConnection.Id.Should().Be(createdFlowVaultConnection.Id);
+        
+        // Delete the newly created vault connection
+        await fixture.ApiClient.FlowsClient.DeleteFlowVaultConnectionAsync(createdFlowVaultConnection.Id);
+    }
+
+    [Fact]
+    public async void Test_flow_executions_crud_sequence()
+    {
+        // Given a flow 
+        var createRequest = new FlowCreateRequest()
+        {
+            Name = "Flow for Test_flow_executions_crud_sequence",
+            Actions = System.Array.Empty<object>()
+        };
+        var newFlow = await fixture.ApiClient.FlowsClient.CreateAsync(createRequest);
+        newFlow.Should().NotBeNull();
+        fixture.TrackIdentifier(CleanUpType.Flows, newFlow.Id);
+        
+        // Get all flow executions 
+        var flowExecutions =
+            await fixture.ApiClient.FlowsClient.GetAllFlowExecutionsAsync(newFlow.Id, new PaginationInfo());
+        
+        flowExecutions.Should().NotBeNull();
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/FormsTest.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/FormsTest.cs
@@ -78,9 +78,9 @@ namespace Auth0.ManagementApi.IntegrationTests
             });
 
             allForms.Should().NotBeNull();
-            allForms.Count.Should().Be(1);
+            allForms.Count.Should().BeGreaterThan(0);
             
-            var form = await fixture.ApiClient.FormsClient.GetAsync(new FormsGetRequest { Id = allForms.First().Id });
+            var form = await fixture.ApiClient.FormsClient.GetAsync(new FormsGetRequest { Id = createdForm.Id });
             
             form.Should().BeEquivalentTo(createdForm, options => options.ExcludingMissingMembers());
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/Testing/ManagementTestBaseUtils.cs
@@ -24,7 +24,8 @@ namespace Auth0.ManagementApi.IntegrationTests.Testing
                 new RolesCleanUpStrategy(client),
                 new EncryptionKeysCleanupStrategy(client),
                 new SelfServiceProviderCleanUpStrategy(client),
-                new FormsCleanUpStrategy(client)
+                new FormsCleanUpStrategy(client),
+                new FlowsCleanUpStrategy(client)
             };
 
             var cleanUpStrategy = strategies.Single(s => s.Type == type);


### PR DESCRIPTION
### Changes
Added support for the following end-points
- [GET  /api/v2/flows](https://auth0.com/docs/api/management/v2/flows/get-flows)
- [POST  /api/v2/flows](https://auth0.com/docs/api/management/v2/flows/post-flows)
- [GET  /api/v2/flows/vault/connections](https://auth0.com/docs/api/management/v2/flows/get-flows-vault-connections)
- [POST  /api/v2/flows/vault/connections](https://auth0.com/docs/api/management/v2/flows/post-flows-vault-connections)
- [GET  /api/v2/flows/vault/connections/{id}](https://auth0.com/docs/api/management/v2/flows/get-flows-vault-connections-by-id)
- [DELETE  /api/v2/flows/vault/connections/{id}](https://auth0.com/docs/api/management/v2/flows/delete-flows-vault-connections-by-id)
- [PATCH  /api/v2/flows/vault/connections/{id}](https://auth0.com/docs/api/management/v2/flows/patch-flows-vault-connections-by-id)
- [GET  /api/v2/flows/{flow_id}/executions](https://auth0.com/docs/api/management/v2/flows/get-flows-executions)
- [GET  /api/v2/flows/{flow_id}/executions/{execution_id}](https://auth0.com/docs/api/management/v2/flows/get-flows-executions-by-execution-id)
- [DELETE  /api/v2/flows/{flow_id}/executions/{execution_id}](https://auth0.com/docs/api/management/v2/flows/delete-flows-executions-by-execution-id)
- [GET  /api/v2/flows/{id}](https://auth0.com/docs/api/management/v2/flows/get-flows-by-id)
- [DELETE  /api/v2/flows/{id}](https://auth0.com/docs/api/management/v2/flows/delete-flows-by-id)
- [PATCH  /api/v2/flows/{id}](https://auth0.com/docs/api/management/v2/flows/patch-flows-by-id)


### References
- [SDK-5044](https://auth0team.atlassian.net/browse/SDK-5044)

### Testing
Added the following test cases : 
- Test_get_all_flows_throws_when_request_is_null
- Test_get_flows_throws_when_request_is_null_when_id_is_null
- Test_update_flows_throws_when_id_is_null
- Test_delete_flow_throws_when_id_is_null
- Test_get_all_flow_vault_connections_throws_when_request_is_null
- Test_get_flow_vault_connections_throws_when_request_is_null_id_is_null
- Test_update_flow_vault_connection_throws_when_id_is_null
- Test_delete_flow_vault_connection_throws_when_id_is_null
- Test_get_all_flow_executions_throws_when_request_is_null
- Test_get_flow_executions_throws_when_id_execution_id_is_null
- Test_flows_crud_sequence
- Test_flow_vault_connection_crud_sequence
- Test_flow_executions_crud_sequence

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5044]: https://auth0team.atlassian.net/browse/SDK-5044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ