### PR TITLE
Deprecate `EnabledClients` in `Connections` in favour of Get and Update EnabledClients

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -17,6 +17,7 @@ namespace Auth0.ManagementApi.Clients
     {
         private readonly JsonConverter[] _converters = { new PagedListConverter<Connection>("connections") };
         readonly JsonConverter[] checkpointPaginationConverter = new JsonConverter[] { new CheckpointPagedListConverter<Connection>("connections") };
+        readonly JsonConverter[] enabledClientsCheckpointPaginationConverter = new JsonConverter[] { new CheckpointPagedListConverter<EnabledClients>("clients") };
         private readonly JsonConverter[] _defaultMappingsConverter = { new ListConverter<ScimMapping>("mapping") };
 
         /// <summary>
@@ -302,7 +303,7 @@ namespace Auth0.ManagementApi.Clients
                     $"connections/{EncodePath(request.ConnectionId)}/clients",
                     queryStrings),
                 DefaultHeaders,
-                checkpointPaginationConverter,
+                enabledClientsCheckpointPaginationConverter,
                 cancellationToken);
         }
         
@@ -312,7 +313,7 @@ namespace Auth0.ManagementApi.Clients
             return Connection.SendAsync<object>(
                 new HttpMethod("PATCH"),
                 BuildUri($"connections/{EncodePath(id)}/clients"),
-                request,
+                request.EnabledClients,
                 DefaultHeaders,
                 cancellationToken: cancellationToken);
         }

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Auth0.ManagementApi.Models.Connections;
 
 namespace Auth0.ManagementApi.Clients
 {
@@ -274,6 +275,46 @@ namespace Auth0.ManagementApi.Clients
         public Task DeleteScimTokenAsync(string id, string tokenId, CancellationToken cancellationToken = default)
         {
             return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"connections/{EncodePath(id)}/scim-configuration/tokens/{EncodePath(tokenId)}"), null, DefaultHeaders, cancellationToken: cancellationToken);
+        }
+        
+        /// <inheritdoc />
+        public Task<ICheckpointPagedList<EnabledClients>> GetEnabledClientsAsync(
+            EnabledClientsGetRequest request,
+            CheckpointPaginationInfo? pagination = null,
+            CancellationToken cancellationToken = default)
+        {
+            if (request == null)
+                throw new ArgumentNullException(nameof(request));
+            
+            if (request.ConnectionId == null)
+                throw new ArgumentNullException(nameof(request.ConnectionId));
+
+            var queryStrings = new Dictionary<string, string>();
+            
+            if (pagination != null)
+            {
+                queryStrings["from"] = pagination.From;
+                queryStrings["take"] = pagination.Take.ToString();
+            }
+
+            return Connection.GetAsync<ICheckpointPagedList<EnabledClients>>(
+                BuildUri(
+                    $"connections/{EncodePath(request.ConnectionId)}/clients",
+                    queryStrings),
+                DefaultHeaders,
+                checkpointPaginationConverter,
+                cancellationToken);
+        }
+        
+        /// <inheritdoc />
+        public Task UpdateEnabledClientsAsync(string id, EnabledClientsUpdateRequest request, CancellationToken cancellationToken = default)
+        {
+            return Connection.SendAsync<object>(
+                new HttpMethod("PATCH"),
+                BuildUri($"connections/{EncodePath(id)}/clients"),
+                request,
+                DefaultHeaders,
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ConnectionsClient.cs
@@ -96,8 +96,7 @@ namespace Auth0.ManagementApi.Clients
         /// <returns>An <see cref="IPagedList{Connection}"/> containing the list of connections.</returns>
         public Task<IPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, PaginationInfo pagination = null, CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull();
 
             var queryStrings = new Dictionary<string, string>
             {
@@ -137,8 +136,7 @@ namespace Auth0.ManagementApi.Clients
         public Task<ICheckpointPagedList<Connection>> GetAllAsync(GetConnectionsRequest request, CheckpointPaginationInfo pagination = null,
             CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
+            request.ThrowIfNull();
 
             var queryStrings = new Dictionary<string, string>
             {
@@ -284,11 +282,8 @@ namespace Auth0.ManagementApi.Clients
             CheckpointPaginationInfo? pagination = null,
             CancellationToken cancellationToken = default)
         {
-            if (request == null)
-                throw new ArgumentNullException(nameof(request));
-            
-            if (request.ConnectionId == null)
-                throw new ArgumentNullException(nameof(request.ConnectionId));
+            request.ThrowIfNull();
+            request.ConnectionId.ThrowIfNull();
 
             var queryStrings = new Dictionary<string, string>();
             
@@ -310,6 +305,7 @@ namespace Auth0.ManagementApi.Clients
         /// <inheritdoc />
         public Task UpdateEnabledClientsAsync(string id, EnabledClientsUpdateRequest request, CancellationToken cancellationToken = default)
         {
+            request.ThrowIfNull();
             return Connection.SendAsync<object>(
                 new HttpMethod("PATCH"),
                 BuildUri($"connections/{EncodePath(id)}/clients"),

--- a/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IConnectionsClient.cs
@@ -1,5 +1,7 @@
 
 
+using Auth0.ManagementApi.Models.Connections;
+
 namespace Auth0.ManagementApi.Clients
 {
   using System.Threading;
@@ -148,5 +150,22 @@ namespace Auth0.ManagementApi.Clients
     /// <param name="tokenId">The ID of the <see cref="ScimToken"/> to delete</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     Task DeleteScimTokenAsync(string id, string tokenId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves a <see cref="ICheckpointPagedList"/> list of enabled clients for a connection.
+    /// </summary>
+    /// <param name="request">The request containing criteria for retrieving enabled clients.</param>
+    /// <param name="pagination">The checkpoint pagination information to use for paged results.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+    /// <returns>An <see cref="ICheckpointPagedList{EnabledClients}"/> containing the list of enabled clients.</returns>
+    public Task<ICheckpointPagedList<EnabledClients>> GetEnabledClientsAsync(EnabledClientsGetRequest request, CheckpointPaginationInfo? pagination = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Updates the list of enabled clients for a connection.
+    /// </summary>
+    /// <param name="id">The ID of the connection to update enabled clients for.</param>
+    /// <param name="request">The request containing the updated list of enabled clients.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+    public Task UpdateEnabledClientsAsync(string id, EnabledClientsUpdateRequest request, CancellationToken cancellationToken = default);
   }
 }

--- a/src/Auth0.ManagementApi/ExtensionMethods.cs
+++ b/src/Auth0.ManagementApi/ExtensionMethods.cs
@@ -36,5 +36,19 @@ namespace Auth0.ManagementApi
             var enumMemberAttribute = ((EnumMemberAttribute[])enumType.GetTypeInfo().GetDeclaredField(name).GetCustomAttributes(typeof(EnumMemberAttribute), true))[0];
             return enumMemberAttribute.Value;
         }
+
+        /// <summary>
+        /// Throws an <see cref="ArgumentNullException"/> if the provided object is <see langword="null"/>.
+        /// </summary>
+        /// <param name="input">The object to check for <see langword="null"/>.</param>
+        /// <param name="paramName">The name of the parameter being checked, automatically captured using <see cref="System.Runtime.CompilerServices.CallerArgumentExpressionAttribute"/>.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="input"/> is <see langword="null"/>.</exception>
+        public static void ThrowIfNull(this object input, [System.Runtime.CompilerServices.CallerArgumentExpression("input")] string? paramName = null)
+        {
+            if (input == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Models/Connections/ConnectionBase.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/ConnectionBase.cs
@@ -1,3 +1,4 @@
+using System;
 using Auth0.ManagementApi.Models.Connections;
 using Newtonsoft.Json;
 
@@ -35,9 +36,7 @@ namespace Auth0.ManagementApi.Models
         [JsonProperty("realms")]
         public string[] Realms { get; set; }
 
-        /// <summary>
-        /// The identifiers of the clients for which the connection is to be enabled. If the array is empty or the property is not specified, no clients are enabled.
-        /// </summary>
+        [Obsolete("This field is deprecated and will be removed in a future version. Use ConnectionsClient.GetEnabledClientsAsync and ConnectionsClient.UpdateEnabledClientsAsync instead. ")]
         [JsonProperty("enabled_clients")]
         public string[] EnabledClients { get; set; }
 

--- a/src/Auth0.ManagementApi/Models/Connections/EnabledClients.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/EnabledClients.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Connections;
+
+public record EnabledClients
+{
+    /// <summary>
+    /// The client ID
+    /// </summary>
+    [JsonProperty("client_id")]
+    public string? ClientId { get; set; }
+};

--- a/src/Auth0.ManagementApi/Models/Connections/EnabledClients.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/EnabledClients.cs
@@ -2,7 +2,7 @@ using Newtonsoft.Json;
 
 namespace Auth0.ManagementApi.Models.Connections;
 
-public record EnabledClients
+public class EnabledClients
 {
     /// <summary>
     /// The client ID

--- a/src/Auth0.ManagementApi/Models/Connections/EnabledClientsGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/EnabledClientsGetRequest.cs
@@ -8,5 +8,5 @@ public class EnabledClientsGetRequest
     /// <summary>
     /// The id of the connection for which enabled clients are to be retrieved
     /// </summary>
-    public string ConnectionId { get; set; } = string.Empty;
+    public string ConnectionId { get; set; }
 };

--- a/src/Auth0.ManagementApi/Models/Connections/EnabledClientsGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/EnabledClientsGetRequest.cs
@@ -1,0 +1,12 @@
+namespace Auth0.ManagementApi.Models.Connections;
+
+/// <summary>
+/// Contains information required to fetch <see cref="EnabledClients"/>. 
+/// </summary>
+public class EnabledClientsGetRequest
+{
+    /// <summary>
+    /// The id of the connection for which enabled clients are to be retrieved
+    /// </summary>
+    public string ConnectionId { get; set; } = string.Empty;
+};

--- a/src/Auth0.ManagementApi/Models/Connections/EnabledClientsUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/EnabledClientsUpdateRequest.cs
@@ -1,0 +1,21 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models.Connections;
+
+/// <summary>
+/// Contains information required to update <see cref="EnabledClients"/>. 
+/// </summary>
+public class EnabledClientsUpdateRequest
+{
+    /// <summary>
+    /// The client_id of the client to be the subject to change status
+    /// </summary>
+    [JsonProperty("client_id")]
+    public string ClientId { get; set; }
+    
+    /// <summary>
+    /// Whether the connection is enabled or not for this client_id
+    /// </summary>
+    [JsonProperty("status")]
+    public bool? Status { get; set; }
+};

--- a/src/Auth0.ManagementApi/Models/Connections/EnabledClientsUpdateRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Connections/EnabledClientsUpdateRequest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Auth0.ManagementApi.Models.Connections;
@@ -5,7 +6,7 @@ namespace Auth0.ManagementApi.Models.Connections;
 /// <summary>
 /// Contains information required to update <see cref="EnabledClients"/>. 
 /// </summary>
-public class EnabledClientsUpdateRequest
+public class EnabledClientsToUpdate
 {
     /// <summary>
     /// The client_id of the client to be the subject to change status
@@ -19,3 +20,12 @@ public class EnabledClientsUpdateRequest
     [JsonProperty("status")]
     public bool? Status { get; set; }
 };
+
+public class EnabledClientsUpdateRequest
+{
+    /// <summary>
+    /// The list of enabled clients to update
+    /// </summary>
+    [JsonProperty("enabled_clients")]
+    public IEnumerable<EnabledClientsToUpdate> EnabledClients { get; set; }
+}

--- a/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
@@ -493,7 +493,7 @@ namespace Auth0.ManagementApi.IntegrationTests
                     new EnabledClientsGetRequest()
                     {
                         ConnectionId = newConnectionResponse.Id
-                    }
+                    }, new CheckpointPaginationInfo()
                 );
 
             enabledClients.Should().NotBeNull();
@@ -506,6 +506,44 @@ namespace Auth0.ManagementApi.IntegrationTests
             getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
 
             fixture.UnTrackIdentifier(CleanUpType.Connections, newConnectionResponse.Id);
+        }
+
+        [Fact]
+        public async Task Test_GetEnabledClients_Throws_When_Input_Is_Null()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => fixture.ApiClient.Connections.GetEnabledClientsAsync(null));
+            exception.Message.Should().Contain("request");
+        }
+        
+        [Fact]
+        public async Task Test_GetEnabledClients_Throws_When_ConnectionId_Is_Null()
+        {
+            var request = new EnabledClientsGetRequest();
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => fixture.ApiClient.Connections.GetEnabledClientsAsync(request));
+            exception.Message.Should().Contain("request");
+        }
+        
+        
+        [Fact]
+        public async Task Test_UpdateEnabledClients_Throws_When_ConnectionId_Is_Null()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => fixture.ApiClient.Connections.UpdateEnabledClientsAsync("id", null));
+            exception.Message.Should().Contain("request");
+        }
+        
+        [Fact]
+        public async Task Test_GetConnections_Throws_When_Input_Is_Null()
+        {
+            var exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => fixture.ApiClient.Connections.GetAllAsync(null, new PaginationInfo()));
+            exception.Message.Should().Contain("request");
+            
+            exception = await Assert.ThrowsAsync<ArgumentNullException>(
+                () => fixture.ApiClient.Connections.GetAllAsync(null, new CheckpointPaginationInfo()));
+            exception.Message.Should().Contain("request");
         }
         private async Task<string> GenerateBruckeManagementApiToken()
         {

--- a/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ConnectionTests.cs
@@ -445,6 +445,68 @@ namespace Auth0.ManagementApi.IntegrationTests
             }
         }
         
+        [Fact]
+        public async Task Test_enabled_clients_get_and_update()
+        {
+
+            await fixture.ApiClient.Connections.GetAllAsync(new GetConnectionsRequest
+            {
+                Strategy = new[] {"auth0"}
+            }, new PaginationInfo());
+
+            var optionsCreateRequestObject = GetConnectionOptionsRequest();
+
+            // Create a new connection
+            var newConnectionRequest = new ConnectionCreateRequest
+            {
+                Name = $"{TestingConstants.ConnectionPrefix}-{TestBaseUtils.MakeRandomName()}",
+                Strategy = "auth0",
+                DisplayName = "enabledClientsConnectionTest",
+                Options = optionsCreateRequestObject
+            };
+            var newConnectionResponse = await fixture.ApiClient.Connections.CreateAsync(newConnectionRequest);
+
+            fixture.TrackIdentifier(CleanUpType.Connections, newConnectionResponse.Id);
+
+            newConnectionResponse.Should().NotBeNull();
+            newConnectionResponse.Name.Should().Be(newConnectionRequest.Name);
+            newConnectionResponse.Strategy.Should().Be(newConnectionRequest.Strategy);
+            newConnectionResponse.DisplayName.Should().Be(newConnectionRequest.DisplayName);
+
+            var listOfClientsToEnabled = new List<EnabledClientsToUpdate>();
+            listOfClientsToEnabled.Add(
+                new EnabledClientsToUpdate()
+                {
+                    ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+                    Status = true
+                }
+            );
+            var enabledClientsUpdateRequest = new EnabledClientsUpdateRequest()
+            {
+                EnabledClients = listOfClientsToEnabled 
+            };
+
+            await fixture.ApiClient.Connections.UpdateEnabledClientsAsync(newConnectionResponse.Id, enabledClientsUpdateRequest);
+
+            var enabledClients = 
+                await fixture.ApiClient.Connections.GetEnabledClientsAsync(
+                    new EnabledClientsGetRequest()
+                    {
+                        ConnectionId = newConnectionResponse.Id
+                    }
+                );
+
+            enabledClients.Should().NotBeNull();
+            enabledClients.Count.Should().Be(1);
+            enabledClients.First().ClientId.Should().Be(TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"));
+
+            // Delete the connection and ensure we get exception when trying to get connection again
+            await fixture.ApiClient.Connections.DeleteAsync(newConnectionResponse.Id);
+            Func<Task> getFunc = async () => await fixture.ApiClient.Connections.GetAsync(newConnectionResponse.Id);
+            getFunc.Should().Throw<ErrorApiException>().And.ApiError.ErrorCode.Should().Be("inexistent_connection");
+
+            fixture.UnTrackIdentifier(CleanUpType.Connections, newConnectionResponse.Id);
+        }
         private async Task<string> GenerateBruckeManagementApiToken()
         {
             using var authenticationApiClient = 

--- a/tests/Auth0.ManagementApi.IntegrationTests/ExtensionMethodsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/ExtensionMethodsTests.cs
@@ -1,0 +1,28 @@
+using System;
+using FluentAssertions;
+using Xunit;
+
+namespace Auth0.ManagementApi.IntegrationTests;
+
+public class ExtensionMethodsTests
+{
+    [Fact]
+    public void ThrowsArgumentNullException_WhenInputIsNull()
+    {
+        // Act & Assert
+        void ValidateInput(object input)
+        {
+            var exception = Assert.Throws<ArgumentNullException>(() => input.ThrowIfNull());
+            exception.Message.Should().Contain($"{nameof(input)}");
+        }
+        ValidateInput(null);
+    }
+
+    [Fact]
+    public void DoesNotThrowException_WhenInputIsNotNull()
+    {
+        // Act & Assert
+        var input = new object();
+        input.ThrowIfNull(); // Should not throw
+    }
+}


### PR DESCRIPTION
### Changes

#### Changed 
- `EnabledClients` property in `Connections` is marked `Obsolete`

#### Added
- Support for 2 new end-points added to support Addition and Updation of `EnabledClients`
      - https://auth0.com/docs/api/management/v2/connections/get-connection-clients
      - https://auth0.com/docs/api/management/v2/connections/patch-clients

### References
- [SDK-6089](https://auth0team.atlassian.net/browse/SDK-6089)

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
