### PR TITLE
Added missing user ID field in Device Credentials class

### DIFF
--- a/src/Auth0.ManagementApi/Models/DeviceCredential.cs
+++ b/src/Auth0.ManagementApi/Models/DeviceCredential.cs
@@ -12,5 +12,11 @@ namespace Auth0.ManagementApi.Models
         /// </summary>
         [JsonProperty("id")]
         public string Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the device credential's user identifier.
+        /// </summary>
+        [JsonProperty("user_id")]
+        public string UserId { get; set; }
     }
 }


### PR DESCRIPTION
### Changes

A missing field of `UserId` has been added to the `Device Crdential` class. It is documented in the [API documentation](https://auth0.com/docs/api/management/v2/device-credentials/get-device-credentials) but it was missing from the Auth0 SDK.



### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
