### PR TITLE
feat: Deprecate GetImpersonationUrlAsync

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -89,6 +89,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     }
 
     /// <inheritdoc />
+    [Obsolete("GetImpersonationUrlAsync is deprecated")]
     public async Task<Uri> GetImpersonationUrlAsync(ImpersonationRequest request, CancellationToken cancellationToken = default)
     {
         request.ThrowIfNull();

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -37,8 +37,9 @@ public interface IAuthenticationApiClient : IDisposable
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
     /// <returns><see cref="Task"/> which can be used to sign in as the specified user.</returns>
     /// <remarks>This feature has been deprecated and will be removed from Auth0 and this library in a future release.</remarks>
+    [Obsolete("GetImpersonationUrlAsync is deprecated")]
     Task<Uri> GetImpersonationUrlAsync(ImpersonationRequest request, CancellationToken cancellationToken = default);
-
+    
     /// <summary>
     /// Returns user information based on the access token that was obtained during login.
     /// </summary>
@@ -192,8 +193,7 @@ public interface IAuthenticationApiClient : IDisposable
     /// <param name="cancellationToken"></param>
     /// <returns><see cref="Task"/> representing the async operation containing 
     /// a <see cref="ClientInitiatedBackchannelAuthorizationResponse" /> with the details of the response.</returns>
-    Task<ClientInitiatedBackchannelAuthorizationResponse> ClientInitiatedBackchannelAuthorization(ClientInitiatedBackchannelAuthorizationRequest request,
-        CancellationToken cancellationToken = default);
+    Task<ClientInitiatedBackchannelAuthorizationResponse> ClientInitiatedBackchannelAuthorization(ClientInitiatedBackchannelAuthorizationRequest request, CancellationToken cancellationToken = default);
         
     /// <summary>
     /// Requests an Access Token using the CIBA flow


### PR DESCRIPTION
### Changes
- Deprecates `IAuthenticationApiClient.GetImpersonationUrlAsync`

### References
- [SDK-6230](https://auth0team.atlassian.net/browse/SDK-6230)

### Testing
N/A

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-6230]: https://auth0team.atlassian.net/browse/SDK-6230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ