### PR TITLE
Fix for PasswordlessEmailRequest passing literal NULL when no client_secre…

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -395,7 +395,8 @@ namespace Auth0.AuthenticationApi
             }
             else
             {
-                body.client_secret = request.ClientSecret;
+                if (!string.IsNullOrEmpty(request.ClientSecret))
+                    body.client_secret = request.ClientSecret;
             }
 
             return connection.SendAsync<PasswordlessEmailResponse>(

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/PasswordlessTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/PasswordlessTests.cs
@@ -1,7 +1,4 @@
-﻿using Auth0.AuthenticationApi.Models;
-using Auth0.Tests.Shared;
-using FluentAssertions;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -9,10 +6,15 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
+
+using FluentAssertions;
 using Xunit;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
+
+using Auth0.AuthenticationApi.Models;
+using Auth0.Tests.Shared;
 
 namespace Auth0.AuthenticationApi.IntegrationTests
 {
@@ -87,6 +89,29 @@ namespace Auth0.AuthenticationApi.IntegrationTests
                 ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
                 Email = email,
                 Type = PasswordlessEmailRequestType.Code
+            };
+            var response = await authenticationApiClient.StartPasswordlessEmailFlowAsync(request);
+            response.Should().NotBeNull();
+            response.Email.Should().Be(request.Email);
+            response.Id.Should().NotBeNullOrEmpty();
+            response.EmailVerified.Should().NotBeNull();
+        }
+
+        [SkippableFact]
+        public async Task Can_launch_email_code_flow_for_SPA()
+        {
+            Skip.If(string.IsNullOrEmpty(email), "AUTH0_PASSWORDLESSDEMO_EMAIL not set");
+
+            var request = new PasswordlessEmailRequest
+            {
+                ClientId = "Qpnq5llXeWEn1o1iLYNQSr3zFI1YPg3K",
+                Email = email,
+                Type = PasswordlessEmailRequestType.Code,
+                AuthenticationParameters = new Dictionary<string, object>
+                {
+                    ["audience"] = "settings.Audience",
+                    ["scope"] = "openid profile email offline_access",
+                }
             };
             var response = await authenticationApiClient.StartPasswordlessEmailFlowAsync(request);
             response.Should().NotBeNull();


### PR DESCRIPTION
…t was provided

### Changes 
- Fixes #797 
#### The problem 
- We are internally constructing an `ExpandoObject` from the request and passing this as body to the API call. 
- Although we use the serialiser setting `NullValueHandling = NullValueHandling.Ignore` to ignore NULL values, we observed that the `NULL` value (for `client_secret`) in this case was still considered during serialisation. 
- On further analysis, it seems the ExpandoObject instance is treated more like a Dictionary than an instance of a class and in `NewtonSoft.JSON`, by design, the `NullValueHandling = NullValueHandling.Ignore` is only for instances of classes and not for objects like Dictionaries. A similar issue raised on [NewtonSoft.Json ](https://github.com/JamesNK/Newtonsoft.Json/issues/951)

#### The Fix 
- We have added a `NULL` check, wherever applicable, before we add a field to the `ExpandoObject`. This removes the field from the body and hence would not send any un-warranted data to the API as part of the request.

### References 📚 

Please include relevant links supporting this change such as a:

- [SDK-5859](https://auth0team.atlassian.net/browse/SDK-5859)
- https://github.com/JamesNK/Newtonsoft.Json/issues/951
- #797 

### Testing 

Added a test case that reproduces the scenario mentioned in #797 

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist ☑️ 

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5859]: https://auth0team.atlassian.net/browse/SDK-5859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ