### PR TITLE
Add support for managing Branding Phone Notification Templates

### DIFF
--- a/src/Auth0.ManagementApi/Clients/BrandingClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BrandingClient.cs
@@ -18,6 +18,9 @@ namespace Auth0.ManagementApi.Clients
         private readonly JsonConverter[] _brandingPhoneProviderConverters = 
             { new ListConverter<BrandingPhoneProvider>("providers") };
         
+        private readonly JsonConverter[] _brandingPhoneNotificationTemplateConverters = 
+            { new ListConverter<BrandingPhoneNotificationTemplate>("templates") };
+        
         /// <summary>
         /// Initializes a new instance of <see cref="BrandingClient"/>.
         /// </summary>
@@ -72,7 +75,7 @@ namespace Auth0.ManagementApi.Clients
         {
             var queryStrings = new Dictionary<string, string>
             {
-                {"disabled", request.Disabled?.ToString().ToLower()},
+                {"disabled", request?.Disabled?.ToString().ToLower()},
             };
             return Connection.GetAsync<IList<BrandingPhoneProvider>>(
                 BuildUri("branding/phone/providers", queryStrings),
@@ -97,6 +100,10 @@ namespace Auth0.ManagementApi.Clients
         /// <inheritdoc />
         public Task<BrandingPhoneProvider> GetPhoneProviderAsync(string id, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
             return Connection.GetAsync<BrandingPhoneProvider>(
                 BuildUri($"branding/phone/providers/{EncodePath(id)}"),
                 DefaultHeaders,
@@ -106,6 +113,10 @@ namespace Auth0.ManagementApi.Clients
         /// <inheritdoc />
         public Task DeletePhoneProviderAsync(string id, CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
             return Connection
                 .SendAsync<object>(
                     HttpMethod.Delete,
@@ -121,10 +132,148 @@ namespace Auth0.ManagementApi.Clients
             BrandingPhoneProviderUpdateRequest request,
             CancellationToken cancellationToken = default)
         {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
             return Connection.SendAsync<BrandingPhoneProvider>(
                 new HttpMethod("PATCH"),
                 BuildUri($"branding/phone/providers/{EncodePath(id)}"),
                 request, 
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingPhoneTestNotificationResponse> SendBrandingPhoneTestNotificationAsync(
+            string id,
+            BrandingPhoneTestNotificationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            return Connection.SendAsync<BrandingPhoneTestNotificationResponse>(
+                HttpMethod.Post,
+                BuildUri($"branding/phone/providers/{EncodePath(id)}/try"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<IList<BrandingPhoneNotificationTemplate>> GetAllBrandingPhoneNotificationTemplatesAsync(
+            BrandingPhoneNotificationTemplatesGetRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            var queryStrings = new Dictionary<string, string>
+            {
+                {"disabled", request?.Disabled?.ToString().ToLower()},
+            };
+            
+            return Connection.GetAsync<IList<BrandingPhoneNotificationTemplate>>(
+                BuildUri("branding/phone/templates", queryStrings),
+                DefaultHeaders,
+                cancellationToken: cancellationToken,
+                converters:_brandingPhoneNotificationTemplateConverters);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingPhoneNotificationTemplate> CreateBrandingPhoneNotificationTemplateAsync(
+            BrandingPhoneNotificationTemplateCreateRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<BrandingPhoneNotificationTemplate>(
+                HttpMethod.Post,
+                BuildUri("branding/phone/templates"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingPhoneNotificationTemplate> GetBrandingPhoneNotificationTemplateAsync(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            return Connection.GetAsync<BrandingPhoneNotificationTemplate>(
+                BuildUri($"branding/phone/templates/{EncodePath(id)}"),
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task DeleteBrandingPhoneNotificationTemplateAsync(string id, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection
+                .SendAsync<object>(
+                    HttpMethod.Delete,
+                    BuildUri($"branding/phone/templates/{EncodePath(id)}"),
+                    null,
+                    DefaultHeaders,
+                    cancellationToken: cancellationToken);       
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingPhoneNotificationTemplate> UpdateBrandingPhoneNotificationTemplate(
+            string id,
+            BrandingPhoneNotificationTemplateUpdateRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection.SendAsync<BrandingPhoneNotificationTemplate>(
+                new HttpMethod("PATCH"),
+                BuildUri($"branding/phone/templates/{EncodePath(id)}"),
+                request, 
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingPhoneNotificationTemplate> ResetBrandingPhoneNotificationTemplate(
+            string id,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection.SendAsync<BrandingPhoneNotificationTemplate>(
+                new HttpMethod("PATCH"),
+                BuildUri($"branding/phone/templates/{EncodePath(id)}/reset"),
+                null, 
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingPhoneTestNotificationResponse> SendBrandingPhoneTemplateTestNotificationAsync(string id, BrandingPhoneTestNotificationRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+            
+            return Connection.SendAsync<BrandingPhoneTestNotificationResponse>(
+                HttpMethod.Post,
+                BuildUri($"branding/phone/templates/{EncodePath(id)}/try"),
+                request,
                 DefaultHeaders,
                 cancellationToken: cancellationToken);
         }

--- a/src/Auth0.ManagementApi/Clients/IBrandingClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IBrandingClient.cs
@@ -94,5 +94,73 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
     /// <returns>Updated <see cref="BrandingPhoneProvider"/></returns>
     Task<BrandingPhoneProvider> UpdatePhoneProviderAsync(string id, BrandingPhoneProviderUpdateRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Send a test phone notification for the configured provider
+    /// </summary>
+    /// <param name="id">ID of the <see cref="BrandingPhoneProvider"/></param>
+    /// <param name="request">
+    /// <see cref="BrandingPhoneTestNotificationRequest"/> containing information on whom to send the notification to.</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns><see cref="BrandingPhoneTestNotificationResponse"/></returns>
+    Task<BrandingPhoneTestNotificationResponse> SendBrandingPhoneTestNotificationAsync(string id, BrandingPhoneTestNotificationRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Get a list of phone notification templates
+    /// </summary>
+    /// <param name="request"><see cref="BrandingPhoneNotificationTemplatesGetRequest"/></param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns><see cref="IList{T}"/> of <see cref="BrandingPhoneNotificationTemplate"/></returns>
+    Task<IList<BrandingPhoneNotificationTemplate>> GetAllBrandingPhoneNotificationTemplatesAsync(BrandingPhoneNotificationTemplatesGetRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create a phone notification template
+    /// </summary>
+    /// <param name="request"><see cref="BrandingPhoneNotificationTemplateCreateRequest"/> containing information on the template to be created</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>Newly created <see cref="BrandingPhoneNotificationTemplate"/></returns>
+    Task<BrandingPhoneNotificationTemplate> CreateBrandingPhoneNotificationTemplateAsync(BrandingPhoneNotificationTemplateCreateRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Get a phone notification template
+    /// </summary>
+    /// <param name="id">ID of the <see cref="BrandingPhoneNotificationTemplate"/></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns><see cref="BrandingPhoneNotificationTemplate"/></returns>
+    Task<BrandingPhoneNotificationTemplate> GetBrandingPhoneNotificationTemplateAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Delete a phone notification template
+    /// </summary>
+    /// <param name="id">ID of the <see cref="BrandingPhoneNotificationTemplate"/></param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns></returns>
+    Task DeleteBrandingPhoneNotificationTemplateAsync(string id, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Update a phone notification template
+    /// </summary>
+    /// <param name="id">ID of the Notification Template to be updated</param>
+    /// <param name="request"><see cref="BrandingPhoneNotificationTemplateUpdateRequest"/> containing information to be updated</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>Updated <see cref="BrandingPhoneNotificationTemplate"/></returns>
+    Task<BrandingPhoneNotificationTemplate> UpdateBrandingPhoneNotificationTemplate(string id, BrandingPhoneNotificationTemplateUpdateRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Resets a phone notification template values
+    /// </summary>
+    /// <param name="id">ID of the Notification Template to be reset</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>Updated <see cref="BrandingPhoneNotificationTemplate"/></returns>
+    Task<BrandingPhoneNotificationTemplate> ResetBrandingPhoneNotificationTemplate(string id, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Send a test phone notification for the configured template
+    /// </summary>
+    /// <param name="id">Id of the Branding Phone Notification Template</param>
+    /// <param name="request"><see cref="BrandingPhoneTestNotificationRequest"/></param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns><see cref="BrandingPhoneTestNotificationResponse"/></returns>
+    Task<BrandingPhoneTestNotificationResponse> SendBrandingPhoneTemplateTestNotificationAsync(string id, BrandingPhoneTestNotificationRequest request, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplateCreateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplateCreateRequest.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingPhoneNotificationTemplateCreateRequest
+    {
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public BrandingPhoneNotificationTemplateType? Type { get; set; }
+        
+        /// <summary>
+        /// Whether the template is enabled (false) or disabled (true).
+        /// </summary>
+        [JsonProperty("disabled")]
+        public bool? Disabled { get; set; }
+        
+        [JsonProperty("content")]
+        public Content Content { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplateUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplateUpdateRequest.cs
@@ -1,0 +1,16 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingPhoneNotificationTemplateUpdateRequest
+    {
+        [JsonProperty("content")]
+        public Content Content { get; set; }
+        
+        /// <summary>
+        /// Whether the template is enabled (false) or disabled (true).
+        /// </summary>
+        [JsonProperty("disabled")]
+        public bool? Disabled { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplates.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplates.cs
@@ -1,0 +1,82 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingPhoneNotificationTemplate
+    {
+        [JsonProperty("id")]
+        public string Id { get; set; }
+
+        [JsonProperty("channel")]
+        public string Channel { get; set; }
+
+        [JsonProperty("customizable")]
+        public bool? Customizable { get; set; }
+
+        [JsonProperty("tenant")]
+        public string Tenant { get; set; }
+
+        [JsonProperty("content")]
+        public Content Content { get; set; }
+
+        [JsonProperty("type")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public BrandingPhoneNotificationTemplateType Type { get; set; }
+
+        /// <summary>
+        /// Whether the template is enabled (false) or disabled (true).
+        /// </summary>
+        [JsonProperty("disabled")]
+        public bool Disabled { get; set; }
+    }
+
+    public class Content
+    {
+        [JsonProperty("syntax")]
+        public string Syntax { get; set; }
+        
+        /// <summary>
+        /// Default phone number to be used as 'from' when sending a phone notification
+        /// </summary>
+        [JsonProperty("from")]
+        public string From { get; set; }
+        
+        [JsonProperty("body")]
+        public ContentBody Body { get; set; }
+    }
+
+    public class ContentBody
+    {
+        /// <summary>
+        /// Content of the phone template for text notifications
+        /// </summary>
+        [JsonProperty("text")]
+        public string Text { get; set; }
+        
+        /// <summary>
+        /// Content of the phone template for voice notifications
+        /// </summary>
+        [JsonProperty("voice")]
+        public string Voice { get; set; }
+    }
+
+    public enum BrandingPhoneNotificationTemplateType
+    {
+        [EnumMember(Value = "otp_verify")]
+        OtpVerify,
+        
+        [EnumMember(Value = "otp_enroll")]
+        OtpEnroll,
+        
+        [EnumMember(Value = "change_password")]
+        ChangePassword,
+        
+        [EnumMember(Value = "blocked_account")]
+        BlockedAccount,
+        
+        [EnumMember(Value = "password_breach")]
+        PasswordBreach,
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplatesGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneNotificationTemplatesGetRequest.cs
@@ -1,0 +1,7 @@
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingPhoneNotificationTemplatesGetRequest
+    {
+        public bool? Disabled { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneTestNotificationRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneTestNotificationRequest.cs
@@ -1,0 +1,19 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingPhoneTestNotificationRequest
+    {
+        /// <summary>
+        /// The recipient phone number to receive a given notification.
+        /// </summary>
+        [JsonProperty("to")]
+        public string To { get; set; }
+        
+        /// <summary>
+        /// The delivery method for the notification
+        /// </summary>
+        [JsonProperty("delivery_method")]
+        public string DeliveryMethod { get; set; }
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneTestNotificationResponse.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneTestNotificationResponse.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingPhoneTestNotificationResponse
+    {
+        /// <summary>
+        /// The status code of the operation.
+        /// </summary>
+        [JsonProperty("code")]
+        public int Code { get; set; }
+        
+        /// <summary>
+        /// The description of the operation status.
+        /// </summary>
+        [JsonProperty("message")]
+        public string Message { get; set; }
+    }
+}


### PR DESCRIPTION
### Changes
Added support for the following end-points
- [POST  /api/v2/branding/phone/providers/{id}/try](https://auth0.com/docs/api/management/v2/branding/try-phone-provider)
- [GET  /api/v2/branding/phone/templates](https://auth0.com/docs/api/management/v2/branding/get-phone-templates)
- [POST  /api/v2/branding/phone/templates](https://auth0.com/docs/api/management/v2/branding/create-phone-template)
- [GET  /api/v2/branding/phone/templates/{id}](https://auth0.com/docs/api/management/v2/branding/get-phone-template)
- [DELETE  /api/v2/branding/phone/templates/{id}](https://auth0.com/docs/api/management/v2/branding/delete-phone-template)
- [PATCH  /api/v2/branding/phone/templates/{id}](https://auth0.com/docs/api/management/v2/branding/update-phone-template)
- [PATCH  /api/v2/branding/phone/templates/{id}/reset](https://auth0.com/docs/api/management/v2/branding/reset-phone-template)
- [POST  /api/v2/branding/phone/templates/{id}/try](https://auth0.com/docs/api/management/v2/branding/try-phone-template)


### References

- [SDK-5043](https://auth0team.atlassian.net/browse/SDK-5043)

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5043]: https://auth0team.atlassian.net/browse/SDK-5043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ