### PR TITLE
Adds missing backchannel logout initiators

### DIFF
--- a/src/Auth0.ManagementApi/Models/LogoutInitiators.cs
+++ b/src/Auth0.ManagementApi/Models/LogoutInitiators.cs
@@ -26,6 +26,24 @@ namespace Auth0.ManagementApi.Models
         /// Request was initiated when a session expires.
         /// </summary>
         [EnumMember(Value = "session-expired")]
-        SessionExpired
+        SessionExpired,
+
+        /// <summary>
+        /// Request was initiated by session deletion.
+        /// </summary>
+        [EnumMember(Value = "session-revoked")]
+        SessionRevoked,
+
+        /// <summary>
+        /// Request was initiated by an account deletion.
+        /// </summary>
+        [EnumMember(Value = "account-deleted")]
+        AccountDeleted,
+
+        /// <summary>
+        /// Request was initiated by an email identifier change.
+        /// </summary>
+        [EnumMember(Value = "email-identifier-changed")]
+        EmailIdentifierChanged
     }
 }

--- a/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ClientTests.cs
@@ -45,6 +45,16 @@ namespace Auth0.ManagementApi.IntegrationTests
         public async Task Test_client_crud_sequence()
         {
             string existingOrganizationId = "org_V6ojENVd1ERs5YY1";
+            var selectedInitiators = new[]
+            {
+                LogoutInitiators.RpLogout,
+                LogoutInitiators.IdpLogout,
+                LogoutInitiators.PasswordChanged,
+                LogoutInitiators.SessionRevoked,
+                LogoutInitiators.AccountDeleted,
+                LogoutInitiators.EmailIdentifierChanged
+            };
+            
             // Add a new client
             var newClientRequest = new ClientCreateRequest
             {
@@ -71,7 +81,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                     BackchannelLogoutInitiators = new BackchannelLogoutInitiators
                     {
                         Mode = LogoutInitiatorModes.Custom,
-                        SelectedInitiators = new [] { LogoutInitiators.RpLogout, LogoutInitiators.IdpLogout, LogoutInitiators.PasswordChanged }
+                        SelectedInitiators = selectedInitiators
                     },
                     BackchannelLogoutUrls = new [] { "https://create.com/logout" }
                 },
@@ -112,8 +122,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             newClientResponse.OrganizationRequireBehavior.Should().Be(OrganizationRequireBehavior.PreLoginPrompt);
             newClientResponse.OidcLogout.BackchannelLogoutUrls[0].Should().Be("https://create.com/logout");
             newClientResponse.OidcLogout.BackchannelLogoutInitiators.Mode.Should().Be(LogoutInitiatorModes.Custom);
-            newClientResponse.OidcLogout.BackchannelLogoutInitiators.SelectedInitiators.Length.Should().Be(3);
-            newClientResponse.OidcLogout.BackchannelLogoutInitiators.SelectedInitiators.Any(i => i == LogoutInitiators.PasswordChanged).Should().BeTrue();
+            newClientResponse.OidcLogout.BackchannelLogoutInitiators.SelectedInitiators.Should().BeEquivalentTo(selectedInitiators);
             newClientResponse.DefaultOrganization.OrganizationId.Should().Be(existingOrganizationId);
             newClientResponse.RequirePushedAuthorizationRequests.Should().BeTrue();
             newClientResponse.SignedRequestObject.Should().NotBeNull();
@@ -169,8 +178,7 @@ namespace Auth0.ManagementApi.IntegrationTests
             updateClientResponse.OrganizationRequireBehavior.Should().Be(OrganizationRequireBehavior.NoPrompt);
             updateClientResponse.OidcLogout.BackchannelLogoutUrls[0].Should().Be("https://create.com/logout");
             updateClientResponse.OidcLogout.BackchannelLogoutInitiators.Mode.Should().Be(LogoutInitiatorModes.Custom);
-            updateClientResponse.OidcLogout.BackchannelLogoutInitiators.SelectedInitiators.Length.Should().Be(3);
-            updateClientResponse.OidcLogout.BackchannelLogoutInitiators.SelectedInitiators.Any(i => i == LogoutInitiators.PasswordChanged).Should().BeTrue();
+            updateClientResponse.OidcLogout.BackchannelLogoutInitiators.SelectedInitiators.Should().BeEquivalentTo(selectedInitiators);
             updateClientResponse.DefaultOrganization.OrganizationId.Should().Be(existingOrganizationId);
             updateClientResponse.DefaultOrganization.Flows.Should().HaveCount(1);
             updateClientResponse.DefaultOrganization.Flows.First().Should().Be(Flows.ClientCredentials);


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Adds missing Backchannel logout Initiators 
- Built on top of contribution from [dmarjoram](https://github.com/dmarjoram) #794 

### References
- [Auth0 Docs](https://auth0.com/docs/authenticate/login/logout/back-channel-logout/oidc-back-channel-logout-initiators)
- [SDK-5823](https://auth0team.atlassian.net/browse/SDK-5823) 

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
