### PR TITLE
Adds support for managing SNS configuration - Push Notification - MFA policies

### DIFF
--- a/src/Auth0.ManagementApi/Clients/GuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/GuardianClient.cs
@@ -408,5 +408,30 @@ namespace Auth0.ManagementApi.Clients
                 cancellationToken: cancellationToken
             );
         }
+
+        /// <inheritdoc />
+        public Task<PushNotificationProviderConfiguration> GetPushNotificationProviderConfigurationAsync(
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.GetAsync<PushNotificationProviderConfiguration>(
+                BuildUri("guardian/factors/push-notification/selected-provider"),
+                DefaultHeaders,
+                cancellationToken: cancellationToken
+            );
+        }
+
+        /// <inheritdoc />
+        public Task<PushNotificationProviderConfiguration> UpdatePushNotificationProviderConfigurationAsync(
+            PushNotificationProviderConfiguration pushNotificationProviderConfiguration,
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<PushNotificationProviderConfiguration>(
+                HttpMethod.Put,
+                BuildUri("guardian/factors/push-notification/selected-provider"),
+                pushNotificationProviderConfiguration,
+                DefaultHeaders,
+                cancellationToken: cancellationToken
+            );
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/GuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/GuardianClient.cs
@@ -126,13 +126,7 @@ namespace Auth0.ManagementApi.Clients
                 DefaultHeaders, cancellationToken: cancellationToken);
         }
 
-        /// <summary>
-        /// Enable or Disable a Guardian factor.
-        /// </summary>
-        /// <param name="request">
-        /// The <see cref="UpdateGuardianFactorRequest" /> containing the details of the factor to update.</param>
-        /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-        /// <returns>The <see cref="UpdateGuardianFactorResponse" /> indicating the status of the factor.</returns>
+        /// <inheritdoc />
         public Task<UpdateGuardianFactorResponse> UpdateFactorAsync(
             UpdateGuardianFactorRequest request, CancellationToken cancellationToken = default)
         {

--- a/src/Auth0.ManagementApi/Clients/GuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/GuardianClient.cs
@@ -380,5 +380,33 @@ namespace Auth0.ManagementApi.Clients
                 cancellationToken: cancellationToken
                 );        
         }
+
+        /// <inheritdoc />
+        public Task<GuardianSnsConfiguration> UpdatePushNotificationSnsConfigurationAsync(
+            GuardianSnsConfigurationPatchUpdateRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<GuardianSnsConfiguration>(
+                new HttpMethod("PATCH"),
+                BuildUri("guardian/factors/push-notification/providers/sns"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken
+            );
+        }
+
+        /// <inheritdoc />
+        public Task<GuardianSnsConfiguration> UpdatePushNotificationSnsConfigurationAsync(
+            GuardianSnsConfigurationPutUpdateRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<GuardianSnsConfiguration>(
+                HttpMethod.Put,
+                BuildUri("guardian/factors/push-notification/providers/sns"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken
+            );
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/GuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/GuardianClient.cs
@@ -427,5 +427,29 @@ namespace Auth0.ManagementApi.Clients
                 cancellationToken: cancellationToken
             );
         }
+
+        /// <inheritdoc />
+        public Task<string[]> GetMultifactorAuthenticationPolicies(CancellationToken cancellationToken = default)
+        {
+            return Connection.GetAsync<string[]>(
+                BuildUri("guardian/policies"),
+                DefaultHeaders,
+                cancellationToken: cancellationToken
+            );
+        }
+
+        /// <inheritdoc />
+        public Task<string[]> UpdateMultifactorAuthenticationPolicies(
+            string[] mfaPolicies,
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<string[]>(
+                HttpMethod.Put,
+                BuildUri("guardian/policies"),
+                mfaPolicies,
+                DefaultHeaders,
+                cancellationToken: cancellationToken
+            );
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
@@ -63,7 +63,7 @@ namespace Auth0.ManagementApi.Clients
     Task<GuardianTwilioConfiguration> GetTwilioConfigurationAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Enable or Disable a Guardian factor.
+    /// Update the status (i.e., enabled or disabled) of a specific multi-factor authentication factor.
     /// </summary>
     /// <param name="request">The <see cref="UpdateGuardianFactorRequest" /> containing the details of the factor to update.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>

--- a/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
@@ -259,5 +259,23 @@ namespace Auth0.ManagementApi.Clients
     /// <returns>A <see cref="GuardianSnsConfiguration"/> containing information about the SNS configuration</returns>
     Task<GuardianSnsConfiguration> UpdatePushNotificationSnsConfigurationAsync(GuardianSnsConfigurationPutUpdateRequest request, CancellationToken cancellationToken = default);
     
+    /// <summary>
+    /// Retrieve details of the push-notification providers configured for your tenant.
+    /// </summary>
+    /// <param name="cancellationToken">
+    /// <see cref="CancellationToken"/> The cancellation token to cancel operation.</param>
+    /// <returns><see cref="PushNotificationProviderConfiguration"/></returns>
+    Task<PushNotificationProviderConfiguration> GetPushNotificationProviderConfigurationAsync(CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Modify the push notification provider configured for your tenant. For more information, review
+    /// <a href="https://auth0.com/docs/secure/multi-factor-authentication/multi-factor-authentication-factors/configure-push-notifications-for-mfa">
+    /// Configure Push Notifications for MFA. </a>
+    /// </summary>
+    /// <param name="pushNotificationProviderConfiguration"><see cref="PushNotificationProviderConfiguration"/> - Containing the configuration information to be updated</param>
+    /// <param name="cancellationToken">
+    /// <see cref="CancellationToken"/> The cancellation token to cancel operation.</param>
+    /// <returns><see cref="PushNotificationProviderConfiguration"/></returns>
+    Task<PushNotificationProviderConfiguration> UpdatePushNotificationProviderConfigurationAsync(PushNotificationProviderConfiguration pushNotificationProviderConfiguration, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
@@ -236,5 +236,28 @@ namespace Auth0.ManagementApi.Clients
     /// <see cref="CancellationToken"/> The cancellation token to cancel operation.</param>
     /// <returns>An <see cref="object"/> containing information about the FCMV1 configuration</returns>
     Task<object> UpdatePushNotificationFcmV1ConfigurationAsync(FcmV1ConfigurationPutUpdateRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Configure the
+    /// <a href="https://auth0.com/docs/multifactor-authentication/developer/sns-configuration">
+    /// AWS SNS push notification provider configuration </a> (subscription required).
+    /// </summary>
+    /// <param name="request"><see cref="GuardianSnsConfigurationPatchUpdateRequest"/></param>
+    /// <param name="cancellationToken">
+    /// <see cref="CancellationToken"/> The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="GuardianSnsConfiguration"/> containing information about the SNS configuration</returns>
+    Task<GuardianSnsConfiguration> UpdatePushNotificationSnsConfigurationAsync(GuardianSnsConfigurationPatchUpdateRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Configure the
+    /// <a href="https://auth0.com/docs/multifactor-authentication/developer/sns-configuration">
+    /// AWS SNS push notification provider configuration </a> (subscription required).
+    /// </summary>
+    /// <param name="request"><see cref="GuardianSnsConfigurationPutUpdateRequest"/></param>
+    /// <param name="cancellationToken">
+    /// <see cref="CancellationToken"/> The cancellation token to cancel operation.</param>
+    /// <returns>A <see cref="GuardianSnsConfiguration"/> containing information about the SNS configuration</returns>
+    Task<GuardianSnsConfiguration> UpdatePushNotificationSnsConfigurationAsync(GuardianSnsConfigurationPutUpdateRequest request, CancellationToken cancellationToken = default);
+    
   }
 }

--- a/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IGuardianClient.cs
@@ -277,5 +277,24 @@ namespace Auth0.ManagementApi.Clients
     /// <see cref="CancellationToken"/> The cancellation token to cancel operation.</param>
     /// <returns><see cref="PushNotificationProviderConfiguration"/></returns>
     Task<PushNotificationProviderConfiguration> UpdatePushNotificationProviderConfigurationAsync(PushNotificationProviderConfiguration pushNotificationProviderConfiguration, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Retrieve the
+    ///<a href="https://auth0.com/docs/secure/multi-factor-authentication/enable-mfa">
+    /// multi-factor authentication (MFA) policies </a> configured for your tenant.
+    /// </summary>
+    /// <param name="cancellationToken"></param>
+    /// <returns>MFA authentication policies configured for your tenant</returns>
+    Task<string[]> GetMultifactorAuthenticationPolicies(CancellationToken cancellationToken = default);
+
+    ///  <summary>
+    ///  Set the
+    /// <a href="https://auth0.com/docs/secure/multi-factor-authentication/enable-mfa">
+    ///  multi-factor authentication (MFA) policies </a> for your tenant.
+    ///  </summary>
+    ///  <param name="mfaPolicies">MFA policies to update</param>
+    ///  <param name="cancellationToken"></param>
+    ///  <returns>MFA policies configured for your tenant</returns>
+    Task<string[]> UpdateMultifactorAuthenticationPolicies(string[] mfaPolicies, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Models/Guardian/GuardianSnsConfiguration.cs
+++ b/src/Auth0.ManagementApi/Models/Guardian/GuardianSnsConfiguration.cs
@@ -3,4 +3,12 @@ namespace Auth0.ManagementApi.Models
     public class GuardianSnsConfiguration : GuardianSnsConfigurationBase
     {
     }
+
+    public class GuardianSnsConfigurationPutUpdateRequest : GuardianSnsConfigurationBase
+    {
+    }
+    
+    public class GuardianSnsConfigurationPatchUpdateRequest : GuardianSnsConfigurationBase
+    {
+    }
 }

--- a/src/Auth0.ManagementApi/Models/Guardian/PhoneProviderConfiguration.cs
+++ b/src/Auth0.ManagementApi/Models/Guardian/PhoneProviderConfiguration.cs
@@ -8,10 +8,10 @@ namespace Auth0.ManagementApi.Models
     {
         [JsonProperty("provider")]
         [JsonConverter(typeof(StringEnumConverter))]
-        public Provider Provider { get; set; }
+        public PhoneProvider PhoneProvider { get; set; }
     }
 
-    public enum Provider
+    public enum PhoneProvider
     {
         [EnumMember(Value = "auth0")]
         Auth0,

--- a/src/Auth0.ManagementApi/Models/Guardian/PushNotificationProviderConfiguration.cs
+++ b/src/Auth0.ManagementApi/Models/Guardian/PushNotificationProviderConfiguration.cs
@@ -1,0 +1,25 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class PushNotificationProviderConfiguration
+    {
+        [JsonProperty("provider")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public PushNotificationProvider PushNotificationProvider { get; set; }
+    }
+
+    public enum PushNotificationProvider
+    {
+        [EnumMember(Value = "guardian")]
+        Guardian,
+        
+        [EnumMember(Value = "sns")]
+        Sns,
+        
+        [EnumMember(Value = "direct")]
+        Direct,
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
@@ -416,5 +416,29 @@ namespace Auth0.ManagementApi.IntegrationTests
             pushNotificationProviderConfiguration.Should().NotBeNull();
             updatedProviderConfiguration.PushNotificationProvider.Should().Be(PushNotificationProvider.Direct);
         }
+        
+        [Fact]
+        public async void Update_Get_MultifactorAuthenticationPolicies_successfully()
+        {
+            try
+            {
+                // update MFA policy
+                var updatedMfaPolicy =
+                    await fixture.ApiClient.Guardian.UpdateMultifactorAuthenticationPolicies(["all-applications"]);
+
+                updatedMfaPolicy.Should().NotBeNull();
+                updatedMfaPolicy.Should().BeEquivalentTo(["all-applications"]);
+
+                // Get the Push Notification provider configuration explicitly
+                var mfaPolicy =
+                    await fixture.ApiClient.Guardian.GetMultifactorAuthenticationPolicies();
+                mfaPolicy.Should().NotBeNull();
+                mfaPolicy.Should().BeEquivalentTo(["all-applications"]);
+            }
+            finally
+            {
+                await fixture.ApiClient.Guardian.UpdateMultifactorAuthenticationPolicies([]);    
+            }
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/GuardianTests.cs
@@ -274,19 +274,19 @@ namespace Auth0.ManagementApi.IntegrationTests
         {
             var phoneProviderConfiguration = new PhoneProviderConfiguration()
             {
-                Provider = Provider.Auth0,
+                PhoneProvider = PhoneProvider.Auth0,
             };
 
             // update phone provider configuration
             var updatedProviderConfiguration = 
                 await fixture.ApiClient.Guardian.UpdatePhoneProviderConfigurationAsync(phoneProviderConfiguration);
             updatedProviderConfiguration.Should().NotBeNull();
-            updatedProviderConfiguration.Provider.Should().Be(Provider.Auth0);
+            updatedProviderConfiguration.PhoneProvider.Should().Be(PhoneProvider.Auth0);
             
             // Get the Phone provider configuration explicitly
             phoneProviderConfiguration = await fixture.ApiClient.Guardian.GetPhoneProviderConfigurationAsync();
             phoneProviderConfiguration.Should().NotBeNull();
-            phoneProviderConfiguration.Provider.Should().Be(Provider.Auth0);
+            phoneProviderConfiguration.PhoneProvider.Should().Be(PhoneProvider.Auth0);
         }
         
         [Fact]
@@ -368,7 +368,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                 ServerCredentials = "server_credentials"
             };
             
-            var fcmV1ConfigurationPutUpdateRequest = new FcmV1ConfigurationPatchUpdateRequest()
+            var fcmV1ConfigurationPutUpdateRequest = new FcmV1ConfigurationPutUpdateRequest()
             {
                 ServerCredentials = "server_credentials"
             };
@@ -392,6 +392,29 @@ namespace Auth0.ManagementApi.IntegrationTests
             response =
                 await fixture.ApiClient.Guardian.UpdatePushNotificationFcmV1ConfigurationAsync(fcmV1ConfigurationPutUpdateRequest);
             response.Should().NotBeNull();
+        }
+        
+        [Fact]
+        public async void Update_Get_PushNotificationProviderConfiguration_successfully()
+        {
+            var pushNotificationProviderConfiguration = new PushNotificationProviderConfiguration()
+            {
+                PushNotificationProvider = PushNotificationProvider.Direct,
+            };
+
+            // update push notification provider configuration
+            var updatedProviderConfiguration = 
+                await fixture.ApiClient.Guardian.UpdatePushNotificationProviderConfigurationAsync(
+                    pushNotificationProviderConfiguration);
+            
+            updatedProviderConfiguration.Should().NotBeNull();
+            updatedProviderConfiguration.PushNotificationProvider.Should().Be(PushNotificationProvider.Direct);
+            
+            // Get the Push Notification provider configuration explicitly
+            pushNotificationProviderConfiguration = 
+                await fixture.ApiClient.Guardian.GetPushNotificationProviderConfigurationAsync();
+            pushNotificationProviderConfiguration.Should().NotBeNull();
+            updatedProviderConfiguration.PushNotificationProvider.Should().Be(PushNotificationProvider.Direct);
         }
     }
 }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
- Any alternative designs or approaches considered

### References

Please include relevant links supporting this change such as a:

- [PATCH  /api/v2/guardian/factors/push-notification/providers/sns](https://auth0.com/docs/api/management/v2/guardian/patch-sns)
- [PUT  /api/v2/guardian/factors/push-notification/providers/sns](https://auth0.com/docs/api/management/v2/guardian/put-sns)
- [GET  /api/v2/guardian/factors/push-notification/selected-provider](https://auth0.com/docs/api/management/v2/guardian/get-pn-providers)
- [PUT  /api/v2/guardian/factors/push-notification/selected-provider](https://auth0.com/docs/api/management/v2/guardian/put-pn-providers)
- [GET  /api/v2/guardian/policies](https://auth0.com/docs/api/management/v2/guardian/get-policies)
- [PUT  /api/v2/guardian/policies](https://auth0.com/docs/api/management/v2/guardian/put-policies)

### Testing

Added the following test cases : 
- Update_Get_MultifactorAuthenticationPolicies_successfully
- Update_Get_PushNotificationProviderConfiguration_successfully

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
