### PR TITLE
Fix inconsistent naming in Organizations.DeleteMemberAsync

### DIFF
--- a/src/Auth0.ManagementApi/Clients/IOrganizationsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IOrganizationsClient.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Auth0.ManagementApi.Clients;
 
 using System.Threading;
@@ -157,6 +159,9 @@ public interface IOrganizationsClient
   /// <returns>An <see cref="ICheckpointPagedList{OrganizationMember}"/> containing the organization members.</returns>
   Task<ICheckpointPagedList<OrganizationMember>> GetAllMembersAsync(string organizationId, OrganizationGetAllMembersRequest request, CheckpointPaginationInfo pagination, CancellationToken cancellationToken = default);
 
+  [Obsolete("Deprecated in favour of IOrganizationsClient.DeleteMembersAsync")]
+  Task DeleteMemberAsync(string organizationId, OrganizationDeleteMembersRequest request, CancellationToken cancellationToken = default);
+  
   /// <summary>
   /// Deletes members from an organization.
   /// </summary>
@@ -164,7 +169,7 @@ public interface IOrganizationsClient
   /// <param name="request">The <see cref="OrganizationDeleteMembersRequest"/> containing the members.</param>
   /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
   /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
-  Task DeleteMemberAsync(string organizationId, OrganizationDeleteMembersRequest request, CancellationToken cancellationToken = default);
+  Task DeleteMembersAsync(string organizationId, OrganizationDeleteMembersRequest request, CancellationToken cancellationToken = default);
 
   /// <summary>
   /// Add members to an organization.

--- a/src/Auth0.ManagementApi/Clients/OrganizationsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/OrganizationsClient.cs
@@ -305,6 +305,12 @@ public class OrganizationsClient : BaseClient, IOrganizationsClient
     /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
     public Task DeleteMemberAsync(string organizationId, OrganizationDeleteMembersRequest request, CancellationToken cancellationToken = default)
     {
+        return DeleteMembersAsync(organizationId, request, cancellationToken);
+    }
+    
+    /// <inheritdoc />
+    public Task DeleteMembersAsync(string organizationId, OrganizationDeleteMembersRequest request, CancellationToken cancellationToken = default)
+    {
         return Connection.SendAsync<object>(HttpMethod.Delete, BuildUri($"organizations/{EncodePath(organizationId)}/members"), request, DefaultHeaders, cancellationToken: cancellationToken);
     }
 

--- a/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/JobsTest.cs
@@ -112,7 +112,7 @@ public class JobsTest : IClassFixture<JobsTestsFixture>
         job.Status.Should().Be("pending");
         job.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromMinutes(5));
 
-        await fixture.ApiClient.Organizations.DeleteMemberAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
+        await fixture.ApiClient.Organizations.DeleteMembersAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
         {
             Members = new List<string> { fixture.TestAuth0User.UserId }
         });

--- a/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/OrganizationTests.cs
@@ -251,7 +251,7 @@ public class OrganizationTests : IClassFixture<OrganizationTestsFixture>
             members[0].Name.Should().BeNull();
             members[1].Name.Should().BeNull();
 
-            await fixture.ApiClient.Organizations.DeleteMemberAsync(ExistingOrganizationId, new OrganizationDeleteMembersRequest
+            await fixture.ApiClient.Organizations.DeleteMembersAsync(ExistingOrganizationId, new OrganizationDeleteMembersRequest
             {
                 Members = new List<string> { user2.UserId }
             });
@@ -314,7 +314,7 @@ public class OrganizationTests : IClassFixture<OrganizationTestsFixture>
         }
         finally
         {
-            await fixture.ApiClient.Organizations.DeleteMemberAsync(ExistingOrganizationId, new OrganizationDeleteMembersRequest { Members = new List<string> { user.UserId, user2.UserId } });
+            await fixture.ApiClient.Organizations.DeleteMembersAsync(ExistingOrganizationId, new OrganizationDeleteMembersRequest { Members = new List<string> { user.UserId, user2.UserId } });
 
             await fixture.ApiClient.Users.DeleteAsync(user.UserId);
             fixture.UnTrackIdentifier(CleanUpType.Users, user.UserId);

--- a/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/TicketsTests.cs
@@ -114,7 +114,7 @@ public class TicketsTests : IClassFixture<TicketsTestsFixture>
         changeTicketRsponse.Should().NotBeNull();
         changeTicketRsponse.Value.Should().NotBeNull();
 
-        await fixture.ApiClient.Organizations.DeleteMemberAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
+        await fixture.ApiClient.Organizations.DeleteMembersAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
         {
             Members = new List<string> { fixture.Auth0User.UserId }
         });

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -609,7 +609,7 @@ public class UsersTests : IClassFixture<UsersTestsFixture>
         organizations.Should().NotBeNull();
         organizations.Count.Should().Be(1);
 
-        await fixture.ApiClient.Organizations.DeleteMemberAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
+        await fixture.ApiClient.Organizations.DeleteMembersAsync(existingOrganizationId, new OrganizationDeleteMembersRequest
         {
             Members = new List<string> { user.UserId }
         });


### PR DESCRIPTION
### Changes

Fixed inconsistent naming in `Organizations.DeleteMemberAsync`. 
- Added a new method with the right naming `IOrganizationsClient.DeleteMembersAsync`
- Marked the existing `IOrganizationsClient.DeleteMemberAsync` as `Obsolete`. 

### References
- #862 
- [SDK-6666](https://auth0team.atlassian.net/browse/SDK-6666)

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-6666]: https://auth0team.atlassian.net/browse/SDK-6666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ