### PR TITLE
Allow Optional AssignMembershipOnLogin field to be nullable

### DIFF
--- a/src/Auth0.ManagementApi/Models/Organization/OrganizationConnectionCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Organization/OrganizationConnectionCreateRequest.cs
@@ -15,7 +15,7 @@ namespace Auth0.ManagementApi.Models
         /// Whether or not users that login will automatically be granted membership to the organization.
         /// </summary>
         [JsonProperty("assign_membership_on_login")]
-        public bool AssignMembershipOnLogin { get; set; }
+        public bool? AssignMembershipOnLogin { get; set; }
 
         /// <summary>
         /// Determines whether a connection should be displayed on this organization’s login prompt.


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Fixes #774 

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
