### PR TITLE
fix: data-type from `int` to `float` for Branding related configs

### DIFF
--- a/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneTestNotificationResponse.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingPhoneTestNotificationResponse.cs
@@ -9,7 +9,7 @@ namespace Auth0.ManagementApi.Models
         /// The status code of the operation.
         /// </summary>
         [JsonProperty("code")]
-        public int Code { get; set; }
+        public float Code { get; set; }
         
         /// <summary>
         /// The description of the operation status.

--- a/src/Auth0.ManagementApi/Models/Branding/BrandingThemeBase.cs
+++ b/src/Auth0.ManagementApi/Models/Branding/BrandingThemeBase.cs
@@ -49,13 +49,13 @@ namespace Auth0.ManagementApi.Models
         /// Button border radius
         /// </summary>
         [JsonProperty("button_border_radius")]
-        public int ButtonBorderRadius { get; set; }
+        public float ButtonBorderRadius { get; set; }
         
         /// <summary>
         /// Button border weight
         /// </summary>
         [JsonProperty("button_border_weight")]
-        public int ButtonBorderWeight { get; set; }
+        public float ButtonBorderWeight { get; set; }
         
         /// <summary>
         /// Possible values: [pill, rounded, sharp]
@@ -69,13 +69,13 @@ namespace Auth0.ManagementApi.Models
         /// Input border radius
         /// </summary>
         [JsonProperty("input_border_radius")]
-        public int InputBorderRadius { get; set; }
+        public float InputBorderRadius { get; set; }
         
         /// <summary>
         /// Input border weight
         /// </summary>
         [JsonProperty("input_border_weight")]
-        public int InputBorderWeight { get; set; }
+        public float InputBorderWeight { get; set; }
         
         /// <summary>
         /// Possible values: [pill, rounded, sharp]
@@ -95,13 +95,13 @@ namespace Auth0.ManagementApi.Models
         /// Widget border weight
         /// </summary>
         [JsonProperty("widget_border_weight")]
-        public int WidgetBorderWeight { get; set; }
+        public float WidgetBorderWeight { get; set; }
         
         /// <summary>
         /// Widget corner radius
         /// </summary>
         [JsonProperty("widget_corner_radius")]
-        public int WidgetCornerRadius { get; set; }
+        public float WidgetCornerRadius { get; set; }
     }
 
     public class BrandingThemeColors
@@ -265,7 +265,7 @@ namespace Auth0.ManagementApi.Models
         /// Reference text size
         /// </summary>
         [JsonProperty("reference_text_size")]
-        public int ReferenceTextSize { get; set; }
+        public float ReferenceTextSize { get; set; }
         
         /// <summary>
         /// Subtitle
@@ -309,7 +309,7 @@ namespace Auth0.ManagementApi.Models
         /// Logo height
         /// </summary>
         [JsonProperty("logo_height")]
-        public int LogoHeight { get; set; }
+        public float LogoHeight { get; set; }
         
         /// <summary>
         /// Logo Position
@@ -338,7 +338,7 @@ namespace Auth0.ManagementApi.Models
         public bool? Bold { get; set; }
         
         [JsonProperty("size")]
-        public int Size { get; set; }
+        public float Size { get; set; }
     }
     
     public class BodyText : BrandingThemeFontsBase


### PR DESCRIPTION
### Changes
- Changed the data-types of the following from `int` to `float` to match the documentation
     - `BrandingPhoneTestNotificationResponse.Code`
     - `BrandingThemeBorder.ButtonBorderRadius`
     - `BrandingThemeBorder.ButtonBorderWeight`
     - `BrandingThemeBorder.InputBorderRadius`
     - `BrandingThemeBorder.InputBorderWeight`
     - `BrandingThemeBorder.WidgetBorderWeight`
     - `BrandingThemeBorder.WidgetCornerRadius`
     - `BrandingThemeFonts.ReferenceTextSize`
     - `BrandingThemeFonts.LogoHeight`
     - `BrandingThemeFontsBase.Size`


### References
- Fixes #823 
- [SDK-6165](https://auth0team.atlassian.net/browse/SDK-6165)

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-6165]: https://auth0team.atlassian.net/browse/SDK-6165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ