### PR TITLE
Adding support for managing branding theme

### DIFF
--- a/src/Auth0.ManagementApi/Clients/BrandingClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BrandingClient.cs
@@ -277,5 +277,74 @@ namespace Auth0.ManagementApi.Clients
                 DefaultHeaders,
                 cancellationToken: cancellationToken);
         }
+
+        /// <inheritdoc />
+        public Task<BrandingTheme> CreateBrandingThemeAsync(
+            BrandingThemeCreateRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<BrandingTheme>(
+                HttpMethod.Post,
+                BuildUri($"branding/themes"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingTheme> GetDefaultBrandingThemeAsync(CancellationToken cancellationToken = default)
+        {
+            return Connection.GetAsync<BrandingTheme>(
+                BuildUri($"branding/themes/default"),
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingTheme> GetBrandingThemeAsync(string brandingThemeId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(brandingThemeId))
+            {
+                throw new ArgumentNullException(nameof(brandingThemeId));
+            }
+            
+            return Connection.GetAsync<BrandingTheme>(
+                BuildUri($"branding/themes/{EncodePath(brandingThemeId)}"),
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task DeleteBrandingThemeAsync(string brandingThemeId, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(brandingThemeId))
+            {
+                throw new ArgumentNullException(nameof(brandingThemeId));
+            }
+            
+            return Connection
+                .SendAsync<object>(
+                    HttpMethod.Delete,
+                    BuildUri($"branding/themes/{EncodePath(brandingThemeId)}"),
+                    null,
+                    DefaultHeaders,
+                    cancellationToken: cancellationToken);
+        }
+
+        /// <inheritdoc />
+        public Task<BrandingTheme> UpdateBrandingThemeAsync(string brandingThemeId, BrandingThemeUpdateRequest request, CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrEmpty(brandingThemeId))
+            {
+                throw new ArgumentNullException(nameof(brandingThemeId));
+            }
+            
+            return Connection.SendAsync<BrandingTheme>(
+                new HttpMethod("PATCH"),
+                BuildUri($"branding/themes/{EncodePath(brandingThemeId)}"),
+                request, 
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/IBrandingClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IBrandingClient.cs
@@ -162,5 +162,44 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
     /// <returns><see cref="BrandingPhoneTestNotificationResponse"/></returns>
     Task<BrandingPhoneTestNotificationResponse> SendBrandingPhoneTemplateTestNotificationAsync(string id, BrandingPhoneTestNotificationRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Create branding theme.
+    /// </summary>
+    /// <param name="request">A <see cref="BrandingThemeCreateRequest"/> containing information required for creating a <see cref="BrandingTheme"/></param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>A <see cref="BrandingTheme"/></returns>
+    Task<BrandingTheme> CreateBrandingThemeAsync(BrandingThemeCreateRequest request, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Retrieve default branding theme.
+    /// </summary>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>The default <see cref="BrandingTheme"/></returns>
+    Task<BrandingTheme> GetDefaultBrandingThemeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieve branding theme.
+    /// </summary>
+    /// <param name="brandingThemeId">ID of the branding Theme to retrieve</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>The <see cref="BrandingTheme"/></returns>
+    Task<BrandingTheme> GetBrandingThemeAsync(string brandingThemeId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Delete branding theme.
+    /// </summary>
+    /// <param name="brandingThemeId">ID of the branding Theme to delete</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    Task DeleteBrandingThemeAsync(string brandingThemeId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Update branding theme.
+    /// </summary>
+    /// <param name="brandingThemeId">ID of the branding Theme to update</param>
+    /// <param name="request">A <see cref="BrandingThemeUpdateRequest"/> containing information required for updating a <see cref="BrandingTheme"/></param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns>An updated <see cref="BrandingTheme"/></returns>
+    Task<BrandingTheme> UpdateBrandingThemeAsync(string brandingThemeId, BrandingThemeUpdateRequest request, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingTheme.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingTheme.cs
@@ -1,0 +1,23 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingTheme : BrandingThemeBase
+    {
+        /// <summary>
+        /// Theme ID
+        /// </summary>
+        [JsonProperty("themeId")]
+        public string ThemeId { get; set; }
+    }
+
+    public class BrandingThemeCreateRequest : BrandingThemeBase
+    {
+        
+    }
+    
+    public class BrandingThemeUpdateRequest : BrandingThemeBase
+    {
+        
+    }
+}

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingThemeBase.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingThemeBase.cs
@@ -1,0 +1,469 @@
+using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Auth0.ManagementApi.Models
+{
+    public class BrandingThemeBase
+    {
+        /// <summary>
+        /// Borders
+        /// </summary>
+        [JsonProperty("borders")]
+        public BrandingThemeBorder Borders { get; set; }
+        
+        /// <summary>
+        /// Colors
+        /// </summary>
+        [JsonProperty("colors")]
+        public BrandingThemeColors Colors { get; set; }
+        
+        /// <summary>
+        /// Display Name
+        /// </summary>
+        [JsonProperty("displayName")]
+        public string DisplayName { get; set; }
+        
+        /// <summary>
+        /// Fonts
+        /// </summary>
+        [JsonProperty("fonts")]
+        public BrandingThemeFonts Fonts { get; set; }
+        
+        /// <summary>
+        /// Page Background
+        /// </summary>
+        [JsonProperty("page_background")]
+        public BrandingThemePageBackground PageBackground { get; set; }
+        
+        /// <summary>
+        /// Widget
+        /// </summary>
+        [JsonProperty("widget")]
+        public BrandingThemeWidget Widget { get; set; }
+    }
+
+    public class BrandingThemeBorder
+    {
+        /// <summary>
+        /// Button border radius
+        /// </summary>
+        [JsonProperty("button_border_radius")]
+        public int ButtonBorderRadius { get; set; }
+        
+        /// <summary>
+        /// Button border weight
+        /// </summary>
+        [JsonProperty("button_border_weight")]
+        public int ButtonBorderWeight { get; set; }
+        
+        /// <summary>
+        /// Possible values: [pill, rounded, sharp]
+        /// Buttons style
+        /// </summary>
+        [JsonProperty("buttons_style")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ButtonsStyle ButtonsStyle { get; set; }
+        
+        /// <summary>
+        /// Input border radius
+        /// </summary>
+        [JsonProperty("input_border_radius")]
+        public int InputBorderRadius { get; set; }
+        
+        /// <summary>
+        /// Input border weight
+        /// </summary>
+        [JsonProperty("input_border_weight")]
+        public int InputBorderWeight { get; set; }
+        
+        /// <summary>
+        /// Possible values: [pill, rounded, sharp]
+        /// Inputs style
+        /// </summary>
+        [JsonProperty("inputs_style")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public ButtonsStyle InputsStyle { get; set; }
+        
+        /// <summary>
+        /// Show widget shadow
+        /// </summary>
+        [JsonProperty("show_widget_shadow")]
+        public bool? ShowWidgetShadow { get; set; }
+        
+        /// <summary>
+        /// Widget border weight
+        /// </summary>
+        [JsonProperty("widget_border_weight")]
+        public int WidgetBorderWeight { get; set; }
+        
+        /// <summary>
+        /// Widget corner radius
+        /// </summary>
+        [JsonProperty("widget_corner_radius")]
+        public int WidgetCornerRadius { get; set; }
+    }
+
+    public class BrandingThemeColors
+    {
+        /// <summary>
+        /// Base Focus Color
+        /// </summary>
+        [JsonProperty("base_focus_color")]
+        public string BaseFocusColor { get; set; }
+        
+        /// <summary>
+        /// Base Hover Color
+        /// </summary>
+        [JsonProperty("base_hover_color")]
+        public string BaseHoverColor { get; set; }
+        
+        /// <summary>
+        /// Body text
+        /// </summary>
+        [JsonProperty("body_text")]
+        public string BodyText { get; set; }
+        
+        /// <summary>
+        /// Captcha Widget Theme
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("captcha_widget_theme")]
+        public CaptchaWidgetTheme CaptchaWidgetTheme { get; set; }
+        
+        /// <summary>
+        /// Error
+        /// </summary>
+        [JsonProperty("error")]
+        public string Error { get; set; }
+        
+        /// <summary>
+        /// Header
+        /// </summary>
+        [JsonProperty("header")]
+        public string Header { get; set; }
+        
+        /// <summary>
+        /// Icons
+        /// </summary>
+        [JsonProperty("icons")]
+        public string Icons { get; set; }
+        
+        /// <summary>
+        /// Input background
+        /// </summary>
+        [JsonProperty("input_background")]
+        public string InputBackground { get; set; }
+        
+        /// <summary>
+        /// Input border
+        /// </summary>
+        [JsonProperty("input_border")]
+        public string InputBorder { get; set; }
+        
+        /// <summary>
+        /// Input filled text
+        /// </summary>
+        [JsonProperty("input_filled_text")]
+        public string InputFilledText { get; set; }
+        
+        /// <summary>
+        /// Input labels & placeholders
+        /// </summary>
+        [JsonProperty("input_labels_placeholders")]
+        public string InputLabelsPlaceholders { get; set; }
+        
+        /// <summary>
+        /// Links & focused components
+        /// </summary>
+        [JsonProperty("links_focused_components")]
+        public string LinksFocusedComponents { get; set; }
+        
+        /// <summary>
+        /// Primary button
+        /// </summary>
+        [JsonProperty("primary_button")]
+        public string PrimaryButton { get; set; }
+        
+        /// <summary>
+        /// Primary button label
+        /// </summary>
+        [JsonProperty("primary_button_label")]
+        public string PrimaryButtonLabel { get; set; }
+        
+        /// <summary>
+        /// Secondary button border
+        /// </summary>
+        [JsonProperty("secondary_button_border")]
+        public string SecondaryButtonBorder { get; set; }
+        
+        /// <summary>
+        /// Secondary button label
+        /// </summary>
+        [JsonProperty("secondary_button_label")]
+        public string SecondaryButtonLabel { get; set; }
+        
+        /// <summary>
+        /// Success
+        /// </summary>
+        [JsonProperty("success")]
+        public string Success { get; set; }
+        
+        /// <summary>
+        /// Widget background
+        /// </summary>
+        [JsonProperty("widget_background")]
+        public string WidgetBackground { get; set; }
+        
+        /// <summary>
+        /// Widget border
+        /// </summary>
+        [JsonProperty("widget_border")]
+        public string WidgetBorder { get; set; }
+    }
+
+    public class BrandingThemeFonts
+    {
+        /// <summary>
+        /// Body text
+        /// </summary>
+        [JsonProperty("body_text")]
+        public BodyText BodyText { get; set; }
+        
+        /// <summary>
+        /// Body text
+        /// </summary>
+        [JsonProperty("buttons_text")]
+        public ButtonsText ButtonsText { get; set; }
+        
+        /// <summary>
+        /// Font URL
+        /// </summary>
+        [JsonProperty("font_url")]
+        public string FontUrl { get; set; }
+        
+        /// <summary>
+        /// Input Labels
+        /// </summary>
+        [JsonProperty("input_labels")]
+        public InputLabels InputLabels { get; set; }
+        
+        /// <summary>
+        /// Links
+        /// </summary>
+        [JsonProperty("links")]
+        public Links Links { get; set; }
+        
+        /// <summary>
+        /// Links style
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("links_style")]
+        public LinksStyle LinksStyle { get; set; }
+        
+        /// <summary>
+        /// Reference text size
+        /// </summary>
+        [JsonProperty("reference_text_size")]
+        public int ReferenceTextSize { get; set; }
+        
+        /// <summary>
+        /// Subtitle
+        /// </summary>
+        [JsonProperty("subtitle")]
+        public Subtitle Subtitle { get; set; }
+        
+        /// <summary>
+        /// Title
+        /// </summary>
+        [JsonProperty("title")]
+        public Title Title { get; set; }
+    }
+
+    public class BrandingThemePageBackground
+    {
+        /// <summary>
+        /// Background color
+        /// </summary>
+        [JsonProperty("background_color")]
+        public string BackgroundColor { get; set; }
+        
+        /// <summary>
+        /// Background image url
+        /// </summary>
+        [JsonProperty("background_image_url")]
+        public string BackgroundImageUrl { get; set; }
+        
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("page_layout")]
+        public PageLayout PageLayout { get; set; }
+    }
+
+    public class BrandingThemeWidget
+    {
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("header_text_alignment")]
+        public HeaderTextAlignment HeaderTextAlignment { get; set; }
+        
+        /// <summary>
+        /// Logo height
+        /// </summary>
+        [JsonProperty("logo_height")]
+        public int LogoHeight { get; set; }
+        
+        /// <summary>
+        /// Logo Position
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("logo_position")]
+        public LogoPosition LogoPosition { get; set; }
+        
+        /// <summary>
+        /// Logo url
+        /// </summary>
+        [JsonProperty("logo_url")]
+        public string LogoUrl { get; set; }
+        
+        /// <summary>
+        /// Social buttons layout
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("social_buttons_layout")]
+        public SocialButtonsLayout SocialButtonsLayout { get; set; }
+    }
+    
+    public class BrandingThemeFontsBase
+    {
+        [JsonProperty("bold")]
+        public bool? Bold { get; set; }
+        
+        [JsonProperty("size")]
+        public int Size { get; set; }
+    }
+    
+    public class BodyText : BrandingThemeFontsBase
+    {
+    }
+    
+    public class ButtonsText : BrandingThemeFontsBase
+    {
+    }
+    
+    public class InputLabels : BrandingThemeFontsBase
+    {
+    }
+    
+    public class Links : BrandingThemeFontsBase
+    {
+    }
+    
+    public class Subtitle : BrandingThemeFontsBase
+    {
+    }
+    
+    public class Title : BrandingThemeFontsBase
+    {
+    }
+    
+    /// <summary>
+    /// Buttons Style
+    /// </summary>
+    public enum ButtonsStyle
+    {
+        [EnumMember(Value = "pill")]
+        Pill,
+        
+        [EnumMember(Value = "rounded")]
+        Rounded,
+        
+        [EnumMember(Value = "sharp")]
+        Sharp,
+    }
+    
+    /// <summary>
+    /// Captcha Widget Theme
+    /// </summary>
+    public enum CaptchaWidgetTheme
+    {
+        [EnumMember(Value = "auto")]
+        Auto,
+        
+        [EnumMember(Value = "dark")]
+        Dark,
+        
+        [EnumMember(Value = "light")]
+        Light,
+    }
+    
+    /// <summary>
+    /// Links style
+    /// </summary>
+    public enum LinksStyle
+    {
+        [EnumMember(Value = "normal")]
+        Normal,
+        
+        [EnumMember(Value = "underlined")]
+        Underlined,
+    }
+    
+    /// <summary>
+    /// Page Layout
+    /// </summary>
+    public enum PageLayout
+    {
+        [EnumMember(Value = "center")]
+        Center,
+        
+        [EnumMember(Value = "left")]
+        Left,
+        
+        [EnumMember(Value = "right")]
+        Right,
+    }
+    
+    /// <summary>
+    /// Header text alignment 
+    /// </summary>
+    public enum HeaderTextAlignment
+    {
+        [EnumMember(Value = "center")]
+        Center,
+        
+        [EnumMember(Value = "left")]
+        Left,
+        
+        [EnumMember(Value = "right")]
+        Right,
+    }
+    
+    /// <summary>
+    /// Logo Position 
+    /// </summary>
+    public enum LogoPosition
+    {
+        [EnumMember(Value = "center")]
+        Center,
+        
+        [EnumMember(Value = "left")]
+        Left,
+        
+        [EnumMember(Value = "right")]
+        Right,
+        
+        [EnumMember(Value = "none")]
+        None,
+    }
+    
+    /// <summary>
+    /// Social buttons layout 
+    /// </summary>
+    public enum SocialButtonsLayout
+    {
+        [EnumMember(Value = "bottom")]
+        Bottom,
+        
+        [EnumMember(Value = "top")]
+        Top,
+    }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/BrandingClientTests.cs
@@ -5,6 +5,7 @@ using Auth0.ManagementApi.IntegrationTests.Testing;
 using Auth0.ManagementApi.Models;
 using Auth0.Tests.Shared;
 using FluentAssertions;
+using FluentAssertions.Common;
 using Xunit;
 
 namespace Auth0.ManagementApi.IntegrationTests
@@ -221,6 +222,13 @@ namespace Auth0.ManagementApi.IntegrationTests
         }
         
         [Fact]
+        public async void Test_GetBrandingTheme_should_throw_for_null_input()
+        {
+            await Assert.ThrowsAsync<ArgumentNullException>(
+                () => fixture.ApiClient.Branding.GetBrandingThemeAsync(null));
+        }
+        
+        [Fact]
         public async void Test_BrandingPhoneNotificationTemplate_crud_sequence()
         {
             BrandingPhoneNotificationTemplate createdBrandingPhoneNotificationTemplate = null;
@@ -301,6 +309,214 @@ namespace Auth0.ManagementApi.IntegrationTests
                     new BrandingPhoneNotificationTemplatesGetRequest());
             allBrandingPhoneNotificationTemplates.Should()
                 .NotContain(x => x.Id == createdBrandingPhoneNotificationTemplate.Id);
+        }
+
+        [Fact]
+        public async void Test_BrandingTheme_crud_sequence()
+        {
+            // Create a branding theme 
+            var createBrandingThemeRequest = new BrandingThemeCreateRequest()
+            {
+                Borders = new BrandingThemeBorder()
+                {
+                    ButtonBorderRadius = 1,
+                    ButtonBorderWeight = 2,
+                    ButtonsStyle = ButtonsStyle.Rounded,
+                    InputBorderRadius = 3,
+                    InputBorderWeight = 3,
+                    InputsStyle = ButtonsStyle.Pill,
+                    ShowWidgetShadow = true,
+                    WidgetBorderWeight = 5,
+                    WidgetCornerRadius = 5
+                },
+                Colors = new BrandingThemeColors()
+                {
+                    BaseFocusColor = "#abcabc",
+                    BaseHoverColor = "#abcabc",
+                    BodyText = "#abcabc",
+                    CaptchaWidgetTheme = CaptchaWidgetTheme.Dark,
+                    Error = "#abcabc",
+                    Header = "#abcabc",
+                    Icons = "#abcabc",
+                    InputBackground = "#abcabc",
+                    InputBorder = "#abcabc",
+                    InputFilledText = "#abcabc",
+                    InputLabelsPlaceholders = "#abcabc",
+                    LinksFocusedComponents = "#abcabc",
+                    PrimaryButton = "#abcabc",
+                    PrimaryButtonLabel = "#abcabc",
+                    SecondaryButtonBorder = "#abcabc",
+                    SecondaryButtonLabel = "#abcabc",
+                    Success = "#abaabc",
+                    WidgetBackground = "#abcaba",
+                    WidgetBorder = "#abcabc"
+                },
+                DisplayName = "Test branding Theme",
+                Fonts = new BrandingThemeFonts()
+                {
+                    BodyText = new BodyText()
+                    {
+                        Bold = true,
+                        Size = 3
+                    },
+                    ButtonsText = new ButtonsText()
+                    {
+                        Size = 10,
+                        Bold = false
+                    },
+                    FontUrl = "https://some.randomurl.com/",
+                    InputLabels = new InputLabels()
+                    {
+                        Bold = true
+                    },
+                    Links = new Links()
+                    {
+                        Bold = false
+                    },
+                    LinksStyle = LinksStyle.Normal,
+                    ReferenceTextSize = 12,
+                    Subtitle = new Subtitle()
+                    {
+                        Bold = true,
+                        Size = 5
+                    },
+                    Title = new Title()
+                    {
+                        Bold = true,
+                        Size = 75
+                    }
+                },
+                PageBackground = new BrandingThemePageBackground()
+                {
+                    BackgroundColor = "#abcabc",
+                    BackgroundImageUrl = "https://another-random-url.com/",
+                    PageLayout = PageLayout.Left
+                },
+                Widget = new BrandingThemeWidget()
+                {
+                    HeaderTextAlignment = HeaderTextAlignment.Center,
+                    LogoHeight = 10,
+                    LogoPosition = LogoPosition.Center,
+                    LogoUrl = "https://logo-url.com/",
+                    SocialButtonsLayout = SocialButtonsLayout.Bottom
+                    
+                }
+            };
+            var createdBrandingTheme =
+                await fixture.ApiClient.Branding.CreateBrandingThemeAsync(createBrandingThemeRequest);
+
+            try
+            {
+                createdBrandingTheme.Should().BeEquivalentTo(createBrandingThemeRequest, options => options.ExcludingMissingMembers());
+
+                // Get the default branding theme
+                var defaultBrandingTheme =
+                    await fixture.ApiClient.Branding.GetDefaultBrandingThemeAsync();
+                defaultBrandingTheme.Should().NotBeNull();
+
+                // Update a branding theme 
+                var updateRequest = new BrandingThemeUpdateRequest()
+                {
+                    Borders = new BrandingThemeBorder()
+                    {
+                        ButtonBorderRadius = 1,
+                        ButtonBorderWeight = 2,
+                        ButtonsStyle = ButtonsStyle.Pill,
+                        InputBorderRadius = 3,
+                        InputBorderWeight = 3,
+                        InputsStyle = ButtonsStyle.Pill,
+                        ShowWidgetShadow = true,
+                        WidgetBorderWeight = 5,
+                        WidgetCornerRadius = 5
+                    },
+                    Colors = new BrandingThemeColors()
+                    {
+                        BaseFocusColor = "#abcabc",
+                        BaseHoverColor = "#abcabc",
+                        BodyText = "#abcabc",
+                        CaptchaWidgetTheme = CaptchaWidgetTheme.Dark,
+                        Error = "#accabc",
+                        Header = "#abcabc",
+                        Icons = "#abcabc",
+                        InputBackground = "#abcabc",
+                        InputBorder = "#abcabc",
+                        InputFilledText = "#abcabc",
+                        InputLabelsPlaceholders = "#abcabc",
+                        LinksFocusedComponents = "#abcabc",
+                        PrimaryButton = "#abcabc",
+                        PrimaryButtonLabel = "#abcabc",
+                        SecondaryButtonBorder = "#abcabc",
+                        SecondaryButtonLabel = "#abcabc",
+                        Success = "#abaabc",
+                        WidgetBackground = "#abcaba",
+                        WidgetBorder = "#abcabc"
+                    },
+                    DisplayName = "Test branding Theme",
+                    Fonts = new BrandingThemeFonts()
+                    {
+                        BodyText = new BodyText()
+                        {
+                            Bold = true,
+                            Size = 3
+                        },
+                        ButtonsText = new ButtonsText()
+                        {
+                            Size = 10,
+                            Bold = false
+                        },
+                        FontUrl = "https://some.randomurl.com/",
+                        InputLabels = new InputLabels()
+                        {
+                            Bold = true
+                        },
+                        Links = new Links()
+                        {
+                            Bold = false
+                        },
+                        LinksStyle = LinksStyle.Normal,
+                        ReferenceTextSize = 12,
+                        Subtitle = new Subtitle()
+                        {
+                            Bold = true,
+                            Size = 5
+                        },
+                        Title = new Title()
+                        {
+                            Bold = true,
+                            Size = 75
+                        }
+                    },
+                    PageBackground = new BrandingThemePageBackground()
+                    {
+                        BackgroundColor = "#abcabc",
+                        BackgroundImageUrl = "https://another-random-url.com/",
+                        PageLayout = PageLayout.Left
+                    },
+                    Widget = new BrandingThemeWidget()
+                    {
+                        HeaderTextAlignment = HeaderTextAlignment.Center,
+                        LogoHeight = 10,
+                        LogoPosition = LogoPosition.Left,
+                        LogoUrl = "https://logo-url.com/",
+                        SocialButtonsLayout = SocialButtonsLayout.Bottom
+                        
+                    }
+                };
+                var updatedBrandingTheme =
+                    await fixture.ApiClient.Branding.UpdateBrandingThemeAsync(createdBrandingTheme.ThemeId, updateRequest);
+            
+                updatedBrandingTheme.Widget.LogoPosition.Should().Be(LogoPosition.Left);
+            
+                // get the branding theme 
+                var fetchBrandingTheme = await fixture.ApiClient.Branding.GetBrandingThemeAsync(createdBrandingTheme.ThemeId);
+                fetchBrandingTheme.Should().BeEquivalentTo(updatedBrandingTheme, options => options.Excluding( x => x.ThemeId));
+
+            }
+            finally
+            {
+                // delete the branding theme
+                await fixture.ApiClient.Branding.DeleteBrandingThemeAsync(createdBrandingTheme.ThemeId);
+            }
         }
     }
 }


### PR DESCRIPTION
### Changes
Added support for the following end-points:
- [POST  /api/v2/branding/themes](https://auth0.com/docs/api/management/v2/branding/post-branding-theme)
- [GET  /api/v2/branding/themes/default](https://auth0.com/docs/api/management/v2/branding/get-default-branding-theme)
- [GET  /api/v2/branding/themes/{themeId}](https://auth0.com/docs/api/management/v2/branding/get-branding-theme)
- [DELETE  /api/v2/branding/themes/{themeId}](https://auth0.com/docs/api/management/v2/branding/delete-branding-theme)
- [PATCH  /api/v2/branding/themes/{themeId}](https://auth0.com/docs/api/management/v2/branding/patch-branding-theme)

### References
- Addresses the ask in #754 
- [SDK-5611](https://auth0team.atlassian.net/browse/SDK-5611)

### Testing
Added the `Test_BrandingTheme_crud_sequence` test case that creates a new branding theme, gets the default theme, updates the existing branding theme, fetches a particular branding theme by ID and later deletes the newly created branding theme. We can refer to the test case for an actual working example of how to create / get / update / delete the Branding end-point.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5611]: https://auth0team.atlassian.net/browse/SDK-5611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ