### PR TITLE
Adds support for getting connections enabled for a specific client

### DIFF
--- a/src/Auth0.Core/Utils.cs
+++ b/src/Auth0.Core/Utils.cs
@@ -50,7 +50,7 @@ internal static class Utils
 
         return new Uri(resource, UriKind.RelativeOrAbsolute);
     }
-    internal static Uri BuildUri(string baseUrl, string resource, IDictionary<string, string>? urlSegments, IList<Tuple<string, string>> queryStringsTuple, bool includeEmptyParameters = false)
+    internal static Uri BuildUri(string baseUrl, string resource, IDictionary<string, string>? urlSegments, IList<Tuple<string, string?>> queryStringsTuple, bool includeEmptyParameters = false)
     {
         resource = ReplaceUrlSegments(resource, urlSegments);
 
@@ -87,7 +87,7 @@ internal static class Utils
         }
         return uri;
     }
-    internal static string AddQueryString(IList<Tuple<string, string>> queryStrings, bool includeEmptyParameters)
+    internal static string AddQueryString(IList<Tuple<string, string?>> queryStrings, bool includeEmptyParameters)
     {
         var sb = new StringBuilder();
         // Add the query strings

--- a/src/Auth0.ManagementApi/Clients/BaseClient.cs
+++ b/src/Auth0.ManagementApi/Clients/BaseClient.cs
@@ -49,7 +49,7 @@ public abstract class BaseClient
         return Utils.BuildUri(BaseUri.AbsoluteUri, resource, null, queryStrings);
     }
         
-    protected Uri BuildUri(string resource, IList<Tuple<string, string>> queryStrings)
+    protected Uri BuildUri(string resource, IList<Tuple<string, string?>> queryStrings)
     {
         return Utils.BuildUri(BaseUri.AbsoluteUri, resource, null, queryStrings);
     }

--- a/src/Auth0.ManagementApi/Clients/IClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/IClientsClient.cs
@@ -119,4 +119,14 @@ public interface IClientsClient
   /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
   /// <returns>A <see cref="Task"/> that represents the asynchronous delete operation.</returns>
   Task DeleteCredentialAsync(string clientId, string credentialId, CancellationToken cancellationToken = default);
+  
+  /// <summary>
+  /// Retrieve all connections that are enabled for the specified client.
+  /// </summary>
+  /// <param name="id">ID of the client for which to retrieve enabled connections.</param>
+  /// <param name="request">Specifies criteria to use when querying clients.</param>
+  /// <param name="pagination">Specifies <see cref="CheckpointPaginationInfo"/> to use in requesting checkpoint-paginated results.</param>
+  /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+  /// <returns>An <see cref="ICheckpointPagedList{Connection}"/> containing the enabled connections.</returns>
+  public Task<ICheckpointPagedList<Connection>> GetEnabledConnectionsForClientAsync(string id, EnabledConnectionsForClientGetRequest? request, CheckpointPaginationInfo? pagination, CancellationToken cancellationToken = default);
 }

--- a/src/Auth0.ManagementApi/Models/Client/EnabledConnectionsForClientGetRequest.cs
+++ b/src/Auth0.ManagementApi/Models/Client/EnabledConnectionsForClientGetRequest.cs
@@ -1,0 +1,27 @@
+using Newtonsoft.Json;
+
+namespace Auth0.ManagementApi.Models;
+
+/// <summary>
+/// Request to get enabled connections for a client
+/// </summary>
+public class EnabledConnectionsForClientGetRequest
+{
+    /// <summary>
+    /// Provide strategies to only retrieve connections with such strategies
+    /// </summary>
+    [JsonProperty("strategy")]
+    public string[]? Strategy { get; set; }
+    
+    /// <summary>
+    /// A comma separated list of fields to include or exclude (depending on include_fields) from the result, empty to retrieve all fields
+    /// </summary>
+    [JsonProperty("fields")]
+    public string? Fields { get; set; }
+    
+    /// <summary>
+    /// True if the fields specified are to be included in the result, false otherwise (defaults to true)
+    /// </summary>
+    [JsonProperty("include_fields")]
+    public bool? IncludeFields { get; set; }
+}


### PR DESCRIPTION
### Changes

- Adds support to query enabled clients for a specific client using `IClientsClient.GetEnabledConnectionsForClientAsync`. 
- Built on top of #849 (PR by [mikejr83](https://github.com/mikejr83) )

### References
- REST Management API Documentation [Get enabled connections for a client](https://auth0.com/docs/api/management/v2/clients/get-client-connections)
- #848 , #849 
- [SDK-6664](https://auth0team.atlassian.net/browse/SDK-6664)

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors


[SDK-6664]: https://auth0team.atlassian.net/browse/SDK-6664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ