### PR TITLE
Add client connection retrieval per #848

### DIFF
--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -91,13 +91,13 @@ public class ClientsClient : BaseClient, IClientsClient
     }
 
     /// <summary>
-    /// Retrieves a list of all client applications.
+    /// Retrieve all connections that are enabled for the specified client.
     /// </summary>
     /// <param name="id">ID of the client for which to retrieve enabled connections.</param>
     /// <param name="request">Specifies criteria to use when querying clients.</param>
     /// <param name="pagination">Specifies <see cref="CheckpointPaginationInfo"/> to use in requesting checkpoint-paginated results.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-    /// <returns>An <see cref="ICheckpointPagedList{Client}"/> containing the clients.</returns>
+    /// <returns>An <see cref="ICheckpointPagedList{Connection}"/> containing the enabled connections.</returns>
     public Task<ICheckpointPagedList<Connection>> GetEnabledConnectionsForClientAsync(string id, GetEnabledConnectionsForClientRequest request, CheckpointPaginationInfo pagination, CancellationToken cancellationToken = default)
     {
         request.ThrowIfNull();

--- a/src/Auth0.ManagementApi/Clients/IClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IClientsClient.cs
@@ -59,13 +59,13 @@ public interface IClientsClient
   Task<Client> GetAsync(string id, string fields = null, bool includeFields = true, CancellationToken cancellationToken = default);
 
   /// <summary>
-  /// Retrieves a list of all client applications.
+  /// Retrieve all connections that are enabled for the specified client.
   /// </summary>
   /// <param name="id">ID of the client for which to retrieve enabled connections.</param>
   /// <param name="request">Specifies criteria to use when querying clients.</param>
   /// <param name="pagination">Specifies <see cref="CheckpointPaginationInfo"/> to use in requesting checkpoint-paginated results.</param>
   /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-  /// <returns>An <see cref="ICheckpointPagedList{Client}"/> containing the clients.</returns>
+  /// <returns>An <see cref="ICheckpointPagedList{Connection}"/> containing the enabled connections.</returns>
   public Task<ICheckpointPagedList<Connection>> GetEnabledConnectionsForClientAsync(string id, GetEnabledConnectionsForClientRequest request, CheckpointPaginationInfo pagination, CancellationToken cancellationToken = default);
 
   /// <summary>

--- a/src/Auth0.ManagementApi/Clients/IClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IClientsClient.cs
@@ -59,6 +59,16 @@ public interface IClientsClient
   Task<Client> GetAsync(string id, string fields = null, bool includeFields = true, CancellationToken cancellationToken = default);
 
   /// <summary>
+  /// Retrieves a list of all client applications.
+  /// </summary>
+  /// <param name="id">ID of the client for which to retrieve enabled connections.</param>
+  /// <param name="request">Specifies criteria to use when querying clients.</param>
+  /// <param name="pagination">Specifies <see cref="CheckpointPaginationInfo"/> to use in requesting checkpoint-paginated results.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+  /// <returns>An <see cref="ICheckpointPagedList{Client}"/> containing the clients.</returns>
+  public Task<ICheckpointPagedList<Connection>> GetEnabledConnectionsForClientAsync(string id, GetEnabledConnectionsForClientRequest request, CheckpointPaginationInfo pagination, CancellationToken cancellationToken = default);
+
+  /// <summary>
   /// Rotate a client secret. The generated secret is NOT base64 encoded.
   /// </summary>
   /// <param name="id">The id of the client which secret needs to be rotated.</param>

--- a/src/Auth0.ManagementApi/Models/Client/GetEnabledConnectionsForClientRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Client/GetEnabledConnectionsForClientRequest.cs
@@ -1,0 +1,23 @@
+﻿namespace Auth0.ManagementApi.Models
+{
+    /// <summary>
+    /// Specifies criteria to use when querying enabled connections for a client.
+    /// </summary>
+    public class GetEnabledConnectionsForClientRequest
+    {
+        /// <summary>
+        /// A comma separated list of fields to include or exclude (depending on <see cref="IncludeFields"/>) from the result, empty to retrieve all fields.
+        /// </summary>
+        public string Fields { get; set; } = null;
+
+        /// <summary>
+        /// Specifies whether the fields specified in <see cref="Fields"/> should be included or excluded in the result.
+        /// </summary>
+        public bool? IncludeFields { get; set; } = null;
+
+        /// <summary>
+        /// Only retrieve connections with these strategies.
+        /// </summary>
+        public string[] Strategy { get; set; } = null;
+    }
+}


### PR DESCRIPTION
Adding client connection retrieval per issue #848.

### Changes

- Introduced `GetEnabledConnectionsForClientAsync` method in `ClientsClient.cs` for fetching enabled connections with pagination.
- Updated `BuildClientQueryStrings` to support new request criteria.
- Modified `IClientsClient` interface to include the new method.
- Created `GetEnabledConnectionsForClientRequest` class to encapsulate query parameters for client connections.
- Added XML documentation for clarity on methods and parameters.

### References

- REST Management API Documentation [Get enabled connections for a client](https://auth0.com/docs/api/management/v2/clients/get-client-connections)
- #848 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

I ran unit tests locally but not the integration tests. I did not see the best route to adding integration tests for getting the enabled connections in the `ClientTests` class.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
