### PR TITLE
Use ordinal ignore case string comparer

### DIFF
--- a/src/Auth0.Core/Exceptions/RateLimit.cs
+++ b/src/Auth0.Core/Exceptions/RateLimit.cs
@@ -49,8 +49,8 @@ public class RateLimit
     /// <returns>Instance of <see cref="RateLimit"/> containing parsed rate limit headers.</returns>
     public static RateLimit? Parse(HttpHeaders headers)
     {
-        var headersKvp = 
-            headers?.ToDictionary(h => h.Key, h => h.Value);
+        var headersKvp =
+            headers?.ToDictionary(h => h.Key, h => h.Value, StringComparer.OrdinalIgnoreCase);
         var reset = GetHeaderValue(headersKvp, "x-ratelimit-reset");
         return new RateLimit
         {

--- a/tests/Auth0.Core.UnitTests/RateLimitDeserializationTests.cs
+++ b/tests/Auth0.Core.UnitTests/RateLimitDeserializationTests.cs
@@ -19,6 +19,15 @@ public class RateLimitDeserializationTests
 
         actual.Should().BeEquivalentTo(expected);
     }
+
+    [Theory]
+    [ClassData(typeof(RateLimitDeserializationDataWithAlternateHeaderCasing))]
+    public void Should_deserialize_all_rate_limit_headers_correctly_with_alternate_header_casing(HttpHeaders content, RateLimit expected)
+    {
+        var actual = RateLimit.Parse(content);
+
+        actual.Should().BeEquivalentTo(expected);
+    }
 }
 
 public class RateLimitDeserializationData : IEnumerable<object[]>
@@ -39,6 +48,123 @@ public class RateLimitDeserializationData : IEnumerable<object[]>
             client.Headers.Add("Auth0-Client-Quota-Limit", clientQuota);
         if (orgQuota != null)
             client.Headers.Add("Auth0-Organization-Quota-Limit", orgQuota);
+        return client.Headers;
+    }
+
+    public IEnumerator<object[]> GetEnumerator()
+    {
+        yield return new object[]
+        {
+            CreateHeaders(100, 10, 1585694338),
+            new RateLimit
+            {
+                Limit = 100,
+                Remaining = 10,
+                Reset = new DateTimeOffset(2020, 3, 31, 22, 38, 58, TimeSpan.Zero)
+            }
+        };
+
+        yield return new object[]
+        {
+            CreateHeaders(5, 100, 1585694338),
+            new RateLimit
+            {
+                Limit = 5,
+                Remaining = 100,
+                Reset = new DateTimeOffset(2020, 3, 31, 22, 38, 58, TimeSpan.Zero)
+            }
+        };
+
+        yield return new object[]
+        {
+            CreateHeaders(null, 10, null),
+            new RateLimit
+            {
+                Limit = 0,
+                Remaining = 10,
+                Reset = null
+            }
+        };
+        yield return new object[]
+        {
+            CreateHeaders(null, 10, null, 34567,
+                "b=per_hour;q=10;r=9;t=774,b=per_day;q=100;r=99;t=22374", null),
+            new RateLimit
+            {
+                Limit = 0,
+                Remaining = 10,
+                Reset = null,
+                RetryAfter = 34567,
+                ClientQuotaLimit = new ClientQuotaLimit()
+                {
+                    PerHour = new QuotaLimit
+                    {
+                        Quota = 10,
+                        Remaining = 9,
+                        ResetAfter = 774
+                    },
+                    PerDay = new QuotaLimit
+                    {
+                        Quota = 100,
+                        Remaining = 99,
+                        ResetAfter = 22374
+                    }
+                }
+            }
+        };
+        yield return new object[]
+        {
+            CreateHeaders(null, 10, null,
+                45678,null, "b=per_hour;q=10;r=9;t=774,b=per_day;q=100;r=99;t=22374"),
+            new RateLimit
+            {
+                Limit = 0,
+                Remaining = 10,
+                Reset = null,
+                RetryAfter = 45678,
+                OrganizationQuotaLimit = new OrganizationQuotaLimit()
+                {
+                    PerHour = new QuotaLimit
+                    {
+                        Quota = 10,
+                        Remaining = 9,
+                        ResetAfter = 774
+                    },
+                    PerDay = new QuotaLimit
+                    {
+                        Quota = 100,
+                        Remaining = 99,
+                        ResetAfter = 22374
+                    }
+                }
+            }
+        };
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}
+
+public class RateLimitDeserializationDataWithAlternateHeaderCasing : IEnumerable<object[]>
+{
+    private static HttpHeaders CreateHeaders(
+        int? limit, int? remaining, long? reset, long? retryAfter = null, string clientQuota = null, string orgQuota = null)
+    {
+        var client = new HttpRequestMessage(HttpMethod.Get, "https://fake");
+        if (limit != null)
+            client.Headers.Add("X-ratelimit-limit", limit.ToString());
+        if (remaining != null)
+            client.Headers.Add("X-Ratelimit-Remaining", remaining.ToString());
+        if (reset != null)
+            client.Headers.Add("x-ratelimit-reset", reset.ToString());
+        if (retryAfter != null)
+            client.Headers.Add("retry-after", retryAfter.ToString());
+        if (clientQuota != null)
+            client.Headers.Add("Auth0-client-quota-limit", clientQuota);
+        if (orgQuota != null)
+            client.Headers.Add("Auth0-OrgaNIZation-quota-Limit", orgQuota);
         return client.Headers;
     }
 


### PR DESCRIPTION
Use `StringComparer.OrdinalIgnoreCase` for constructing the dictionary used to parse header values for rate limited responses. Add unit tests for different cased headers.

### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)
- Any alternative designs or approaches considered

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
