### PR TITLE
Add support for Delete authenticators registered to a user

### DIFF
--- a/src/Auth0.ManagementApi/Clients/IUsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IUsersClient.cs
@@ -307,5 +307,13 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
     /// <returns></returns>
     Task DeleteSessionsAsync(string userId, CancellationToken cancellationToken = default);
+    
+    /// <summary>
+    /// Remove all authenticators registered to a given user ID, such as OTP, email, phone, and push-notification.
+    /// </summary>
+    /// <param name="userId">ID of the user to delete authenticators for</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/></param>
+    /// <returns></returns>
+    Task DeleteAuthenticatorsAsync(string userId, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/Clients/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Clients/UsersClient.cs
@@ -539,5 +539,15 @@ namespace Auth0.ManagementApi.Clients
                 null, 
                 DefaultHeaders, cancellationToken: cancellationToken);
         }
+
+        /// <inheritdoc cref="IUsersClient.DeleteAuthenticatorsAsync"/>
+        public Task DeleteAuthenticatorsAsync(string userId, CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<object>(
+                HttpMethod.Delete,
+                BuildUri($"users/{EncodePath(userId)}/authenticators"),
+                null, 
+                DefaultHeaders, cancellationToken: cancellationToken);
+        }
     }
 }


### PR DESCRIPTION
### Changes

- Added support for Deleting all Authenticators registered to a user.

### References

- [SDK-5706](https://auth0team.atlassian.net/browse/SDK-5706)
- #790 
- [Auth0 Docs](https://auth0.com/docs/api/management/v2/users/delete-authenticators) 


- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-5706]: https://auth0team.atlassian.net/browse/SDK-5706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ