### PR TITLE
Add missing backchannel logout initiators to model type.

### DIFF
--- a/src/Auth0.ManagementApi/Models/LogoutInitiators.cs
+++ b/src/Auth0.ManagementApi/Models/LogoutInitiators.cs
@@ -26,6 +26,24 @@ namespace Auth0.ManagementApi.Models
         /// Request was initiated when a session expires.
         /// </summary>
         [EnumMember(Value = "session-expired")]
-        SessionExpired
+        SessionExpired,
+
+        /// <summary>
+        /// Request was initiated by session deletion.
+        /// </summary>
+        [EnumMember(Value = "session-revoked")]
+        SessionRevoked,
+
+        /// <summary>
+        /// Request was initiated by an account deletion.
+        /// </summary>
+        [EnumMember(Value = "account-deleted")]
+        AccountDeleted,
+
+        /// <summary>
+        /// Request was initiated by an email identifier change.
+        /// </summary>
+        [EnumMember(Value = "email-identifier-changed")]
+        EmailIdentifierChanged
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -71,7 +71,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                     BackchannelLogoutInitiators = new BackchannelLogoutInitiators
                     {
                         Mode = LogoutInitiatorModes.Custom,
-                        SelectedInitiators = new [] { LogoutInitiators.RpLogout, LogoutInitiators.IdpLogout, LogoutInitiators.PasswordChanged }
+                        SelectedInitiators = new[] { LogoutInitiators.RpLogout, LogoutInitiators.IdpLogout, LogoutInitiators.PasswordChanged, LogoutInitiators.SessionRevoked, LogoutInitiators.AccountDeleted, LogoutInitiators.EmailIdentifierChanged }
                     },
                     BackchannelLogoutUrls = new [] { "https://create.com/logout" }
                 },


### PR DESCRIPTION
### Changes

If a client is configured with a certain backchannel logout initiators, any GetClient calls to the management API using the Auth0 SDK will fail with a serialisation exception.

e.g. 
```
"Message": "Error converting value \"email-identifier-changed\" to type 'Auth0.ManagementApi.Models.LogoutInitiators'. 
Path 'oidc_logout.backchannel_logout_initiators.selected_initiators[2]', line 1, position 2385."
```

The following will cause failures on the latest Auth0 SDK version:

| Value | Description |
| -------- | ------- |
| session-revoked  | Request was initiated by session deletion. |
| account-deleted| Request was initiated by an account deletion. |
| email-identifier-changed| Request was initiated by an email identifier change. |

### References

The additions to the enumeration come from https://auth0.com/docs/authenticate/login/logout/back-channel-logout/oidc-back-channel-logout-initiators#selected-initiators-property so this PR ensures all initiators currently documented are supported by the SDK.

### Testing

- [X] This change adds unit test coverage

- [X] This change adds integration test coverage

- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [X] All existing and new tests complete without errors
