### PR TITLE
Fix query generation in GetAllAsync

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -69,7 +69,7 @@ namespace Auth0.ManagementApi.Clients
                 {"include_fields", request.IncludeFields?.ToString().ToLower()},
                 {"is_global", request.IsGlobal?.ToString().ToLower()},
                 {"is_first_party", request.IsFirstParty?.ToString().ToLower()},
-                {"q", request.Query?.ToLower()}
+                {"q", request.Query}
             };
 
             if (pagination != null)
@@ -97,7 +97,7 @@ namespace Auth0.ManagementApi.Clients
                 {"include_fields", request.IncludeFields?.ToString().ToLower()},
                 {"is_global", request.IsGlobal?.ToString().ToLower()},
                 {"is_first_party", request.IsFirstParty?.ToString().ToLower()},
-                {"q", request.Query?.ToLower()}
+                {"q", request.Query}
             };
 
             if (pagination != null)

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -486,7 +486,25 @@ namespace Auth0.ManagementApi.IntegrationTests
             };
             
             // Act
-            var clients = await fixture.ApiClient.Clients.GetAllAsync(request, new CheckpointPaginationInfo(100));
+            var checkpointPagedClients =
+                await fixture.ApiClient.Clients.GetAllAsync(request, new CheckpointPaginationInfo(100));
+            
+            // Assert
+            Assert.Contains(checkpointPagedClients.ToList(), x => x.ClientId == client.ClientId);
+            
+            request = new GetClientsRequest()
+            {
+                Query = $"client_grant.organization_id:{organization.Id}"
+            };
+            
+            // Act
+            checkpointPagedClients = await fixture.ApiClient.Clients.GetAllAsync(request, new CheckpointPaginationInfo(100));
+            
+            // Assert
+            Assert.Contains(checkpointPagedClients.ToList(), x => x.ClientId == client.ClientId);
+            
+            // Act
+            var clients = await fixture.ApiClient.Clients.GetAllAsync(request);
             
             // Assert
             Assert.Contains(clients.ToList(), x => x.ClientId == client.ClientId);


### PR DESCRIPTION
### Changes

- Fixes an un-intended `.ToLower()` while generating the query parameter in `Clients.GetAllAsync()`

### References

- [SDK-6086](https://auth0team.atlassian.net/browse/SDK-6086)
- #815 

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-6086]: https://auth0team.atlassian.net/browse/SDK-6086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ