### PR TITLE
Accepts expected nonce value from user for Id token validation

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -143,7 +143,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
-        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization).ConfigureAwait(false);
+        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization, request.Nonce).ConfigureAwait(false);
 
         return response;
     }
@@ -169,7 +169,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
-        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization).ConfigureAwait(false);
+        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization, request.Nonce).ConfigureAwait(false);
 
         return response;
     }
@@ -218,7 +218,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
-        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization).ConfigureAwait(false);
+        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization, request.Nonce).ConfigureAwait(false);
 
         return response;
     }
@@ -251,7 +251,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken
         ).ConfigureAwait(false);
 
-        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret).ConfigureAwait(false);
+        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, null, request.Nonce).ConfigureAwait(false);
 
         return response;
     }
@@ -279,7 +279,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken: cancellationToken).ConfigureAwait(false);
 
         await AssertIdTokenValidIfExisting(response.IdToken, request.ClientId, request.SigningAlgorithm,
-            request.ClientSecret).ConfigureAwait(false);
+            request.ClientSecret, null, request.Nonce).ConfigureAwait(false);
 
         return response;
     }
@@ -311,7 +311,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         ).ConfigureAwait(false);
 
         await AssertIdTokenValidIfExisting(response.IdToken, request.ClientId, request.SigningAlgorithm,
-            request.ClientSecret).ConfigureAwait(false);
+            request.ClientSecret, null, request.Nonce).ConfigureAwait(false);
 
         return response;
     }
@@ -335,7 +335,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
-        await AssertIdTokenValidIfExisting(response.IdToken, request.ClientId, request.SigningAlgorithm, null)
+        await AssertIdTokenValidIfExisting(response.IdToken, request.ClientId, request.SigningAlgorithm, null, null)
             .ConfigureAwait(false);
 
         return response;
@@ -700,17 +700,27 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         GC.SuppressFinalize(this);
     }
 
-    private async Task AssertIdTokenValidIfExisting(string idToken, string audience, JwtSignatureAlgorithm algorithm, string clientSecret, string organization = null)
+    private async Task AssertIdTokenValidIfExisting(string idToken, string audience, JwtSignatureAlgorithm algorithm, string clientSecret, string organization = null, string nonce = null)
     {
         if (!string.IsNullOrEmpty(idToken))
         {
-            await AssertIdTokenValid(idToken, audience, algorithm, clientSecret, organization).ConfigureAwait(false);
+            await AssertIdTokenValid(idToken, audience, algorithm, clientSecret, organization, nonce).ConfigureAwait(false);
         }
     }
 
-    private Task AssertIdTokenValid(string idToken, string audience, JwtSignatureAlgorithm algorithm, string clientSecret, string organization = null)
+    /// <summary>
+    /// Validates that an ID token meets the specified requirements.
+    /// </summary>
+    /// <param name="idToken">The ID token to validate.</param>
+    /// <param name="audience">The expected audience (aud claim).</param>
+    /// <param name="algorithm">The expected signing algorithm.</param>
+    /// <param name="clientSecret">Client secret used for HS256 signature validation; null for asymmetric algorithms.</param>
+    /// <param name="organization">Optional organization (org_id/org_name) to validate; null skips org validation.</param>
+    /// <param name="nonce">Optional nonce that must match the nonce claim in the ID token; null skips nonce validation.</param>
+    private Task AssertIdTokenValid(string idToken, string audience, JwtSignatureAlgorithm algorithm, string clientSecret, string organization = null, string nonce = null)
     {
         var requirements = new IdTokenRequirements(algorithm, BaseUri.AbsoluteUri, audience, idTokenValidationLeeway, null, organization);
+        requirements.Nonce = nonce;
         return idTokenValidator.Assert(requirements, idToken, clientSecret);
     }
 

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationCodeRequestBase.cs
@@ -54,4 +54,13 @@ public abstract class AuthorizationCodeRequestBase : IClientAuthentication
     /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
     /// </remarks>
     public string Organization { get; set; }
+
+    /// <summary>
+    /// Optional nonce to validate against the nonce claim in the returned ID token.
+    /// </summary>
+    /// <remarks>
+    /// When set, the nonce claim in the returned ID token must exactly match this value.
+    /// Leave null (the default) to skip nonce validation.
+    /// </remarks>
+    public string? Nonce { get; set; }
 }

--- a/src/Auth0.AuthenticationApi/Models/DeviceCodeTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/DeviceCodeTokenRequest.cs
@@ -20,4 +20,5 @@ public class DeviceCodeTokenRequest
     /// of Id Tokens.
     /// </summary>
     public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+
 }

--- a/src/Auth0.AuthenticationApi/Models/PasswordlessTokenRequestBase.cs
+++ b/src/Auth0.AuthenticationApi/Models/PasswordlessTokenRequestBase.cs
@@ -53,4 +53,13 @@ public abstract class PasswordlessTokenRequestBase : IClientAuthentication
     /// of Id Tokens.
     /// </summary>
     public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+
+    /// <summary>
+    /// Optional nonce to validate against the nonce claim in the returned ID token.
+    /// </summary>
+    /// <remarks>
+    /// When set, the nonce claim in the returned ID token must exactly match this value.
+    /// Leave null (the default) to skip nonce validation.
+    /// </remarks>
+    public string? Nonce { get; set; }
 }

--- a/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/RefreshTokenRequest.cs
@@ -61,4 +61,13 @@ public class RefreshTokenRequest : IClientAuthentication
     /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
     /// </remarks>
     public string Organization { get; set; }
+
+    /// <summary>
+    /// Optional nonce to validate against the nonce claim in the returned ID token.
+    /// </summary>
+    /// <remarks>
+    /// When set, the nonce claim in the returned ID token must exactly match this value.
+    /// Leave null (the default) to skip nonce validation.
+    /// </remarks>
+    public string? Nonce { get; set; }
 }

--- a/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/ResourceOwnerTokenRequest.cs
@@ -69,4 +69,13 @@ public class ResourceOwnerTokenRequest : IClientAuthentication
     /// of Id Tokens.
     /// </summary>
     public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+
+    /// <summary>
+    /// Optional nonce to validate against the nonce claim in the returned ID token.
+    /// </summary>
+    /// <remarks>
+    /// When set, the nonce claim in the returned ID token must exactly match this value.
+    /// Leave null (the default) to skip nonce validation.
+    /// </remarks>
+    public string? Nonce { get; set; }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup    >
+  <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\Auth0NetStrongName.snk</AssemblyOriginatorKeyFile>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/AuthorizationCodeNonceValidationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/AuthorizationCodeNonceValidationTests.cs
@@ -1,0 +1,541 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Auth0.AuthenticationApi.Models;
+using Auth0.AuthenticationApi.Tokens;
+using Auth0.Tests.Shared;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests.Tokens;
+
+public class AuthorizationCodeNonceValidationTests
+{
+    private const string Issuer = "https://tokens-test.auth0.com/";
+    private const string ClientId = "tokens-test-123";
+    private const string Subject = "auth0|test-user";
+    private const string CorrectNonce = "abc123nonce";
+    private const string WrongNonce = "wrong-nonce-xyz";
+
+    // RSA key pair used to sign test tokens — generated once per test class.
+    private static readonly RsaSecurityKey RsaKey = new(new RSACryptoServiceProvider(2048));
+    private static readonly JwtTokenFactory TokenFactory = new(RsaKey, SecurityAlgorithms.RsaSha256);
+
+    /// <summary>
+    /// Builds a mock HttpMessageHandler that returns a token endpoint response
+    /// containing the given idToken.
+    /// </summary>
+    private static Mock<HttpMessageHandler> BuildMockHandlerReturning(string idToken)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var tokenResponseJson = JsonConvert.SerializeObject(new
+        {
+            access_token = "some-access-token",
+            token_type = "Bearer",
+            expires_in = 86400,
+            id_token = idToken
+        });
+
+        // Return a new HttpResponseMessage (with a fresh StringContent) on each call
+        // to avoid ObjectDisposedException when the handler is invoked more than once.
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(tokenResponseJson, Encoding.UTF8, "application/json")
+            });
+
+        return mockHandler;
+    }
+
+    /// <summary>
+    /// Builds a TestAuthenticationApiClient backed by the given mock handler.
+    /// The domain matches the Issuer so that signature validation resolves correctly.
+    /// We pass the RSA public key directly via a custom OIDC document retriever shim.
+    /// Since RS256 validation fetches keys from the OIDC discovery endpoint, we test
+    /// nonce wiring via HS256 (symmetric) which doesn't require a key fetch.
+    /// </summary>
+    private static TestAuthenticationApiClient BuildClient(HttpMessageHandler handler)
+    {
+        // Strip trailing slash for domain
+        var domain = Issuer.TrimEnd('/').Replace("https://", "");
+        return new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(handler));
+    }
+
+    /// <summary>
+    /// Generates an HS256 ID token (no external key fetch needed).
+    /// </summary>
+    private static string GenerateHs256Token(string nonce, string clientSecret)
+    {
+        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(clientSecret));
+        var factory = new JwtTokenFactory(key, SecurityAlgorithms.HmacSha256);
+        var claims = nonce != null
+            ? new List<Claim> { new(JwtRegisteredClaimNames.Nonce, nonce) }
+            : null;
+        return factory.GenerateToken(Issuer, ClientId, Subject, claims);
+    }
+
+    /// <summary>
+    /// Generates an RS256 ID token signed with the shared RSA key.
+    /// Used for flows (e.g. device code) that have no client secret and therefore
+    /// cannot use HS256.
+    /// </summary>
+    private static string GenerateRs256Token(string nonce)
+    {
+        var claims = nonce != null
+            ? new List<Claim> { new(JwtRegisteredClaimNames.Nonce, nonce) }
+            : null;
+        return TokenFactory.GenerateToken(Issuer, ClientId, Subject, claims);
+    }
+
+    /// <summary>
+    /// Builds a mock handler that responds to the token endpoint (POST) plus the
+    /// OIDC discovery and JWKS endpoints (GET) required for RS256 signature validation.
+    /// </summary>
+    private static Mock<HttpMessageHandler> BuildMockHandlerWithDiscovery(string idToken)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        var tokenResponseJson = JsonConvert.SerializeObject(new
+        {
+            access_token = "some-access-token",
+            token_type = "Bearer",
+            expires_in = 86400,
+            id_token = idToken
+        });
+
+        var rsaParams = RsaKey.Rsa.ExportParameters(false);
+        var jwksJson = JsonConvert.SerializeObject(new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kty = "RSA",
+                    n = Base64UrlEncoder.Encode(rsaParams.Modulus),
+                    e = Base64UrlEncoder.Encode(rsaParams.Exponent)
+                }
+            }
+        });
+
+        var discoveryJson = JsonConvert.SerializeObject(new
+        {
+            issuer = Issuer,
+            jwks_uri = $"{Issuer}.well-known/jwks.json"
+        });
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(tokenResponseJson, Encoding.UTF8, "application/json")
+            });
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get && r.RequestUri.AbsolutePath.Contains("openid-configuration")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(discoveryJson, Encoding.UTF8, "application/json")
+            });
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get && r.RequestUri.AbsolutePath.Contains("jwks")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jwksJson, Encoding.UTF8, "application/json")
+            });
+
+        return mockHandler;
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCode_ThrowsWhenNonceSetAndTokenHasMismatchedNonce()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        // Token contains the WRONG nonce — should be rejected when request.Nonce is set.
+        var idToken = GenerateHs256Token(WrongNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new AuthorizationCodeTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                Code = "some-code",
+                RedirectUri = "https://app.example.com/callback",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = CorrectNonce  // caller supplies the nonce they sent to /authorize
+            }));
+
+        Assert.Equal(
+            $"Nonce (nonce) claim mismatch in the ID token; expected \"{CorrectNonce}\", found \"{WrongNonce}\".",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCode_ThrowsWhenNonceSetAndTokenHasNoNonceClaim()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        // Token has NO nonce claim — should be rejected when request.Nonce is set.
+        var idToken = GenerateHs256Token(null, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new AuthorizationCodeTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                Code = "some-code",
+                RedirectUri = "https://app.example.com/callback",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = CorrectNonce
+            }));
+
+        Assert.Equal("Nonce (nonce) claim must be a string present in the ID token.", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCode_SucceedsWhenNonceSetAndTokenNonceMatches()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(CorrectNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        // Should not throw.
+        var result = await client.GetTokenAsync(new AuthorizationCodeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = clientSecret,
+            Code = "some-code",
+            RedirectUri = "https://app.example.com/callback",
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+            Nonce = CorrectNonce
+        });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCode_SucceedsWhenNoNonceSetEvenIfTokenHasNonceClaim()
+    {
+        // Backward compatibility: if caller doesn't set Nonce, nonce validation is skipped
+        // even if the token happens to contain a nonce claim.
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(CorrectNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var result = await client.GetTokenAsync(new AuthorizationCodeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = clientSecret,
+            Code = "some-code",
+            RedirectUri = "https://app.example.com/callback",
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256
+            // Nonce not set — opt-in behaviour
+        });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCodePkce_ThrowsWhenNonceSetAndTokenHasMismatchedNonce()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(WrongNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new AuthorizationCodePkceTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                Code = "some-code",
+                CodeVerifier = "some-code-verifier",
+                RedirectUri = "https://app.example.com/callback",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = CorrectNonce
+            }));
+
+        Assert.Equal(
+            $"Nonce (nonce) claim mismatch in the ID token; expected \"{CorrectNonce}\", found \"{WrongNonce}\".",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCodePkce_SucceedsWhenNoNonceSetEvenIfTokenHasNonceClaim()
+    {
+        // Backward compatibility: if caller doesn't set Nonce, nonce validation is skipped
+        // even if the token happens to contain a nonce claim.
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(CorrectNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var result = await client.GetTokenAsync(new AuthorizationCodePkceTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = clientSecret,
+            Code = "some-code",
+            CodeVerifier = "some-code-verifier",
+            RedirectUri = "https://app.example.com/callback",
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256
+            // Nonce not set — opt-in behaviour
+        });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCode_ThrowsWhenNonceDiffersOnlyInCase()
+    {
+        // Nonce comparison must be case-sensitive per OpenID Connect spec.
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var upperNonce = CorrectNonce.ToUpperInvariant();
+        var idToken = GenerateHs256Token(upperNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new AuthorizationCodeTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                Code = "some-code",
+                RedirectUri = "https://app.example.com/callback",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = CorrectNonce  // lowercase — token has uppercase
+            }));
+
+        Assert.Equal(
+            $"Nonce (nonce) claim mismatch in the ID token; expected \"{CorrectNonce}\", found \"{upperNonce}\".",
+            ex.Message);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // RefreshTokenRequest
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetTokenAsync_RefreshToken_ThrowsWhenNonceSetAndTokenHasMismatchedNonce()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(WrongNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new RefreshTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                RefreshToken = "some-refresh-token",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = CorrectNonce
+            }));
+
+        Assert.Equal(
+            $"Nonce (nonce) claim mismatch in the ID token; expected \"{CorrectNonce}\", found \"{WrongNonce}\".",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_RefreshToken_SucceedsWhenNoNonceSetEvenIfTokenHasNonceClaim()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(CorrectNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var result = await client.GetTokenAsync(new RefreshTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = clientSecret,
+            RefreshToken = "some-refresh-token",
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256
+            // Nonce not set — opt-in behaviour
+        });
+
+        Assert.NotNull(result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // ResourceOwnerTokenRequest
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetTokenAsync_ResourceOwner_ThrowsWhenNonceSetAndTokenHasMismatchedNonce()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(WrongNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new ResourceOwnerTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                Username = "user@example.com",
+                Password = "password",
+                Scope = "openid",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = CorrectNonce
+            }));
+
+        Assert.Equal(
+            $"Nonce (nonce) claim mismatch in the ID token; expected \"{CorrectNonce}\", found \"{WrongNonce}\".",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ResourceOwner_SucceedsWhenNoNonceSetEvenIfTokenHasNonceClaim()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(CorrectNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var result = await client.GetTokenAsync(new ResourceOwnerTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = clientSecret,
+            Username = "user@example.com",
+            Password = "password",
+            Scope = "openid",
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256
+            // Nonce not set — opt-in behaviour
+        });
+
+        Assert.NotNull(result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // PasswordlessEmailTokenRequest
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetTokenAsync_PasswordlessEmail_ThrowsWhenNonceSetAndTokenHasMismatchedNonce()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(WrongNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new PasswordlessEmailTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                Email = "user@example.com",
+                Code = "123456",
+                Audience = "https://api.example.com",
+                Scope = "openid",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = CorrectNonce
+            }));
+
+        Assert.Equal(
+            $"Nonce (nonce) claim mismatch in the ID token; expected \"{CorrectNonce}\", found \"{WrongNonce}\".",
+            ex.Message);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_PasswordlessEmail_SucceedsWhenNoNonceSetEvenIfTokenHasNonceClaim()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(CorrectNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var result = await client.GetTokenAsync(new PasswordlessEmailTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = clientSecret,
+            Email = "user@example.com",
+            Code = "123456",
+            Audience = "https://api.example.com",
+            Scope = "openid",
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256
+            // Nonce not set — opt-in behaviour
+        });
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_AuthorizationCode_ThrowsWhenNonceSetToEmptyString()
+    {
+        // An empty string is not the same as null — the validator checks `!= null` to
+        // decide whether to validate, so an empty Nonce triggers validation and will
+        // always fail because no token will carry an empty nonce claim.
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(CorrectNonce, clientSecret);
+
+        var mockHandler = BuildMockHandlerReturning(idToken);
+        using var client = BuildClient(mockHandler.Object);
+
+        var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(new AuthorizationCodeTokenRequest
+            {
+                ClientId = ClientId,
+                ClientSecret = clientSecret,
+                Code = "some-code",
+                RedirectUri = "https://app.example.com/callback",
+                SigningAlgorithm = JwtSignatureAlgorithm.HS256,
+                Nonce = string.Empty
+            }));
+
+        Assert.Equal(
+            $"Nonce (nonce) claim mismatch in the ID token; expected \"\", found \"{CorrectNonce}\".",
+            ex.Message);
+    }
+}


### PR DESCRIPTION
### Changes

Adds opt-in **nonce validation** for ID tokens returned by all `GetTokenAsync` flows in `AuthenticationApiClient`. Per the [OpenID Connect spec](https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation), the `nonce` claim in the ID token must match the value originally sent to the `/authorize` endpoint.

**New `Nonce` property** added to the following request models:
- `AuthorizationCodeRequestBase` (covers `AuthorizationCodeTokenRequest` and `AuthorizationCodePkceTokenRequest`)
- `RefreshTokenRequest`
- `ResourceOwnerTokenRequest`
- `PasswordlessTokenRequestBase` (covers `PasswordlessEmailTokenRequest` and `PasswordlessSmsTokenRequest`)

**Behavior:**
- When `Nonce` is set on a request, the SDK validates that the returned ID token's `nonce` claim exactly matches (case-sensitive). Throws `IdTokenValidationException` on mismatch or missing claim.
- When `Nonce` is `null` (default), nonce validation is skipped — **fully backward compatible**.

**Internal changes:**
- `AssertIdTokenValid` and `AssertIdTokenValidIfExisting` now accept an optional `nonce` parameter and set `IdTokenRequirements.Nonce` before validation.
- Added XML documentation to `AssertIdTokenValid`.

### References

- Fixes #948 

### Testing

Tests added in `AuthorizationCodeNonceValidationTests.cs` covering all token flows:

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors