### PR TITLE
mgmt: Remove IDirectoryProvisioningClient and DirectoryProvisioningClient from .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -42,8 +42,6 @@ tests/Auth0.ManagementApi.Test/Auth0.ManagementApi.Test.Custom.props
 tests/Auth0.ManagementApi.Test/Unit/MockServer/Auth0ClientHeaderTest.cs
 tests/Auth0.ManagementApi.Test/Wrapper
 
-src/Auth0.ManagementApi/Connections/DirectoryProvisioning/DirectoryProvisioningClient.cs
-src/Auth0.ManagementApi/Connections/DirectoryProvisioning/IDirectoryProvisioningClient.cs
 src/Auth0.ManagementApi/Types/ResourceServerTokenEncryptionKey.cs
 
 src/Auth0.ManagementApi/Wrapper


### PR DESCRIPTION

### Changes

- Removes `IDirectoryProvisioningClient` and `DirectoryProvisioningClient` from `.fernignore`

### References

### Testing

- [ ] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
