### PR TITLE
Update documentation to clarify LoginHint.Issuer field usage in CIBA context

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ We appreciate feedback and contribution to this repo! Before you get started, pl
 
 - [Auth0's general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
 - [Auth0's code of conduct guidelines](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
+- Ensure your commits are signed to enhance security, authorship, trust and compliance.
+[About commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+
 
 ### Raise an issue
 

--- a/src/Auth0.AuthenticationApi/Models/Ciba/LoginHint.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/LoginHint.cs
@@ -10,6 +10,10 @@ namespace Auth0.AuthenticationApi.Models.Ciba
         [JsonProperty("format")]
         public string Format { get; set; }
         
+        /// <summary>
+        /// Issuer of the ID Token. 
+        /// This value should match the 'Issuer' value configured in the well-known configuration.
+        /// </summary>
         [JsonProperty("iss")]
         public string Issuer { get; set; }
         


### PR DESCRIPTION
### Changes

- Updated documentation to clarify the usage of the `LoginHint.Issuer` field in CIBA context.
- Added the pre-requisite of signing commits for open-source contributions.

### References

- JIRA -> [SDK-5569](https://auth0team.atlassian.net/browse/SDK-5569)


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
