### PR TITLE
Fix Scopes datatype

### DIFF
--- a/src/Auth0.ManagementApi/Models/LogEntry.cs
+++ b/src/Auth0.ManagementApi/Models/LogEntry.cs
@@ -144,7 +144,7 @@ namespace Auth0.ManagementApi.Models
         /// Scope permissions applied to the event
         /// </summary>
         [JsonProperty("scope")]
-        public string Scope { get; set; }
+        public string[] Scope { get; set; }
 
         /// <summary>
         /// Unique ID of the event

--- a/tests/Auth0.Core.UnitTests/ApiErrorDeserializationTests.cs
+++ b/tests/Auth0.Core.UnitTests/ApiErrorDeserializationTests.cs
@@ -21,6 +21,7 @@ namespace Auth0.Core.UnitTests
             Assert.Contains(parsed.ExtraData, (d) => d.Key == "mfa_token" && string.Equals(d.Value, "2x4b-r2d2-c3po-bb8-ig88"));
         }
 
+
         [Theory]
         [ClassData(typeof(ApiErrorDeserializationData))]
         public void Should_deserialize_all_error_structures_correctly(string content, ApiError expected)

--- a/tests/Auth0.Core.UnitTests/LogEntryDeserializationTests.cs
+++ b/tests/Auth0.Core.UnitTests/LogEntryDeserializationTests.cs
@@ -1,0 +1,46 @@
+﻿using Auth0.ManagementApi.Models;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Auth0.Core.UnitTests;
+
+public class LogEntryDeserializationTests
+{
+    [Fact]
+    public void Should_deserialize_scopes_as_array()
+    {
+        var content = @"{
+                      ""date"": ""2025-04-18T21:33:54.447Z"",
+                      ""type"": ""f"",
+                      ""user_agent"": ""Edge 135.0.0 / Windows 10.0.0"",
+                      ""scope"": [
+                        ""openid"",
+                        ""profile"",
+                        ""offline_access"",
+                      ],
+                    }";
+
+        var parsed = JsonConvert.DeserializeObject<LogEntry>(content);
+
+        Assert.Equal(new[] { "openid", "profile", "offline_access" }, parsed.Scope);
+
+    }
+
+    [Fact]
+    public void Should_deserialize_scopes_as_null_when_null()
+    {
+        var content = @"{
+                      ""date"": ""2025-04-18T21:33:54.447Z"",
+                      ""type"": ""f"",
+                      ""user_agent"": ""Edge 135.0.0 / Windows 10.0.0"",
+                      ""scope"": null,
+                    }";
+
+        var parsed = JsonConvert.DeserializeObject<LogEntry>(content);
+
+        Assert.Null(parsed.Scope);
+
+    }
+
+
+}


### PR DESCRIPTION
Can be an array of strings

### Changes

Please describe both what is changing and why this is important. Include:

- Classes and methods added, deleted, deprecated, or changed

changed LogEntry Scope type from string to string[]
This matches possible type and fixes json serialization error

here is the shape of data
`{
"date": "2025-04-18T21:33:54.447Z",
"type": "f",
"description": "OBMITTED",
"connection": "OBMITTED",
"connection_id": "OBMITTED",
"client_id": "OBMITTED",
"client_name": "OBMITTED",
"ip": "OBMITTED",
"user_agent": "OBMITTED",
"details": {
"body": {},
"qs": {
},

"error": {
"oauthError": "access_denied",
"type": "oauth-authorization"
},
"actions": {
},
"stats": {
"loginsCount": 8
}
},
"strategy_type": "enterprise",
"scope": [
    "openid",
    "profile",
    "offline_access",
],
}`


- NOTE this is a breaking change.

### References

Please include relevant links supporting this change such as a:

- support ticket
-https://github.com/auth0/auth0.net/issues/806

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
