### PR TITLE
Add support for email verification_method in ConnectionOptions

### DIFF
--- a/src/Auth0.ManagementApi/Models/Connections/ConnectionOptionsEmailAttribute.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/ConnectionOptionsEmailAttribute.cs
@@ -12,5 +12,12 @@ namespace Auth0.ManagementApi.Models.Connections
         /// </summary>
         [JsonProperty("signup")]
         public ConnectionOptionsEmailSignup Signup { get; set; }
+
+        /// <summary>
+        /// Gets or sets the verification method for email.
+        /// </summary>
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("verification_method")]
+        public ConnectionOptionsEmailVerificationMethod? VerificationMethod { get; set; }
     }
 }

--- a/src/Auth0.ManagementApi/Models/Connections/ConnectionOptionsEmailVerificationMethod.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/ConnectionOptionsEmailVerificationMethod.cs
@@ -1,0 +1,22 @@
+using System.Runtime.Serialization;
+
+namespace Auth0.ManagementApi.Models.Connections
+{
+    /// <summary>
+    /// Verification methods for email authentication
+    /// </summary>
+    public enum ConnectionOptionsEmailVerificationMethod
+    {
+        /// <summary>
+        /// Use magic link for verification
+        /// </summary>
+        [EnumMember(Value = "link")]
+        Link,
+
+        /// <summary>
+        /// Use one-time password for verification
+        /// </summary>
+        [EnumMember(Value = "otp")]
+        Otp
+    }
+}


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

This PR adds support for the `verification_method` property on the `ConnectionOptionsEmailAttribute` class, allowing developers to specify whether email verification should use a magic link ("link") or a one-time password ("otp").

Specifically:
- Added a new `ConnectionOptionsEmailVerificationMethod` enum with `Link` and `Otp` values
- Added a new `VerificationMethod` property to the `ConnectionOptionsEmailAttribute` class

This change is important because the Auth0 Management API supports configuring email verification methods, but the .NET SDK currently lacks this capability. This forces developers to either use direct HTTP calls or be limited to the default magic link verification.

### References

Issue #787 

The Auth0 Management API documentation showing the verification_method property:
https://auth0.com/docs/api/management/v2#!/Connections/post_connections

### Testing

The change has been manually tested on the latest version of the platform to verify:
- Proper serialization of the verification_method property when creating connections
- The Auth0 API correctly accepts and processes the property
- Creating connections with both "link" and "otp" verification methods works as expected

I didn't add automated tests because:
- The change is limited to adding a property to an existing model class
- Similar model properties in the codebase generally don't have dedicated unit tests

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
