### PR TITLE
mgmt: SDK generation

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -46,3 +46,8 @@ src/Auth0.ManagementApi/Types/ResourceServerTokenEncryptionKey.cs
 
 src/Auth0.ManagementApi/Wrapper
 src/Auth0.ManagementApi/CHANGELOG.md
+
+src/Auth0.ManagementApi/Core/CustomDomainInterceptor.cs
+src/Auth0.ManagementApi/CustomDomainHeader.cs
+tests/Auth0.ManagementApi.Test/Core/CustomDomainInterceptorTest.cs
+tests/Auth0.ManagementApi.Test/Unit/MockServer/CustomDomainHeaderTest.cs

--- a/Examples.md
+++ b/Examples.md
@@ -202,9 +202,10 @@ await authClient.DeleteMfaAuthenticatorAsync(
   - [4.3 Get a specific Network ACL configuration](#43-get-a-specific-network-acl-configuration)
   - [4.4 Update Network ACL with a PATCH request](#44-update-network-acl-with-a-patch-request)
   - [4.5 Update Network ACL with a PUT request](#45-update-network-acl-with-a-put-request)
-- [5. Using a Custom Domain with the Management API](#5-using-a-custom-domain-with-the-management-api)
-  - [5.1 Let the client manage the connection (simplest)](#51-let-the-client-manage-the-connection-simplest)
-  - [5.2 Bring your own connection](#52-bring-your-own-connection)
+- [5. Multiple Custom Domain (MCD) Header](#5-multiple-custom-domain-mcd-header)
+  - [5.1 Global configuration via ManagementClient (recommended)](#51-global-configuration-via-managementclient-recommended)
+  - [5.2 Per-request override](#52-per-request-override)
+  - [5.3 Global configuration via ManagementApiClient](#53-global-configuration-via-managementapiclient)
 
 ## 1. Management Client Initialization
 
@@ -564,5 +565,150 @@ public async Task SetNetworkAcl(string aclId)
     await client.NetworkAcls.SetAsync(aclId, setRequest);
 }
 ```
+
+[Go to Top](#)
+
+## 5. Multiple Custom Domain (MCD) Header
+
+Auth0 tenants with Multiple Custom Domains enabled must supply the `Auth0-Custom-Domain` header
+on the Management API endpoints that generate user-facing links. The affected endpoints are:
+
+- `POST /api/v2/tickets/email-verification`
+- `POST /api/v2/tickets/password-change`
+- `POST /api/v2/organizations/{id}/invitations`
+- `POST /api/v2/guardian/enrollments/ticket`
+- `POST /api/v2/jobs/verification-email`
+- `POST /api/v2/jobs/users-imports` (when `verify_email: true`)
+- `POST /api/v2/users` (Create)
+- `PATCH /api/v2/users/{id}` (Update, when `verify_email: true`)
+
+### 5.1 Global configuration via ManagementClient (recommended)
+
+When `CustomDomain` is set on `ManagementClientOptions` and no custom `HttpClient` is provided,
+the SDK automatically configures a `CustomDomainInterceptor` that strips the header from any
+endpoint not on the whitelist above.
+
+```csharp
+using Auth0.ManagementApi;
+
+public async Task UseCustomDomainGlobal()
+{
+    var client = new ManagementClient(new ManagementClientOptions
+    {
+        Domain = "my.auth0.domain",
+        TokenProvider = new ClientCredentialsTokenProvider(
+            domain: "my.auth0.domain",
+            clientId: "clientId",
+            clientSecret: "clientSecret"
+        ),
+        CustomDomain = "login.mycompany.com"
+    });
+
+    // Auth0-Custom-Domain header is sent automatically on whitelisted endpoints
+    // and stripped from all others.
+    var ticket = await client.Tickets.VerifyEmailAsync(
+        new VerifyEmailTicketRequestContent { UserId = "auth0|abc123" });
+
+    Console.WriteLine($"Ticket URL: {ticket.Ticket}");
+}
+```
+
+[Go to Top](#)
+
+### 5.2 Per-request override
+
+Use `CustomDomainHeader.For()` to supply the header for a single call without configuring it
+globally. This is useful when only a subset of calls require the header, or when you need to
+use a different domain for a specific request.
+
+```csharp
+using Auth0.ManagementApi;
+
+public async Task UseCustomDomainPerRequest()
+{
+    // Client without a global custom domain
+    var client = new ManagementClient(new ManagementClientOptions
+    {
+        Domain = "my.auth0.domain",
+        TokenProvider = new ClientCredentialsTokenProvider(
+            domain: "my.auth0.domain",
+            clientId: "clientId",
+            clientSecret: "clientSecret"
+        )
+    });
+
+    // Supply the header only for this call
+    var ticket = await client.Tickets.VerifyEmailAsync(
+        new VerifyEmailTicketRequestContent { UserId = "auth0|abc123" },
+        CustomDomainHeader.For("login.mycompany.com"));
+
+    Console.WriteLine($"Ticket URL: {ticket.Ticket}");
+
+    // Works with any whitelisted endpoint
+    var invitation = await client.Organizations.Invitations.CreateAsync(
+        "org_123",
+        new CreateOrganizationInvitationRequestContent
+        {
+            Inviter = new OrganizationInvitationInviter { Name = "Admin" },
+            Invitee = new OrganizationInvitationInvitee { Email = "user@example.com" },
+            ClientId = "clientId"
+        },
+        CustomDomainHeader.For("login.mycompany.com"));
+}
+```
+
+> **Combining with other per-request options:** `CustomDomainHeader.For()` is a convenience
+> helper that returns a `RequestOptions` pre-populated with only the `Auth0-Custom-Domain`
+> header. When you also need to set other options on the same call (additional headers, timeout,
+> retries), construct `RequestOptions` directly instead:
+>
+> ```csharp
+> await client.Tickets.VerifyEmailAsync(
+>     new VerifyEmailTicketRequestContent { UserId = "auth0|abc123" },
+>     new RequestOptions
+>     {
+>         AdditionalHeaders = new[]
+>         {
+>             new KeyValuePair<string, string?>("Auth0-Custom-Domain", "login.mycompany.com"),
+>             new KeyValuePair<string, string?>("X-Correlation-Id", "abc-123"),
+>         },
+>         MaxRetries = 1,
+>     });
+> ```
+
+[Go to Top](#)
+
+### 5.3 Global configuration via ManagementApiClient
+
+If you manage tokens yourself using `ManagementApiClient` directly, pass a `CustomDomainInterceptor`
+as the `HttpClient` handler to enable automatic header stripping.
+
+```csharp
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Core;
+
+public async Task UseCustomDomainWithManagementApiClient()
+{
+    // CustomDomainInterceptor strips the header from non-whitelisted endpoints.
+    var client = new ManagementApiClient(
+        token: "your-access-token",
+        clientOptions: new ClientOptions
+        {
+            BaseUrl = "https://my.auth0.domain/api/v2",
+            CustomDomain = "login.mycompany.com",
+            HttpClient = new HttpClient(new CustomDomainInterceptor())
+        });
+
+    var ticket = await client.Tickets.VerifyEmailAsync(
+        new VerifyEmailTicketRequestContent { UserId = "auth0|abc123" });
+
+    Console.WriteLine($"Ticket URL: {ticket.Ticket}");
+}
+```
+
+> **Note:** If you supply your own `HttpClient` alongside `CustomDomain`, the
+> `CustomDomainInterceptor` is **not** injected automatically — you must add it yourself
+> as shown above. Without it the header is still sent, but it will be present on every
+> request rather than only whitelisted ones.
 
 [Go to Top](#)

--- a/reference.md
+++ b/reference.md
@@ -558,6 +558,7 @@ await client.ClientGrants.ListAsync(
         ClientId = "client_id",
         AllowAnyOrganization = true,
         SubjectType = ClientGrantSubjectTypeEnum.Client,
+        DefaultFor = ClientGrantDefaultForEnum.ThirdPartyClients,
     }
 );
 ```
@@ -3346,7 +3347,7 @@ await client.EventStreams.TestAsync(
     "id",
     new CreateEventStreamTestEventRequestContent
     {
-        EventType = EventStreamTestEventTypeEnum.UserCreated,
+        EventType = EventStreamTestEventTypeEnum.GroupCreated,
     }
 );
 ```
@@ -4553,72 +4554,77 @@ await client.Jobs.GetAsync("id");
 <dl>
 <dd>
 
-Retrieve details on <a href="https://auth0.com/docs/logs/streams">log streams</a>.
-<h5>Sample Response</h5><pre><code>[{
-	"id": "string",
-	"name": "string",
-	"type": "eventbridge",
-	"status": "active|paused|suspended",
-	"sink": {
-		"awsAccountId": "string",
-		"awsRegion": "string",
-		"awsPartnerEventSource": "string"
-	}
+Retrieve details on [log streams](https://auth0.com/docs/logs/streams).
+
+**Sample Response**
+
+```json
+[{
+  "id": "string",
+  "name": "string",
+  "type": "eventbridge",
+  "status": "active|paused|suspended",
+  "sink": {
+    "awsAccountId": "string",
+    "awsRegion": "string",
+    "awsPartnerEventSource": "string"
+  }
 }, {
-	"id": "string",
-	"name": "string",
-	"type": "http",
-	"status": "active|paused|suspended",
-	"sink": {
-		"httpContentFormat": "JSONLINES|JSONARRAY",
-		"httpContentType": "string",
-		"httpEndpoint": "string",
-		"httpAuthorization": "string"
-	}
+  "id": "string",
+  "name": "string",
+  "type": "http",
+  "status": "active|paused|suspended",
+  "sink": {
+    "httpContentFormat": "JSONLINES|JSONARRAY",
+    "httpContentType": "string",
+    "httpEndpoint": "string",
+    "httpAuthorization": "string"
+  }
 },
 {
-	"id": "string",
-	"name": "string",
-	"type": "eventgrid",
-	"status": "active|paused|suspended",
-	"sink": {
-		"azureSubscriptionId": "string",
-		"azureResourceGroup": "string",
-		"azureRegion": "string",
-		"azurePartnerTopic": "string"
-	}
+  "id": "string",
+  "name": "string",
+  "type": "eventgrid",
+  "status": "active|paused|suspended",
+  "sink": {
+    "azureSubscriptionId": "string",
+    "azureResourceGroup": "string",
+    "azureRegion": "string",
+    "azurePartnerTopic": "string"
+  }
 },
 {
-	"id": "string",
-	"name": "string",
-	"type": "splunk",
-	"status": "active|paused|suspended",
-	"sink": {
-		"splunkDomain": "string",
-		"splunkToken": "string",
-		"splunkPort": "string",
-		"splunkSecure": "boolean"
-	}
+  "id": "string",
+  "name": "string",
+  "type": "splunk",
+  "status": "active|paused|suspended",
+  "sink": {
+    "splunkDomain": "string",
+    "splunkToken": "string",
+    "splunkPort": "string",
+    "splunkSecure": "boolean"
+  }
 },
 {
-	"id": "string",
-	"name": "string",
-	"type": "sumo",
-	"status": "active|paused|suspended",
-	"sink": {
-		"sumoSourceAddress": "string",
-	}
+  "id": "string",
+  "name": "string",
+  "type": "sumo",
+  "status": "active|paused|suspended",
+  "sink": {
+    "sumoSourceAddress": "string"
+  }
 },
 {
-	"id": "string",
-	"name": "string",
-	"type": "datadog",
-	"status": "active|paused|suspended",
-	"sink": {
-		"datadogRegion": "string",
-		"datadogApiKey": "string"
-	}
-}]</code></pre>
+  "id": "string",
+  "name": "string",
+  "type": "datadog",
+  "status": "active|paused|suspended",
+  "sink": {
+    "datadogRegion": "string",
+    "datadogApiKey": "string"
+  }
+}]
+```
 </dd>
 </dl>
 </dd>
@@ -4658,131 +4664,202 @@ await client.LogStreams.ListAsync();
 <dd>
 
 Create a log stream.
-<h5>Log Stream Types</h5> The <code>type</code> of log stream being created determines the properties required in the <code>sink</code> payload.
-<h5>HTTP Stream</h5> For an <code>http</code> Stream, the <code>sink</code> properties are listed in the payload below
-Request: <pre><code>{
-	"name": "string",
-	"type": "http",
-	"sink": {
-		"httpEndpoint": "string",
-		"httpContentType": "string",
-		"httpContentFormat": "JSONLINES|JSONARRAY",
-		"httpAuthorization": "string"
-	}
-}</code></pre>
-Response: <pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "http",
-	"status": "active",
-	"sink": {
-		"httpEndpoint": "string",
-		"httpContentType": "string",
-		"httpContentFormat": "JSONLINES|JSONARRAY",
-		"httpAuthorization": "string"
-	}
-}</code></pre>
-<h5>Amazon EventBridge Stream</h5> For an <code>eventbridge</code> Stream, the <code>sink</code> properties are listed in the payload below
-Request: <pre><code>{
-	"name": "string",
-	"type": "eventbridge",
-	"sink": {
-		"awsRegion": "string",
-		"awsAccountId": "string"
-	}
-}</code></pre>
-The response will include an additional field <code>awsPartnerEventSource</code> in the <code>sink</code>: <pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "eventbridge",
-	"status": "active",
-	"sink": {
-		"awsAccountId": "string",
-		"awsRegion": "string",
-		"awsPartnerEventSource": "string"
-	}
-}</code></pre>
-<h5>Azure Event Grid Stream</h5> For an <code>Azure Event Grid</code> Stream, the <code>sink</code> properties are listed in the payload below
-Request: <pre><code>{
-	"name": "string",
-	"type": "eventgrid",
-	"sink": {
-		"azureSubscriptionId": "string",
-		"azureResourceGroup": "string",
-		"azureRegion": "string"
-	}
-}</code></pre>
-Response: <pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "http",
-	"status": "active",
-	"sink": {
-		"azureSubscriptionId": "string",
-		"azureResourceGroup": "string",
-		"azureRegion": "string",
-		"azurePartnerTopic": "string"
-	}
-}</code></pre>
-<h5>Datadog Stream</h5> For a <code>Datadog</code> Stream, the <code>sink</code> properties are listed in the payload below
-Request: <pre><code>{
-	"name": "string",
-	"type": "datadog",
-	"sink": {
-		"datadogRegion": "string",
-		"datadogApiKey": "string"
-	}
-}</code></pre>
-Response: <pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "datadog",
-	"status": "active",
-	"sink": {
-		"datadogRegion": "string",
-		"datadogApiKey": "string"
-	}
-}</code></pre>
-<h5>Splunk Stream</h5> For a <code>Splunk</code> Stream, the <code>sink</code> properties are listed in the payload below
-Request: <pre><code>{
-	"name": "string",
-	"type": "splunk",
-	"sink": {
-		"splunkDomain": "string",
-		"splunkToken": "string",
-		"splunkPort": "string",
-		"splunkSecure": "boolean"
-	}
-}</code></pre>
-Response: <pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "splunk",
-	"status": "active",
-	"sink": {
-		"splunkDomain": "string",
-		"splunkToken": "string",
-		"splunkPort": "string",
-		"splunkSecure": "boolean"
-	}
-}</code></pre>
-<h5>Sumo Logic Stream</h5> For a <code>Sumo Logic</code> Stream, the <code>sink</code> properties are listed in the payload below
-Request: <pre><code>{
-	"name": "string",
-	"type": "sumo",
-	"sink": {
-		"sumoSourceAddress": "string",
-	}
-}</code></pre>
-Response: <pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "sumo",
-	"status": "active",
-	"sink": {
-		"sumoSourceAddress": "string",
-	}
-}</code></pre>
+
+**Log Stream Types**
+
+The `type` of log stream being created determines the properties required in the `sink` payload.
+
+**HTTP Stream**
+
+For an `http` Stream, the `sink` properties are listed in the payload below.
+
+**Request:**
+```json
+{
+  "name": "string",
+  "type": "http",
+  "sink": {
+    "httpEndpoint": "string",
+    "httpContentType": "string",
+    "httpContentFormat": "JSONLINES|JSONARRAY",
+    "httpAuthorization": "string"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "http",
+  "status": "active",
+  "sink": {
+    "httpEndpoint": "string",
+    "httpContentType": "string",
+    "httpContentFormat": "JSONLINES|JSONARRAY",
+    "httpAuthorization": "string"
+  }
+}
+```
+
+**Amazon EventBridge Stream**
+
+For an `eventbridge` Stream, the `sink` properties are listed in the payload below.
+
+**Request:**
+```json
+{
+  "name": "string",
+  "type": "eventbridge",
+  "sink": {
+    "awsRegion": "string",
+    "awsAccountId": "string"
+  }
+}
+```
+
+The response will include an additional field `awsPartnerEventSource` in the `sink`:
+
+**Response:**
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "eventbridge",
+  "status": "active",
+  "sink": {
+    "awsAccountId": "string",
+    "awsRegion": "string",
+    "awsPartnerEventSource": "string"
+  }
+}
+```
+
+**Azure Event Grid Stream**
+
+For an `Azure Event Grid` Stream, the `sink` properties are listed in the payload below.
+
+**Request:**
+```json
+{
+  "name": "string",
+  "type": "eventgrid",
+  "sink": {
+    "azureSubscriptionId": "string",
+    "azureResourceGroup": "string",
+    "azureRegion": "string"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "http",
+  "status": "active",
+  "sink": {
+    "azureSubscriptionId": "string",
+    "azureResourceGroup": "string",
+    "azureRegion": "string",
+    "azurePartnerTopic": "string"
+  }
+}
+```
+
+**Datadog Stream**
+
+For a `Datadog` Stream, the `sink` properties are listed in the payload below.
+
+**Request:**
+```json
+{
+  "name": "string",
+  "type": "datadog",
+  "sink": {
+    "datadogRegion": "string",
+    "datadogApiKey": "string"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "datadog",
+  "status": "active",
+  "sink": {
+    "datadogRegion": "string",
+    "datadogApiKey": "string"
+  }
+}
+```
+
+**Splunk Stream**
+
+For a `Splunk` Stream, the `sink` properties are listed in the payload below.
+
+**Request:**
+```json
+{
+  "name": "string",
+  "type": "splunk",
+  "sink": {
+    "splunkDomain": "string",
+    "splunkToken": "string",
+    "splunkPort": "string",
+    "splunkSecure": "boolean"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "splunk",
+  "status": "active",
+  "sink": {
+    "splunkDomain": "string",
+    "splunkToken": "string",
+    "splunkPort": "string",
+    "splunkSecure": "boolean"
+  }
+}
+```
+
+**Sumo Logic Stream**
+
+For a `Sumo Logic` Stream, the `sink` properties are listed in the payload below.
+
+**Request:**
+```json
+{
+  "name": "string",
+  "type": "sumo",
+  "sink": {
+    "sumoSourceAddress": "string"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "sumo",
+  "status": "active",
+  "sink": {
+    "sumoSourceAddress": "string"
+  }
+}
+```
 </dd>
 </dl>
 </dd>
@@ -4843,107 +4920,157 @@ await client.LogStreams.CreateAsync(
 <dd>
 
 Retrieve a log stream configuration and status.
-<h5>Sample responses</h5><h5>Amazon EventBridge Log Stream</h5><pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "eventbridge",
-	"status": "active|paused|suspended",
-	"sink": {
-		"awsAccountId": "string",
-		"awsRegion": "string",
-		"awsPartnerEventSource": "string"
-	}
-}</code></pre> <h5>HTTP Log Stream</h5><pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "http",
-	"status": "active|paused|suspended",
-	"sink": {
-		"httpContentFormat": "JSONLINES|JSONARRAY",
-		"httpContentType": "string",
-		"httpEndpoint": "string",
-		"httpAuthorization": "string"
-	}
-}</code></pre> <h5>Datadog Log Stream</h5><pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "datadog",
-	"status": "active|paused|suspended",
-	"sink": {
-		"datadogRegion": "string",
-		"datadogApiKey": "string"
-	}
 
-}</code></pre><h5>Mixpanel</h5>
-	
-	Request: <pre><code>{
-	  "name": "string",
-	  "type": "mixpanel",
-	  "sink": {
-		"mixpanelRegion": "string", // "us" | "eu",
-		"mixpanelProjectId": "string",
-		"mixpanelServiceAccountUsername": "string",
-		"mixpanelServiceAccountPassword": "string"
-	  }
-	} </code></pre>
-	
-	
-	Response: <pre><code>{
-		"id": "string",
-		"name": "string",
-		"type": "mixpanel",
-		"status": "active",
-		"sink": {
-		  "mixpanelRegion": "string", // "us" | "eu",
-		  "mixpanelProjectId": "string",
-		  "mixpanelServiceAccountUsername": "string",
-		  "mixpanelServiceAccountPassword": "string" // the following is redacted on return
-		}
-	  } </code></pre>
+**Sample responses**
 
-	<h5>Segment</h5>
+**Amazon EventBridge Log Stream**
 
-	Request: <pre><code> {
-	  "name": "string",
-	  "type": "segment",
-	  "sink": {
-		"segmentWriteKey": "string"
-	  }
-	}</code></pre>
-	
-	Response: <pre><code>{
-	  "id": "string",
-	  "name": "string",
-	  "type": "segment",
-	  "status": "active",
-	  "sink": {
-		"segmentWriteKey": "string"
-	  }
-	} </code></pre>
-	
-<h5>Splunk Log Stream</h5><pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "splunk",
-	"status": "active|paused|suspended",
-	"sink": {
-		"splunkDomain": "string",
-		"splunkToken": "string",
-		"splunkPort": "string",
-		"splunkSecure": "boolean"
-	}
-}</code></pre> <h5>Sumo Logic Log Stream</h5><pre><code>{
-	"id": "string",
-	"name": "string",
-	"type": "sumo",
-	"status": "active|paused|suspended",
-	"sink": {
-		"sumoSourceAddress": "string",
-	}
-}</code></pre> <h5>Status</h5> The <code>status</code> of a log stream maybe any of the following:
-1. <code>active</code> - Stream is currently enabled.
-2. <code>paused</code> - Stream is currently user disabled and will not attempt log delivery.
-3. <code>suspended</code> - Stream is currently disabled because of errors and will not attempt log delivery.
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "eventbridge",
+  "status": "active|paused|suspended",
+  "sink": {
+    "awsAccountId": "string",
+    "awsRegion": "string",
+    "awsPartnerEventSource": "string"
+  }
+}
+```
+
+**HTTP Log Stream**
+
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "http",
+  "status": "active|paused|suspended",
+  "sink": {
+    "httpContentFormat": "JSONLINES|JSONARRAY",
+    "httpContentType": "string",
+    "httpEndpoint": "string",
+    "httpAuthorization": "string"
+  }
+}
+```
+
+**Datadog Log Stream**
+
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "datadog",
+  "status": "active|paused|suspended",
+  "sink": {
+    "datadogRegion": "string",
+    "datadogApiKey": "string"
+  }
+}
+```
+
+**Mixpanel**
+
+**Request:**
+
+```json
+{
+  "name": "string",
+  "type": "mixpanel",
+  "sink": {
+    "mixpanelRegion": "string",
+    "mixpanelProjectId": "string",
+    "mixpanelServiceAccountUsername": "string",
+    "mixpanelServiceAccountPassword": "string"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "mixpanel",
+  "status": "active",
+  "sink": {
+    "mixpanelRegion": "string",
+    "mixpanelProjectId": "string",
+    "mixpanelServiceAccountUsername": "string",
+    "mixpanelServiceAccountPassword": "string"
+  }
+}
+```
+
+**Segment**
+
+**Request:**
+
+```json
+{
+  "name": "string",
+  "type": "segment",
+  "sink": {
+    "segmentWriteKey": "string"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "segment",
+  "status": "active",
+  "sink": {
+    "segmentWriteKey": "string"
+  }
+}
+```
+
+**Splunk Log Stream**
+
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "splunk",
+  "status": "active|paused|suspended",
+  "sink": {
+    "splunkDomain": "string",
+    "splunkToken": "string",
+    "splunkPort": "string",
+    "splunkSecure": "boolean"
+  }
+}
+```
+
+**Sumo Logic Log Stream**
+
+```json
+{
+  "id": "string",
+  "name": "string",
+  "type": "sumo",
+  "status": "active|paused|suspended",
+  "sink": {
+    "sumoSourceAddress": "string"
+  }
+}
+```
+
+**Status**
+
+The `status` of a log stream maybe any of the following:
+
+1. `active` - Stream is currently enabled.
+2. `paused` - Stream is currently user disabled and will not attempt log delivery.
+3. `suspended` - Stream is currently disabled because of errors and will not attempt log delivery.
 </dd>
 </dl>
 </dd>
@@ -5052,40 +5179,79 @@ await client.LogStreams.DeleteAsync("id");
 <dd>
 
 Update a log stream.
-<h4>Examples of how to use the PATCH endpoint.</h4> The following fields may be updated in a PATCH operation: <ul><li>name</li><li>status</li><li>sink</li></ul> Note: For log streams of type <code>eventbridge</code> and <code>eventgrid</code>, updating the <code>sink</code> is not permitted.
-<h5>Update the status of a log stream</h5><pre><code>{
-	"status": "active|paused"
-}</code></pre>
-<h5>Update the name of a log stream</h5><pre><code>{
-	"name": "string"
-}</code></pre>
-<h5>Update the sink properties of a stream of type <code>http</code></h5><pre><code>{
+
+**Examples of how to use the PATCH endpoint.**
+
+The following fields may be updated in a PATCH operation:
+
+- name
+- status
+- sink
+
+Note: For log streams of type `eventbridge` and `eventgrid`, updating the `sink` is not permitted.
+
+**Update the status of a log stream**
+
+```json
+{
+  "status": "active|paused"
+}
+```
+
+**Update the name of a log stream**
+
+```json
+{
+  "name": "string"
+}
+```
+
+**Update the sink properties of a stream of type `http`**
+
+```json
+{
   "sink": {
     "httpEndpoint": "string",
     "httpContentType": "string",
     "httpContentFormat": "JSONARRAY|JSONLINES",
     "httpAuthorization": "string"
   }
-}</code></pre>
-<h5>Update the sink properties of a stream of type <code>datadog</code></h5><pre><code>{
+}
+```
+
+**Update the sink properties of a stream of type `datadog`**
+
+```json
+{
   "sink": {
-		"datadogRegion": "string",
-		"datadogApiKey": "string"
+    "datadogRegion": "string",
+    "datadogApiKey": "string"
   }
-}</code></pre>
-<h5>Update the sink properties of a stream of type <code>splunk</code></h5><pre><code>{
+}
+```
+
+**Update the sink properties of a stream of type `splunk`**
+
+```json
+{
   "sink": {
     "splunkDomain": "string",
     "splunkToken": "string",
     "splunkPort": "string",
     "splunkSecure": "boolean"
   }
-}</code></pre>
-<h5>Update the sink properties of a stream of type <code>sumo</code></h5><pre><code>{
+}
+```
+
+**Update the sink properties of a stream of type `sumo`**
+
+```json
+{
   "sink": {
     "sumoSourceAddress": "string"
   }
-}</code></pre> 
+}
+```
 </dd>
 </dl>
 </dd>
@@ -13334,6 +13500,142 @@ await client.Connections.DirectoryProvisioning.GetDefaultMappingAsync("id");
 <dd>
 
 **id:** `string` — The id of the connection to retrieve its directory provisioning configuration
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.Connections.DirectoryProvisioning.<a href="/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/DirectoryProvisioningClient.cs">ListSynchronizedGroupsAsync</a>(id, ListSynchronizedGroupsRequestParameters { ... }) -> Pager&lt;SynchronizedGroupPayload&gt;</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Retrieve the configured synchronized groups for a connection directory provisioning configuration.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```csharp
+await client.Connections.DirectoryProvisioning.ListSynchronizedGroupsAsync(
+    "id",
+    new ListSynchronizedGroupsRequestParameters { From = "from", Take = 1 }
+);
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**id:** `string` — The id of the connection to list synchronized groups for.
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request:** `ListSynchronizedGroupsRequestParameters` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.Connections.DirectoryProvisioning.<a href="/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/DirectoryProvisioningClient.cs">SetAsync</a>(id, ReplaceSynchronizedGroupsRequestContent { ... })</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Create or replace the selected groups for a connection directory provisioning configuration.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```csharp
+await client.Connections.DirectoryProvisioning.SetAsync(
+    "id",
+    new ReplaceSynchronizedGroupsRequestContent
+    {
+        Groups = new List<SynchronizedGroupPayload>()
+        {
+            new SynchronizedGroupPayload { Id = "id" },
+        },
+    }
+);
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**id:** `string` — The id of the connection to create or replace synchronized groups for
+    
+</dd>
+</dl>
+
+<dl>
+<dd>
+
+**request:** `ReplaceSynchronizedGroupsRequestContent` 
     
 </dd>
 </dl>

--- a/src/Auth0.ManagementApi/ClientGrants/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/ClientGrants/ClientGrantsClient.cs
@@ -37,7 +37,7 @@ public partial class ClientGrantsClient : IClientGrantsClient
         CancellationToken cancellationToken = default
     )
     {
-        var _queryString = new Auth0.ManagementApi.Core.QueryStringBuilder.Builder(capacity: 6)
+        var _queryString = new Auth0.ManagementApi.Core.QueryStringBuilder.Builder(capacity: 7)
             .Add("from", request.From.IsDefined ? request.From.Value : null)
             .Add("take", request.Take.IsDefined ? request.Take.Value : null)
             .Add("audience", request.Audience.IsDefined ? request.Audience.Value : null)
@@ -47,6 +47,7 @@ public partial class ClientGrantsClient : IClientGrantsClient
                 request.AllowAnyOrganization.IsDefined ? request.AllowAnyOrganization.Value : null
             )
             .Add("subject_type", request.SubjectType.IsDefined ? request.SubjectType.Value : null)
+            .Add("default_for", request.DefaultFor.IsDefined ? request.DefaultFor.Value : null)
             .MergeAdditional(options?.AdditionalQueryParameters)
             .Build();
         var _headers = await new Auth0.ManagementApi.Core.HeadersBuilder.Builder()
@@ -412,6 +413,7 @@ public partial class ClientGrantsClient : IClientGrantsClient
     ///         ClientId = "client_id",
     ///         AllowAnyOrganization = true,
     ///         SubjectType = ClientGrantSubjectTypeEnum.Client,
+    ///         DefaultFor = ClientGrantDefaultForEnum.ThirdPartyClients,
     ///     }
     /// );
     /// </code></example>

--- a/src/Auth0.ManagementApi/ClientGrants/Requests/CreateClientGrantRequestContent.cs
+++ b/src/Auth0.ManagementApi/ClientGrants/Requests/CreateClientGrantRequestContent.cs
@@ -20,6 +20,10 @@ public record CreateClientGrantRequestContent
     public required string Audience { get; set; }
 
     [Optional]
+    [JsonPropertyName("default_for")]
+    public ClientGrantDefaultForEnum? DefaultFor { get; set; }
+
+    [Optional]
     [JsonPropertyName("organization_usage")]
     public ClientGrantOrganizationUsageEnum? OrganizationUsage { get; set; }
 

--- a/src/Auth0.ManagementApi/ClientGrants/Requests/ListClientGrantsRequestParameters.cs
+++ b/src/Auth0.ManagementApi/ClientGrants/Requests/ListClientGrantsRequestParameters.cs
@@ -42,6 +42,12 @@ public record ListClientGrantsRequestParameters
     [JsonIgnore]
     public Optional<ClientGrantSubjectTypeEnum?> SubjectType { get; set; }
 
+    /// <summary>
+    /// Applies this client grant as the default for all clients in the specified group. The only accepted value is `third_party_clients`, which applies the grant to all third-party clients. Per-client grants for the same audience take precedence. Mutually exclusive with `client_id`.
+    /// </summary>
+    [JsonIgnore]
+    public Optional<ClientGrantDefaultForEnum?> DefaultFor { get; set; }
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/src/Auth0.ManagementApi/Clients/Requests/CreateClientRequestContent.cs
+++ b/src/Auth0.ManagementApi/Clients/Requests/CreateClientRequestContent.cs
@@ -287,8 +287,20 @@ public record CreateClientRequestContent
     public string? ResourceServerIdentifier { get; set; }
 
     [Optional]
+    [JsonPropertyName("third_party_security_mode")]
+    public ClientThirdPartySecurityModeEnum? ThirdPartySecurityMode { get; set; }
+
+    [Optional]
+    [JsonPropertyName("redirection_policy")]
+    public ClientRedirectionPolicyEnum? RedirectionPolicy { get; set; }
+
+    [Optional]
     [JsonPropertyName("express_configuration")]
     public ExpressConfiguration? ExpressConfiguration { get; set; }
+
+    [Optional]
+    [JsonPropertyName("my_organization_configuration")]
+    public ClientMyOrganizationPostConfiguration? MyOrganizationConfiguration { get; set; }
 
     [Optional]
     [JsonPropertyName("async_approval_notification_channels")]

--- a/src/Auth0.ManagementApi/Clients/Requests/UpdateClientRequestContent.cs
+++ b/src/Auth0.ManagementApi/Clients/Requests/UpdateClientRequestContent.cs
@@ -298,8 +298,20 @@ public record UpdateClientRequestContent
     public Optional<ExpressConfigurationOrNull?> ExpressConfiguration { get; set; }
 
     [Nullable, Optional]
+    [JsonPropertyName("my_organization_configuration")]
+    public Optional<ClientMyOrganizationPatchConfiguration?> MyOrganizationConfiguration { get; set; }
+
+    [Nullable, Optional]
     [JsonPropertyName("async_approval_notification_channels")]
     public Optional<IEnumerable<AsyncApprovalNotificationsChannelsEnum>?> AsyncApprovalNotificationChannels { get; set; }
+
+    [Optional]
+    [JsonPropertyName("third_party_security_mode")]
+    public ClientThirdPartySecurityModeEnum? ThirdPartySecurityMode { get; set; }
+
+    [Optional]
+    [JsonPropertyName("redirection_policy")]
+    public ClientRedirectionPolicyEnum? RedirectionPolicy { get; set; }
 
     /// <inheritdoc />
     public override string ToString()

--- a/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/DirectoryProvisioningClient.cs
+++ b/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/DirectoryProvisioningClient.cs
@@ -498,6 +498,120 @@ public partial class DirectoryProvisioningClient : IDirectoryProvisioningClient
     }
 
     /// <summary>
+    /// Retrieve the configured synchronized groups for a connection directory provisioning configuration.
+    /// </summary>
+    private WithRawResponseTask<ListSynchronizedGroupsResponseContent> ListSynchronizedGroupsInternalAsync(
+        string id,
+        ListSynchronizedGroupsRequestParameters request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        return new WithRawResponseTask<ListSynchronizedGroupsResponseContent>(
+            ListSynchronizedGroupsInternalAsyncCore(id, request, options, cancellationToken)
+        );
+    }
+
+    private async Task<
+        WithRawResponse<ListSynchronizedGroupsResponseContent>
+    > ListSynchronizedGroupsInternalAsyncCore(
+        string id,
+        ListSynchronizedGroupsRequestParameters request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var _queryString = new Auth0.ManagementApi.Core.QueryStringBuilder.Builder(capacity: 2)
+            .Add("from", request.From.IsDefined ? request.From.Value : null)
+            .Add("take", request.Take.IsDefined ? request.Take.Value : null)
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
+        var _headers = await new Auth0.ManagementApi.Core.HeadersBuilder.Builder()
+            .Add(_client.Options.Headers)
+            .Add(_client.Options.AdditionalHeaders)
+            .Add(options?.AdditionalHeaders)
+            .BuildAsync()
+            .ConfigureAwait(false);
+        var response = await _client
+            .SendRequestAsync(
+                new JsonRequest
+                {
+                    Method = HttpMethod.Get,
+                    Path = string.Format(
+                        "connections/{0}/directory-provisioning/synchronized-groups",
+                        ValueConvert.ToPathParameterString(id)
+                    ),
+                    QueryString = _queryString,
+                    Headers = _headers,
+                    Options = options,
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        if (response.StatusCode is >= 200 and < 400)
+        {
+            var responseBody = await response
+                .Raw.Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                var responseData = JsonUtils.Deserialize<ListSynchronizedGroupsResponseContent>(
+                    responseBody
+                )!;
+                return new WithRawResponse<ListSynchronizedGroupsResponseContent>()
+                {
+                    Data = responseData,
+                    RawResponse = new RawResponse()
+                    {
+                        StatusCode = response.Raw.StatusCode,
+                        Url = response.Raw.RequestMessage?.RequestUri ?? new Uri("about:blank"),
+                        Headers = ResponseHeaders.FromHttpResponseMessage(response.Raw),
+                    },
+                };
+            }
+            catch (JsonException e)
+            {
+                throw new ManagementApiException(
+                    "Failed to deserialize response",
+                    response.StatusCode,
+                    null,
+                    e
+                );
+            }
+        }
+        {
+            var responseBody = await response
+                .Raw.Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                switch (response.StatusCode)
+                {
+                    case 400:
+                        throw new BadRequestError(JsonUtils.Deserialize<object>(responseBody));
+                    case 401:
+                        throw new UnauthorizedError(JsonUtils.Deserialize<object>(responseBody));
+                    case 403:
+                        throw new ForbiddenError(JsonUtils.Deserialize<object>(responseBody));
+                    case 404:
+                        throw new NotFoundError(JsonUtils.Deserialize<object>(responseBody));
+                    case 429:
+                        throw new TooManyRequestsError(JsonUtils.Deserialize<object>(responseBody));
+                }
+            }
+            catch (JsonException)
+            {
+                // unable to map error response, throwing generic error
+            }
+            throw new ManagementApiException(
+                $"Error with status code {response.StatusCode}",
+                response.StatusCode,
+                responseBody
+            );
+        }
+    }
+
+    /// <summary>
     /// Retrieve a list of directory provisioning configurations of a tenant.
     /// </summary>
     /// <example><code>
@@ -682,5 +796,138 @@ public partial class DirectoryProvisioningClient : IDirectoryProvisioningClient
         return new WithRawResponseTask<GetDirectoryProvisioningDefaultMappingResponseContent>(
             GetDefaultMappingAsyncCore(id, options, cancellationToken)
         );
+    }
+
+    /// <summary>
+    /// Retrieve the configured synchronized groups for a connection directory provisioning configuration.
+    /// </summary>
+    /// <example><code>
+    /// await client.Connections.DirectoryProvisioning.ListSynchronizedGroupsAsync(
+    ///     "id",
+    ///     new ListSynchronizedGroupsRequestParameters { From = "from", Take = 1 }
+    /// );
+    /// </code></example>
+    public async Task<Pager<SynchronizedGroupPayload>> ListSynchronizedGroupsAsync(
+        string id,
+        ListSynchronizedGroupsRequestParameters request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        if (request is not null)
+        {
+            request = request with { };
+        }
+        var pager = await CursorPager<
+            ListSynchronizedGroupsRequestParameters,
+            RequestOptions?,
+            ListSynchronizedGroupsResponseContent,
+            string?,
+            SynchronizedGroupPayload
+        >
+            .CreateInstanceAsync(
+                request,
+                options,
+                async (request, options, cancellationToken) =>
+                    await ListSynchronizedGroupsInternalAsync(
+                            id,
+                            request,
+                            options,
+                            cancellationToken
+                        )
+                        .WithRawResponse(),
+                (request, cursor) =>
+                {
+                    request.From = cursor;
+                },
+                response => response.Next,
+                response => response.Groups?.ToList(),
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        return pager;
+    }
+
+    /// <summary>
+    /// Create or replace the selected groups for a connection directory provisioning configuration.
+    /// </summary>
+    /// <example><code>
+    /// await client.Connections.DirectoryProvisioning.SetAsync(
+    ///     "id",
+    ///     new ReplaceSynchronizedGroupsRequestContent
+    ///     {
+    ///         Groups = new List&lt;SynchronizedGroupPayload&gt;()
+    ///         {
+    ///             new SynchronizedGroupPayload { Id = "id" },
+    ///         },
+    ///     }
+    /// );
+    /// </code></example>
+    public async Task SetAsync(
+        string id,
+        ReplaceSynchronizedGroupsRequestContent request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var _headers = await new Auth0.ManagementApi.Core.HeadersBuilder.Builder()
+            .Add(_client.Options.Headers)
+            .Add(_client.Options.AdditionalHeaders)
+            .Add(options?.AdditionalHeaders)
+            .BuildAsync()
+            .ConfigureAwait(false);
+        var response = await _client
+            .SendRequestAsync(
+                new JsonRequest
+                {
+                    Method = HttpMethod.Put,
+                    Path = string.Format(
+                        "connections/{0}/directory-provisioning/synchronized-groups",
+                        ValueConvert.ToPathParameterString(id)
+                    ),
+                    Body = request,
+                    Headers = _headers,
+                    ContentType = "application/json",
+                    Options = options,
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        if (response.StatusCode is >= 200 and < 400)
+        {
+            return;
+        }
+        {
+            var responseBody = await response
+                .Raw.Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                switch (response.StatusCode)
+                {
+                    case 400:
+                        throw new BadRequestError(JsonUtils.Deserialize<object>(responseBody));
+                    case 401:
+                        throw new UnauthorizedError(JsonUtils.Deserialize<object>(responseBody));
+                    case 403:
+                        throw new ForbiddenError(JsonUtils.Deserialize<object>(responseBody));
+                    case 404:
+                        throw new NotFoundError(JsonUtils.Deserialize<object>(responseBody));
+                    case 409:
+                        throw new ConflictError(JsonUtils.Deserialize<object>(responseBody));
+                    case 429:
+                        throw new TooManyRequestsError(JsonUtils.Deserialize<object>(responseBody));
+                }
+            }
+            catch (JsonException)
+            {
+                // unable to map error response, throwing generic error
+            }
+            throw new ManagementApiException(
+                $"Error with status code {response.StatusCode}",
+                response.StatusCode,
+                responseBody
+            );
+        }
     }
 }

--- a/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/IDirectoryProvisioningClient.cs
+++ b/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/IDirectoryProvisioningClient.cs
@@ -63,4 +63,24 @@ public partial interface IDirectoryProvisioningClient
         RequestOptions? options = null,
         CancellationToken cancellationToken = default
     );
+
+    /// <summary>
+    /// Retrieve the configured synchronized groups for a connection directory provisioning configuration.
+    /// </summary>
+    Task<Pager<SynchronizedGroupPayload>> ListSynchronizedGroupsAsync(
+        string id,
+        ListSynchronizedGroupsRequestParameters request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
+    /// Create or replace the selected groups for a connection directory provisioning configuration.
+    /// </summary>
+    Task SetAsync(
+        string id,
+        ReplaceSynchronizedGroupsRequestContent request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
 }

--- a/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/Requests/ListSynchronizedGroupsRequestParameters.cs
+++ b/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/Requests/ListSynchronizedGroupsRequestParameters.cs
@@ -1,0 +1,26 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi.Connections;
+
+[Serializable]
+public record ListSynchronizedGroupsRequestParameters
+{
+    /// <summary>
+    /// Optional Id from which to start selection.
+    /// </summary>
+    [JsonIgnore]
+    public Optional<string?> From { get; set; }
+
+    /// <summary>
+    /// Number of results per page. Defaults to 50.
+    /// </summary>
+    [JsonIgnore]
+    public Optional<int?> Take { get; set; } = 50;
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/Requests/ReplaceSynchronizedGroupsRequestContent.cs
+++ b/src/Auth0.ManagementApi/Connections/DirectoryProvisioning/Requests/ReplaceSynchronizedGroupsRequestContent.cs
@@ -1,0 +1,22 @@
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi.Connections;
+
+[Serializable]
+public record ReplaceSynchronizedGroupsRequestContent
+{
+    /// <summary>
+    /// Array of Google Workspace Directory group objects to synchronize.
+    /// </summary>
+    [JsonPropertyName("groups")]
+    public IEnumerable<SynchronizedGroupPayload> Groups { get; set; } =
+        new List<SynchronizedGroupPayload>();
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Core/CustomDomainInterceptor.cs
+++ b/src/Auth0.ManagementApi/Core/CustomDomainInterceptor.cs
@@ -1,0 +1,88 @@
+using System.Text.RegularExpressions;
+
+namespace Auth0.ManagementApi.Core;
+
+/// <summary>
+/// A <see cref="DelegatingHandler"/> that enforces the <c>Auth0-Custom-Domain</c> header whitelist.
+///
+/// <para>
+/// The <c>Auth0-Custom-Domain</c> header is only meaningful for specific Management API endpoints
+/// that generate user-facing links (email verification, password reset, invitations, etc.).
+/// This handler strips the header from requests to any path not on the whitelist, preventing
+/// it from leaking to unrelated endpoints.
+/// </para>
+///
+/// <para>Whitelisted paths:</para>
+/// <list type="bullet">
+///   <item><c>POST /tickets/email-verification</c></item>
+///   <item><c>POST /tickets/password-change</c></item>
+///   <item><c>POST /organizations/{id}/invitations</c></item>
+///   <item><c>POST /guardian/enrollments/ticket</c></item>
+///   <item><c>POST /jobs/verification-email</c></item>
+///   <item><c>POST /jobs/users-imports</c></item>
+///   <item><c>POST /users</c> and <c>PATCH /users/{id}</c></item>
+///   <item><c>POST /self-service-profiles/{id}/sso-ticket</c></item>
+/// </list>
+/// </summary>
+public class CustomDomainInterceptor : DelegatingHandler
+{
+    /// <summary>
+    /// The name of the custom domain header.
+    /// </summary>
+    public const string HeaderName = "Auth0-Custom-Domain";
+
+    private static readonly Regex[] WhitelistedPaths =
+    {
+        new Regex(@".*/tickets/email-verification$", RegexOptions.Compiled),
+        new Regex(@".*/tickets/password-change$", RegexOptions.Compiled),
+        new Regex(@".*/organizations/[^/]+/invitations(/[^/]+)?$", RegexOptions.Compiled),
+        new Regex(@".*/guardian/enrollments/ticket$", RegexOptions.Compiled),
+        new Regex(@".*/jobs/verification-email$", RegexOptions.Compiled),
+        new Regex(@".*/jobs/users-imports$", RegexOptions.Compiled),
+        new Regex(@".*/users(/[^/]+)?$", RegexOptions.Compiled),
+        new Regex(@".*/self-service-profiles/[^/]+/sso-ticket(/[^/]+/revoke)?$", RegexOptions.Compiled),
+    };
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="CustomDomainInterceptor"/> with a default
+    /// <see cref="HttpClientHandler"/> as the inner handler.
+    /// </summary>
+    public CustomDomainInterceptor()
+        : base(new HttpClientHandler()) { }
+
+    /// <summary>
+    /// Initializes a new instance of <see cref="CustomDomainInterceptor"/> wrapping the
+    /// specified inner handler.
+    /// </summary>
+    /// <param name="innerHandler">The inner <see cref="HttpMessageHandler"/> to delegate to.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="innerHandler"/> is null.</exception>
+    public CustomDomainInterceptor(HttpMessageHandler innerHandler)
+        : base(innerHandler ?? throw new ArgumentNullException(nameof(innerHandler))) { }
+
+    /// <inheritdoc />
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        if (request.Headers.Contains(HeaderName) &&
+            !IsWhitelisted(request.RequestUri?.AbsolutePath))
+        {
+            request.Headers.Remove(HeaderName);
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if <paramref name="path"/> matches one of the whitelisted endpoint patterns.
+    /// Used internally by <see cref="SendAsync"/> and exposed for unit testing via <c>InternalsVisibleTo</c>.
+    /// </summary>
+    /// <param name="path">The URL absolute path to test (e.g. <c>/api/v2/tickets/email-verification</c>).</param>
+    internal static bool IsWhitelisted(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+
+        return WhitelistedPaths.Any(p => p.IsMatch(path));
+    }
+}

--- a/src/Auth0.ManagementApi/Core/Public/ClientOptions.Custom.cs
+++ b/src/Auth0.ManagementApi/Core/Public/ClientOptions.Custom.cs
@@ -1,10 +1,59 @@
 using System.Text;
 using System.Text.Json;
+using Auth0.ManagementApi.Core;
 
 namespace Auth0.ManagementApi;
 
 public partial class ClientOptions
 {
+    private string? _customDomain;
+
+    /// <summary>
+    /// Sets the <c>Auth0-Custom-Domain</c> header value sent on Management API requests that
+    /// generate user-facing links (email verification, password reset, invitations, etc.).
+    ///
+    /// <para>
+    /// When set, the header is included in <em>every</em> outgoing request. To restrict the
+    /// header to only the whitelisted endpoints and strip it from all others, also configure
+    /// your <see cref="HttpClient"/> with a <see cref="CustomDomainInterceptor"/> handler:
+    /// <code>
+    /// new ClientOptions
+    /// {
+    ///     CustomDomain = "login.mycompany.com",
+    ///     HttpClient   = new HttpClient(new CustomDomainInterceptor())
+    /// }
+    /// </code>
+    /// </para>
+    ///
+    /// <para>
+    /// If you are using <see cref="ManagementClient"/>, stripping is configured automatically
+    /// when no custom <see cref="HttpClient"/> is provided - prefer that path.
+    /// </para>
+    /// </summary>
+    /// <exception cref="ArgumentException">Thrown when the value is non-null but empty or contains only whitespace.</exception>
+    public string? CustomDomain
+    {
+        get => _customDomain;
+#if NET5_0_OR_GREATER
+        init
+#else
+        set
+#endif
+        {
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                _customDomain = value;
+                Headers[CustomDomainInterceptor.HeaderName] = value;
+            }
+            else if (value != null)
+            {
+                throw new ArgumentException(
+                    "CustomDomain must not be empty or contain only whitespace.",
+                    nameof(value));
+            }
+        }
+    }
+
     public ClientOptions()
     {
         Headers["Auth0-Client"] = CreateAgentString();

--- a/src/Auth0.ManagementApi/CustomDomainHeader.cs
+++ b/src/Auth0.ManagementApi/CustomDomainHeader.cs
@@ -1,0 +1,65 @@
+using Auth0.ManagementApi.Core;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Convenience helper for creating per-request <c>Auth0-Custom-Domain</c> overrides.
+///
+/// <para>
+/// Use this when you need to specify a custom domain for a single API call without
+/// configuring it globally on the client. The header is forwarded only to whitelisted
+/// endpoints — if you have a <see cref="CustomDomainInterceptor"/> configured on your
+/// <see cref="System.Net.Http.HttpClient"/>, it is stripped automatically from any
+/// non-whitelisted path.
+/// </para>
+///
+/// <para>
+/// When you need the custom domain header <em>and</em> other <see cref="RequestOptions"/>
+/// settings (extra headers, timeout, retries) in the same call, construct
+/// <see cref="RequestOptions"/> directly instead of using this helper:
+/// <code>
+/// await client.Tickets.VerifyEmailAsync(request, new RequestOptions
+/// {
+///     AdditionalHeaders = new[]
+///     {
+///         new KeyValuePair&lt;string, string?&gt;(CustomDomainInterceptor.HeaderName, "login.mycompany.com"),
+///         new KeyValuePair&lt;string, string?&gt;("X-Correlation-Id", "abc-123"),
+///     },
+///     MaxRetries = 1,
+/// });
+/// </code>
+/// </para>
+///
+/// <example>
+/// <code>
+/// // Override for a specific request
+/// await client.Tickets.VerifyEmailAsync(request, CustomDomainHeader.For("login.mycompany.com"));
+///
+/// // Override for organization invitations
+/// await client.Organizations.Invitations.CreateAsync(orgId, invitation, CustomDomainHeader.For("login.mycompany.com"));
+/// </code>
+/// </example>
+/// </summary>
+public static class CustomDomainHeader
+{
+    /// <summary>
+    /// Creates a <see cref="RequestOptions"/> with the <c>Auth0-Custom-Domain</c> header set
+    /// to <paramref name="domain"/>.
+    /// </summary>
+    /// <param name="domain">The custom domain (e.g. <c>"login.mycompany.com"</c>).</param>
+    /// <returns>A <see cref="RequestOptions"/> carrying the custom domain header.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="domain"/> is null, empty, or whitespace.</exception>
+    public static RequestOptions For(string domain)
+    {
+        if (string.IsNullOrWhiteSpace(domain))
+            throw new ArgumentException("Domain must not be null or whitespace.", nameof(domain));
+
+        return new RequestOptions
+        {
+            AdditionalHeaders = new[]
+            {
+                new KeyValuePair<string, string?>(CustomDomainInterceptor.HeaderName, domain),
+            },
+        };
+    }
+}

--- a/src/Auth0.ManagementApi/EventStreams/EventStreamsClient.cs
+++ b/src/Auth0.ManagementApi/EventStreams/EventStreamsClient.cs
@@ -646,7 +646,7 @@ public partial class EventStreamsClient : IEventStreamsClient
     ///     "id",
     ///     new CreateEventStreamTestEventRequestContent
     ///     {
-    ///         EventType = EventStreamTestEventTypeEnum.UserCreated,
+    ///         EventType = EventStreamTestEventTypeEnum.GroupCreated,
     ///     }
     /// );
     /// </code></example>

--- a/src/Auth0.ManagementApi/LogStreams/ILogStreamsClient.cs
+++ b/src/Auth0.ManagementApi/LogStreams/ILogStreamsClient.cs
@@ -3,72 +3,77 @@ namespace Auth0.ManagementApi;
 public partial interface ILogStreamsClient
 {
     /// <summary>
-    /// Retrieve details on <see href="https://auth0.com/docs/logs/streams">log streams</see>.
-    /// <para>Sample Response</para><code>[{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"awsAccountId": "string",
-    /// 		"awsRegion": "string",
-    /// 		"awsPartnerEventSource": "string"
-    /// 	}
+    /// Retrieve details on [log streams](https://auth0.com/docs/logs/streams).
+    ///
+    /// **Sample Response**
+    ///
+    /// ```json
+    /// [{
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "awsAccountId": "string",
+    ///     "awsRegion": "string",
+    ///     "awsPartnerEventSource": "string"
+    ///   }
     /// }, {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpContentType": "string",
-    /// 		"httpEndpoint": "string",
-    /// 		"httpAuthorization": "string"
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpContentType": "string",
+    ///     "httpEndpoint": "string",
+    ///     "httpAuthorization": "string"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventgrid",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"azureSubscriptionId": "string",
-    /// 		"azureResourceGroup": "string",
-    /// 		"azureRegion": "string",
-    /// 		"azurePartnerTopic": "string"
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventgrid",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "azureSubscriptionId": "string",
+    ///     "azureResourceGroup": "string",
+    ///     "azureRegion": "string",
+    ///     "azurePartnerTopic": "string"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
-    /// }]</code>
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }]
+    /// ```
     /// </summary>
     WithRawResponseTask<IEnumerable<LogStreamResponseSchema>> ListAsync(
         RequestOptions? options = null,
@@ -77,131 +82,202 @@ public partial interface ILogStreamsClient
 
     /// <summary>
     /// Create a log stream.
-    /// <para>Log Stream Types</para> The <c>type</c> of log stream being created determines the properties required in the <c>sink</c> payload.
-    /// <para>HTTP Stream</para> For an <c>http</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"sink": {
-    /// 		"httpEndpoint": "string",
-    /// 		"httpContentType": "string",
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpAuthorization": "string"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"httpEndpoint": "string",
-    /// 		"httpContentType": "string",
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpAuthorization": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Amazon EventBridge Stream</para> For an <c>eventbridge</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"sink": {
-    /// 		"awsRegion": "string",
-    /// 		"awsAccountId": "string"
-    /// 	}
-    /// }</code>
-    /// The response will include an additional field <c>awsPartnerEventSource</c> in the <c>sink</c>: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"awsAccountId": "string",
-    /// 		"awsRegion": "string",
-    /// 		"awsPartnerEventSource": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Azure Event Grid Stream</para> For an <c>Azure Event Grid</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "eventgrid",
-    /// 	"sink": {
-    /// 		"azureSubscriptionId": "string",
-    /// 		"azureResourceGroup": "string",
-    /// 		"azureRegion": "string"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"azureSubscriptionId": "string",
-    /// 		"azureResourceGroup": "string",
-    /// 		"azureRegion": "string",
-    /// 		"azurePartnerTopic": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Datadog Stream</para> For a <c>Datadog</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Splunk Stream</para> For a <c>Splunk</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
-    /// }</code>
-    /// <para>Sumo Logic Stream</para> For a <c>Sumo Logic</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
-    /// }</code>
+    ///
+    /// **Log Stream Types**
+    ///
+    /// The `type` of log stream being created determines the properties required in the `sink` payload.
+    ///
+    /// **HTTP Stream**
+    ///
+    /// For an `http` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "sink": {
+    ///     "httpEndpoint": "string",
+    ///     "httpContentType": "string",
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpAuthorization": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "httpEndpoint": "string",
+    ///     "httpContentType": "string",
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpAuthorization": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Amazon EventBridge Stream**
+    ///
+    /// For an `eventbridge` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "sink": {
+    ///     "awsRegion": "string",
+    ///     "awsAccountId": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// The response will include an additional field `awsPartnerEventSource` in the `sink`:
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "awsAccountId": "string",
+    ///     "awsRegion": "string",
+    ///     "awsPartnerEventSource": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Azure Event Grid Stream**
+    ///
+    /// For an `Azure Event Grid` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "eventgrid",
+    ///   "sink": {
+    ///     "azureSubscriptionId": "string",
+    ///     "azureResourceGroup": "string",
+    ///     "azureRegion": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "azureSubscriptionId": "string",
+    ///     "azureResourceGroup": "string",
+    ///     "azureRegion": "string",
+    ///     "azurePartnerTopic": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Datadog Stream**
+    ///
+    /// For a `Datadog` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Splunk Stream**
+    ///
+    /// For a `Splunk` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Sumo Logic Stream**
+    ///
+    /// For a `Sumo Logic` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
+    /// }
+    /// ```
     /// </summary>
     WithRawResponseTask<CreateLogStreamResponseContent> CreateAsync(
         CreateLogStreamRequestContent request,
@@ -211,107 +287,157 @@ public partial interface ILogStreamsClient
 
     /// <summary>
     /// Retrieve a log stream configuration and status.
-    /// <para>Sample responses</para><para>Amazon EventBridge Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"awsAccountId": "string",
-    /// 		"awsRegion": "string",
-    /// 		"awsPartnerEventSource": "string"
-    /// 	}
-    /// }</code> <para>HTTP Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpContentType": "string",
-    /// 		"httpEndpoint": "string",
-    /// 		"httpAuthorization": "string"
-    /// 	}
-    /// }</code> <para>Datadog Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
     ///
-    /// }</code><para>Mixpanel</para>
+    /// **Sample responses**
     ///
-    /// 	Request: <code>{
-    /// 	  "name": "string",
-    /// 	  "type": "mixpanel",
-    /// 	  "sink": {
-    /// 		"mixpanelRegion": "string", // "us" | "eu",
-    /// 		"mixpanelProjectId": "string",
-    /// 		"mixpanelServiceAccountUsername": "string",
-    /// 		"mixpanelServiceAccountPassword": "string"
-    /// 	  }
-    /// 	} </code>
+    /// **Amazon EventBridge Log Stream**
     ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "awsAccountId": "string",
+    ///     "awsRegion": "string",
+    ///     "awsPartnerEventSource": "string"
+    ///   }
+    /// }
+    /// ```
     ///
-    /// 	Response: <code>{
-    /// 		"id": "string",
-    /// 		"name": "string",
-    /// 		"type": "mixpanel",
-    /// 		"status": "active",
-    /// 		"sink": {
-    /// 		  "mixpanelRegion": "string", // "us" | "eu",
-    /// 		  "mixpanelProjectId": "string",
-    /// 		  "mixpanelServiceAccountUsername": "string",
-    /// 		  "mixpanelServiceAccountPassword": "string" // the following is redacted on return
-    /// 		}
-    /// 	  } </code>
+    /// **HTTP Log Stream**
     ///
-    /// 	<para>Segment</para>
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpContentType": "string",
+    ///     "httpEndpoint": "string",
+    ///     "httpAuthorization": "string"
+    ///   }
+    /// }
+    /// ```
     ///
-    /// 	Request: <code> {
-    /// 	  "name": "string",
-    /// 	  "type": "segment",
-    /// 	  "sink": {
-    /// 		"segmentWriteKey": "string"
-    /// 	  }
-    /// 	}</code>
+    /// **Datadog Log Stream**
     ///
-    /// 	Response: <code>{
-    /// 	  "id": "string",
-    /// 	  "name": "string",
-    /// 	  "type": "segment",
-    /// 	  "status": "active",
-    /// 	  "sink": {
-    /// 		"segmentWriteKey": "string"
-    /// 	  }
-    /// 	} </code>
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }
+    /// ```
     ///
-    /// <para>Splunk Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
-    /// }</code> <para>Sumo Logic Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
-    /// }</code> <para>Status</para> The <c>status</c> of a log stream maybe any of the following:
-    /// 1. <c>active</c> - Stream is currently enabled.
-    /// 2. <c>paused</c> - Stream is currently user disabled and will not attempt log delivery.
-    /// 3. <c>suspended</c> - Stream is currently disabled because of errors and will not attempt log delivery.
+    /// **Mixpanel**
+    ///
+    /// **Request:**
+    ///
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "mixpanel",
+    ///   "sink": {
+    ///     "mixpanelRegion": "string",
+    ///     "mixpanelProjectId": "string",
+    ///     "mixpanelServiceAccountUsername": "string",
+    ///     "mixpanelServiceAccountPassword": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "mixpanel",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "mixpanelRegion": "string",
+    ///     "mixpanelProjectId": "string",
+    ///     "mixpanelServiceAccountUsername": "string",
+    ///     "mixpanelServiceAccountPassword": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Segment**
+    ///
+    /// **Request:**
+    ///
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "segment",
+    ///   "sink": {
+    ///     "segmentWriteKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "segment",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "segmentWriteKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Splunk Log Stream**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Sumo Logic Log Stream**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Status**
+    ///
+    /// The `status` of a log stream maybe any of the following:
+    ///
+    /// 1. `active` - Stream is currently enabled.
+    /// 2. `paused` - Stream is currently user disabled and will not attempt log delivery.
+    /// 3. `suspended` - Stream is currently disabled because of errors and will not attempt log delivery.
     /// </summary>
     WithRawResponseTask<GetLogStreamResponseContent> GetAsync(
         string id,
@@ -330,40 +456,79 @@ public partial interface ILogStreamsClient
 
     /// <summary>
     /// Update a log stream.
-    /// <para>Examples of how to use the PATCH endpoint.</para> The following fields may be updated in a PATCH operation: <list type="bullet"><item><description>name</description></item><item><description>status</description></item><item><description>sink</description></item></list> Note: For log streams of type <c>eventbridge</c> and <c>eventgrid</c>, updating the <c>sink</c> is not permitted.
-    /// <para>Update the status of a log stream</para><code>{
-    /// 	"status": "active|paused"
-    /// }</code>
-    /// <para>Update the name of a log stream</para><code>{
-    /// 	"name": "string"
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>http</c></para><code>{
+    ///
+    /// **Examples of how to use the PATCH endpoint.**
+    ///
+    /// The following fields may be updated in a PATCH operation:
+    ///
+    /// - name
+    /// - status
+    /// - sink
+    ///
+    /// Note: For log streams of type `eventbridge` and `eventgrid`, updating the `sink` is not permitted.
+    ///
+    /// **Update the status of a log stream**
+    ///
+    /// ```json
+    /// {
+    ///   "status": "active|paused"
+    /// }
+    /// ```
+    ///
+    /// **Update the name of a log stream**
+    ///
+    /// ```json
+    /// {
+    ///   "name": "string"
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `http`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
     ///     "httpEndpoint": "string",
     ///     "httpContentType": "string",
     ///     "httpContentFormat": "JSONARRAY|JSONLINES",
     ///     "httpAuthorization": "string"
     ///   }
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>datadog</c></para><code>{
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `datadog`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
     ///   }
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>splunk</c></para><code>{
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `splunk`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
     ///     "splunkDomain": "string",
     ///     "splunkToken": "string",
     ///     "splunkPort": "string",
     ///     "splunkSecure": "boolean"
     ///   }
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>sumo</c></para><code>{
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `sumo`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
     ///     "sumoSourceAddress": "string"
     ///   }
-    /// }</code>
+    /// }
+    /// ```
     /// </summary>
     WithRawResponseTask<UpdateLogStreamResponseContent> UpdateAsync(
         string id,

--- a/src/Auth0.ManagementApi/LogStreams/LogStreamsClient.cs
+++ b/src/Auth0.ManagementApi/LogStreams/LogStreamsClient.cs
@@ -359,72 +359,77 @@ public partial class LogStreamsClient : ILogStreamsClient
     }
 
     /// <summary>
-    /// Retrieve details on <see href="https://auth0.com/docs/logs/streams">log streams</see>.
-    /// <para>Sample Response</para><code>[{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"awsAccountId": "string",
-    /// 		"awsRegion": "string",
-    /// 		"awsPartnerEventSource": "string"
-    /// 	}
+    /// Retrieve details on [log streams](https://auth0.com/docs/logs/streams).
+    ///
+    /// **Sample Response**
+    ///
+    /// ```json
+    /// [{
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "awsAccountId": "string",
+    ///     "awsRegion": "string",
+    ///     "awsPartnerEventSource": "string"
+    ///   }
     /// }, {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpContentType": "string",
-    /// 		"httpEndpoint": "string",
-    /// 		"httpAuthorization": "string"
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpContentType": "string",
+    ///     "httpEndpoint": "string",
+    ///     "httpAuthorization": "string"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventgrid",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"azureSubscriptionId": "string",
-    /// 		"azureResourceGroup": "string",
-    /// 		"azureRegion": "string",
-    /// 		"azurePartnerTopic": "string"
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventgrid",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "azureSubscriptionId": "string",
+    ///     "azureResourceGroup": "string",
+    ///     "azureRegion": "string",
+    ///     "azurePartnerTopic": "string"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
     /// },
     /// {
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
-    /// }]</code>
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }]
+    /// ```
     /// </summary>
     /// <example><code>
     /// await client.LogStreams.ListAsync();
@@ -441,131 +446,202 @@ public partial class LogStreamsClient : ILogStreamsClient
 
     /// <summary>
     /// Create a log stream.
-    /// <para>Log Stream Types</para> The <c>type</c> of log stream being created determines the properties required in the <c>sink</c> payload.
-    /// <para>HTTP Stream</para> For an <c>http</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"sink": {
-    /// 		"httpEndpoint": "string",
-    /// 		"httpContentType": "string",
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpAuthorization": "string"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"httpEndpoint": "string",
-    /// 		"httpContentType": "string",
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpAuthorization": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Amazon EventBridge Stream</para> For an <c>eventbridge</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"sink": {
-    /// 		"awsRegion": "string",
-    /// 		"awsAccountId": "string"
-    /// 	}
-    /// }</code>
-    /// The response will include an additional field <c>awsPartnerEventSource</c> in the <c>sink</c>: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"awsAccountId": "string",
-    /// 		"awsRegion": "string",
-    /// 		"awsPartnerEventSource": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Azure Event Grid Stream</para> For an <c>Azure Event Grid</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "eventgrid",
-    /// 	"sink": {
-    /// 		"azureSubscriptionId": "string",
-    /// 		"azureResourceGroup": "string",
-    /// 		"azureRegion": "string"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"azureSubscriptionId": "string",
-    /// 		"azureResourceGroup": "string",
-    /// 		"azureRegion": "string",
-    /// 		"azurePartnerTopic": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Datadog Stream</para> For a <c>Datadog</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
-    /// }</code>
-    /// <para>Splunk Stream</para> For a <c>Splunk</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
-    /// }</code>
-    /// <para>Sumo Logic Stream</para> For a <c>Sumo Logic</c> Stream, the <c>sink</c> properties are listed in the payload below
-    /// Request: <code>{
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
-    /// }</code>
-    /// Response: <code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"status": "active",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
-    /// }</code>
+    ///
+    /// **Log Stream Types**
+    ///
+    /// The `type` of log stream being created determines the properties required in the `sink` payload.
+    ///
+    /// **HTTP Stream**
+    ///
+    /// For an `http` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "sink": {
+    ///     "httpEndpoint": "string",
+    ///     "httpContentType": "string",
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpAuthorization": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "httpEndpoint": "string",
+    ///     "httpContentType": "string",
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpAuthorization": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Amazon EventBridge Stream**
+    ///
+    /// For an `eventbridge` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "sink": {
+    ///     "awsRegion": "string",
+    ///     "awsAccountId": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// The response will include an additional field `awsPartnerEventSource` in the `sink`:
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "awsAccountId": "string",
+    ///     "awsRegion": "string",
+    ///     "awsPartnerEventSource": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Azure Event Grid Stream**
+    ///
+    /// For an `Azure Event Grid` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "eventgrid",
+    ///   "sink": {
+    ///     "azureSubscriptionId": "string",
+    ///     "azureResourceGroup": "string",
+    ///     "azureRegion": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "azureSubscriptionId": "string",
+    ///     "azureResourceGroup": "string",
+    ///     "azureRegion": "string",
+    ///     "azurePartnerTopic": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Datadog Stream**
+    ///
+    /// For a `Datadog` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Splunk Stream**
+    ///
+    /// For a `Splunk` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Sumo Logic Stream**
+    ///
+    /// For a `Sumo Logic` Stream, the `sink` properties are listed in the payload below.
+    ///
+    /// **Request:**
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
+    /// }
+    /// ```
     /// </summary>
     /// <example><code>
     /// await client.LogStreams.CreateAsync(
@@ -589,107 +665,157 @@ public partial class LogStreamsClient : ILogStreamsClient
 
     /// <summary>
     /// Retrieve a log stream configuration and status.
-    /// <para>Sample responses</para><para>Amazon EventBridge Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "eventbridge",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"awsAccountId": "string",
-    /// 		"awsRegion": "string",
-    /// 		"awsPartnerEventSource": "string"
-    /// 	}
-    /// }</code> <para>HTTP Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "http",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"httpContentFormat": "JSONLINES|JSONARRAY",
-    /// 		"httpContentType": "string",
-    /// 		"httpEndpoint": "string",
-    /// 		"httpAuthorization": "string"
-    /// 	}
-    /// }</code> <para>Datadog Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "datadog",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
-    /// 	}
     ///
-    /// }</code><para>Mixpanel</para>
+    /// **Sample responses**
     ///
-    /// 	Request: <code>{
-    /// 	  "name": "string",
-    /// 	  "type": "mixpanel",
-    /// 	  "sink": {
-    /// 		"mixpanelRegion": "string", // "us" | "eu",
-    /// 		"mixpanelProjectId": "string",
-    /// 		"mixpanelServiceAccountUsername": "string",
-    /// 		"mixpanelServiceAccountPassword": "string"
-    /// 	  }
-    /// 	} </code>
+    /// **Amazon EventBridge Log Stream**
     ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "eventbridge",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "awsAccountId": "string",
+    ///     "awsRegion": "string",
+    ///     "awsPartnerEventSource": "string"
+    ///   }
+    /// }
+    /// ```
     ///
-    /// 	Response: <code>{
-    /// 		"id": "string",
-    /// 		"name": "string",
-    /// 		"type": "mixpanel",
-    /// 		"status": "active",
-    /// 		"sink": {
-    /// 		  "mixpanelRegion": "string", // "us" | "eu",
-    /// 		  "mixpanelProjectId": "string",
-    /// 		  "mixpanelServiceAccountUsername": "string",
-    /// 		  "mixpanelServiceAccountPassword": "string" // the following is redacted on return
-    /// 		}
-    /// 	  } </code>
+    /// **HTTP Log Stream**
     ///
-    /// 	<para>Segment</para>
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "http",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "httpContentFormat": "JSONLINES|JSONARRAY",
+    ///     "httpContentType": "string",
+    ///     "httpEndpoint": "string",
+    ///     "httpAuthorization": "string"
+    ///   }
+    /// }
+    /// ```
     ///
-    /// 	Request: <code> {
-    /// 	  "name": "string",
-    /// 	  "type": "segment",
-    /// 	  "sink": {
-    /// 		"segmentWriteKey": "string"
-    /// 	  }
-    /// 	}</code>
+    /// **Datadog Log Stream**
     ///
-    /// 	Response: <code>{
-    /// 	  "id": "string",
-    /// 	  "name": "string",
-    /// 	  "type": "segment",
-    /// 	  "status": "active",
-    /// 	  "sink": {
-    /// 		"segmentWriteKey": "string"
-    /// 	  }
-    /// 	} </code>
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "datadog",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
+    ///   }
+    /// }
+    /// ```
     ///
-    /// <para>Splunk Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "splunk",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"splunkDomain": "string",
-    /// 		"splunkToken": "string",
-    /// 		"splunkPort": "string",
-    /// 		"splunkSecure": "boolean"
-    /// 	}
-    /// }</code> <para>Sumo Logic Log Stream</para><code>{
-    /// 	"id": "string",
-    /// 	"name": "string",
-    /// 	"type": "sumo",
-    /// 	"status": "active|paused|suspended",
-    /// 	"sink": {
-    /// 		"sumoSourceAddress": "string",
-    /// 	}
-    /// }</code> <para>Status</para> The <c>status</c> of a log stream maybe any of the following:
-    /// 1. <c>active</c> - Stream is currently enabled.
-    /// 2. <c>paused</c> - Stream is currently user disabled and will not attempt log delivery.
-    /// 3. <c>suspended</c> - Stream is currently disabled because of errors and will not attempt log delivery.
+    /// **Mixpanel**
+    ///
+    /// **Request:**
+    ///
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "mixpanel",
+    ///   "sink": {
+    ///     "mixpanelRegion": "string",
+    ///     "mixpanelProjectId": "string",
+    ///     "mixpanelServiceAccountUsername": "string",
+    ///     "mixpanelServiceAccountPassword": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "mixpanel",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "mixpanelRegion": "string",
+    ///     "mixpanelProjectId": "string",
+    ///     "mixpanelServiceAccountUsername": "string",
+    ///     "mixpanelServiceAccountPassword": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Segment**
+    ///
+    /// **Request:**
+    ///
+    /// ```json
+    /// {
+    ///   "name": "string",
+    ///   "type": "segment",
+    ///   "sink": {
+    ///     "segmentWriteKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Response:**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "segment",
+    ///   "status": "active",
+    ///   "sink": {
+    ///     "segmentWriteKey": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Splunk Log Stream**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "splunk",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "splunkDomain": "string",
+    ///     "splunkToken": "string",
+    ///     "splunkPort": "string",
+    ///     "splunkSecure": "boolean"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Sumo Logic Log Stream**
+    ///
+    /// ```json
+    /// {
+    ///   "id": "string",
+    ///   "name": "string",
+    ///   "type": "sumo",
+    ///   "status": "active|paused|suspended",
+    ///   "sink": {
+    ///     "sumoSourceAddress": "string"
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// **Status**
+    ///
+    /// The `status` of a log stream maybe any of the following:
+    ///
+    /// 1. `active` - Stream is currently enabled.
+    /// 2. `paused` - Stream is currently user disabled and will not attempt log delivery.
+    /// 3. `suspended` - Stream is currently disabled because of errors and will not attempt log delivery.
     /// </summary>
     /// <example><code>
     /// await client.LogStreams.GetAsync("id");
@@ -773,40 +899,79 @@ public partial class LogStreamsClient : ILogStreamsClient
 
     /// <summary>
     /// Update a log stream.
-    /// <para>Examples of how to use the PATCH endpoint.</para> The following fields may be updated in a PATCH operation: <list type="bullet"><item><description>name</description></item><item><description>status</description></item><item><description>sink</description></item></list> Note: For log streams of type <c>eventbridge</c> and <c>eventgrid</c>, updating the <c>sink</c> is not permitted.
-    /// <para>Update the status of a log stream</para><code>{
-    /// 	"status": "active|paused"
-    /// }</code>
-    /// <para>Update the name of a log stream</para><code>{
-    /// 	"name": "string"
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>http</c></para><code>{
+    ///
+    /// **Examples of how to use the PATCH endpoint.**
+    ///
+    /// The following fields may be updated in a PATCH operation:
+    ///
+    /// - name
+    /// - status
+    /// - sink
+    ///
+    /// Note: For log streams of type `eventbridge` and `eventgrid`, updating the `sink` is not permitted.
+    ///
+    /// **Update the status of a log stream**
+    ///
+    /// ```json
+    /// {
+    ///   "status": "active|paused"
+    /// }
+    /// ```
+    ///
+    /// **Update the name of a log stream**
+    ///
+    /// ```json
+    /// {
+    ///   "name": "string"
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `http`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
     ///     "httpEndpoint": "string",
     ///     "httpContentType": "string",
     ///     "httpContentFormat": "JSONARRAY|JSONLINES",
     ///     "httpAuthorization": "string"
     ///   }
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>datadog</c></para><code>{
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `datadog`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
-    /// 		"datadogRegion": "string",
-    /// 		"datadogApiKey": "string"
+    ///     "datadogRegion": "string",
+    ///     "datadogApiKey": "string"
     ///   }
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>splunk</c></para><code>{
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `splunk`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
     ///     "splunkDomain": "string",
     ///     "splunkToken": "string",
     ///     "splunkPort": "string",
     ///     "splunkSecure": "boolean"
     ///   }
-    /// }</code>
-    /// <para>Update the sink properties of a stream of type <c>sumo</c></para><code>{
+    /// }
+    /// ```
+    ///
+    /// **Update the sink properties of a stream of type `sumo`**
+    ///
+    /// ```json
+    /// {
     ///   "sink": {
     ///     "sumoSourceAddress": "string"
     ///   }
-    /// }</code>
+    /// }
+    /// ```
     /// </summary>
     /// <example><code>
     /// await client.LogStreams.UpdateAsync("id", new UpdateLogStreamRequestContent());

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/Requests/CreateSelfServiceProfileSsoTicketRequestContent.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/Requests/CreateSelfServiceProfileSsoTicketRequestContent.cs
@@ -54,6 +54,10 @@ public record CreateSelfServiceProfileSsoTicketRequestContent
     [JsonPropertyName("use_for_organization_discovery")]
     public bool? UseForOrganizationDiscovery { get; set; }
 
+    [Optional]
+    [JsonPropertyName("enabled_features")]
+    public SelfServiceProfileSsoTicketEnabledFeatures? EnabledFeatures { get; set; }
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/src/Auth0.ManagementApi/Tenants/Settings/Requests/UpdateTenantSettingsRequestContent.cs
+++ b/src/Auth0.ManagementApi/Tenants/Settings/Requests/UpdateTenantSettingsRequestContent.cs
@@ -204,6 +204,13 @@ public record UpdateTenantSettingsRequestContent
     public TenantSettingsResourceParameterProfile? ResourceParameterProfile { get; set; }
 
     /// <summary>
+    /// Whether the authorization server supports retrieving client metadata from a client_id URL.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("client_id_metadata_document_supported")]
+    public bool? ClientIdMetadataDocumentSupported { get; set; }
+
+    /// <summary>
     /// Whether Auth0 Guide (AI-powered assistance) is enabled for this tenant.
     /// </summary>
     [Optional]
@@ -216,6 +223,10 @@ public record UpdateTenantSettingsRequestContent
     [Optional]
     [JsonPropertyName("phone_consolidated_experience")]
     public bool? PhoneConsolidatedExperience { get; set; }
+
+    [Optional]
+    [JsonPropertyName("dynamic_client_registration_security_mode")]
+    public TenantSettingsDynamicClientRegistrationSecurityMode? DynamicClientRegistrationSecurityMode { get; set; }
 
     /// <inheritdoc />
     public override string ToString()

--- a/src/Auth0.ManagementApi/Types/Client.cs
+++ b/src/Auth0.ManagementApi/Types/Client.cs
@@ -309,6 +309,18 @@ public record Client : IJsonOnDeserialized, IJsonOnSerializing
     [JsonPropertyName("express_configuration")]
     public ExpressConfiguration? ExpressConfiguration { get; set; }
 
+    [Optional]
+    [JsonPropertyName("my_organization_configuration")]
+    public ClientMyOrganizationResponseConfiguration? MyOrganizationConfiguration { get; set; }
+
+    [Optional]
+    [JsonPropertyName("third_party_security_mode")]
+    public ClientThirdPartySecurityModeEnum? ThirdPartySecurityMode { get; set; }
+
+    [Optional]
+    [JsonPropertyName("redirection_policy")]
+    public ClientRedirectionPolicyEnum? RedirectionPolicy { get; set; }
+
     /// <summary>
     /// The identifier of the resource server that this client is linked to.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/ClientGrantDefaultForEnum.cs
+++ b/src/Auth0.ManagementApi/Types/ClientGrantDefaultForEnum.cs
@@ -1,0 +1,113 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(ClientGrantDefaultForEnum.ClientGrantDefaultForEnumSerializer))]
+[Serializable]
+public readonly record struct ClientGrantDefaultForEnum : IStringEnum
+{
+    public static readonly ClientGrantDefaultForEnum ThirdPartyClients = new(
+        Values.ThirdPartyClients
+    );
+
+    public ClientGrantDefaultForEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ClientGrantDefaultForEnum FromCustom(string value)
+    {
+        return new ClientGrantDefaultForEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(ClientGrantDefaultForEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(ClientGrantDefaultForEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(ClientGrantDefaultForEnum value) => value.Value;
+
+    public static explicit operator ClientGrantDefaultForEnum(string value) => new(value);
+
+    internal class ClientGrantDefaultForEnumSerializer : JsonConverter<ClientGrantDefaultForEnum>
+    {
+        public override ClientGrantDefaultForEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ClientGrantDefaultForEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ClientGrantDefaultForEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ClientGrantDefaultForEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ClientGrantDefaultForEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ClientGrantDefaultForEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string ThirdPartyClients = "third_party_clients";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientGrantResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/ClientGrantResponseContent.cs
@@ -50,6 +50,10 @@ public record ClientGrantResponseContent : IJsonOnDeserialized
     [JsonPropertyName("allow_any_organization")]
     public bool? AllowAnyOrganization { get; set; }
 
+    [Optional]
+    [JsonPropertyName("default_for")]
+    public ClientGrantDefaultForEnum? DefaultFor { get; set; }
+
     /// <summary>
     /// If enabled, this grant is a special grant created by Auth0. It cannot be modified or deleted directly.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/ClientMyOrganizationConfigurationAllowedStrategiesEnum.cs
+++ b/src/Auth0.ManagementApi/Types/ClientMyOrganizationConfigurationAllowedStrategiesEnum.cs
@@ -1,0 +1,159 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(ClientMyOrganizationConfigurationAllowedStrategiesEnum.ClientMyOrganizationConfigurationAllowedStrategiesEnumSerializer)
+)]
+[Serializable]
+public readonly record struct ClientMyOrganizationConfigurationAllowedStrategiesEnum : IStringEnum
+{
+    public static readonly ClientMyOrganizationConfigurationAllowedStrategiesEnum Pingfederate =
+        new(Values.Pingfederate);
+
+    public static readonly ClientMyOrganizationConfigurationAllowedStrategiesEnum Adfs = new(
+        Values.Adfs
+    );
+
+    public static readonly ClientMyOrganizationConfigurationAllowedStrategiesEnum Waad = new(
+        Values.Waad
+    );
+
+    public static readonly ClientMyOrganizationConfigurationAllowedStrategiesEnum GoogleApps = new(
+        Values.GoogleApps
+    );
+
+    public static readonly ClientMyOrganizationConfigurationAllowedStrategiesEnum Okta = new(
+        Values.Okta
+    );
+
+    public static readonly ClientMyOrganizationConfigurationAllowedStrategiesEnum Oidc = new(
+        Values.Oidc
+    );
+
+    public static readonly ClientMyOrganizationConfigurationAllowedStrategiesEnum Samlp = new(
+        Values.Samlp
+    );
+
+    public ClientMyOrganizationConfigurationAllowedStrategiesEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ClientMyOrganizationConfigurationAllowedStrategiesEnum FromCustom(string value)
+    {
+        return new ClientMyOrganizationConfigurationAllowedStrategiesEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        ClientMyOrganizationConfigurationAllowedStrategiesEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        ClientMyOrganizationConfigurationAllowedStrategiesEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        ClientMyOrganizationConfigurationAllowedStrategiesEnum value
+    ) => value.Value;
+
+    public static explicit operator ClientMyOrganizationConfigurationAllowedStrategiesEnum(
+        string value
+    ) => new(value);
+
+    internal class ClientMyOrganizationConfigurationAllowedStrategiesEnumSerializer
+        : JsonConverter<ClientMyOrganizationConfigurationAllowedStrategiesEnum>
+    {
+        public override ClientMyOrganizationConfigurationAllowedStrategiesEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ClientMyOrganizationConfigurationAllowedStrategiesEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ClientMyOrganizationConfigurationAllowedStrategiesEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ClientMyOrganizationConfigurationAllowedStrategiesEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ClientMyOrganizationConfigurationAllowedStrategiesEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ClientMyOrganizationConfigurationAllowedStrategiesEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Pingfederate = "pingfederate";
+
+        public const string Adfs = "adfs";
+
+        public const string Waad = "waad";
+
+        public const string GoogleApps = "google-apps";
+
+        public const string Okta = "okta";
+
+        public const string Oidc = "oidc";
+
+        public const string Samlp = "samlp";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientMyOrganizationDeletionBehaviorEnum.cs
+++ b/src/Auth0.ManagementApi/Types/ClientMyOrganizationDeletionBehaviorEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(ClientMyOrganizationDeletionBehaviorEnum.ClientMyOrganizationDeletionBehaviorEnumSerializer)
+)]
+[Serializable]
+public readonly record struct ClientMyOrganizationDeletionBehaviorEnum : IStringEnum
+{
+    public static readonly ClientMyOrganizationDeletionBehaviorEnum Allow = new(Values.Allow);
+
+    public static readonly ClientMyOrganizationDeletionBehaviorEnum AllowIfEmpty = new(
+        Values.AllowIfEmpty
+    );
+
+    public ClientMyOrganizationDeletionBehaviorEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ClientMyOrganizationDeletionBehaviorEnum FromCustom(string value)
+    {
+        return new ClientMyOrganizationDeletionBehaviorEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        ClientMyOrganizationDeletionBehaviorEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        ClientMyOrganizationDeletionBehaviorEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(ClientMyOrganizationDeletionBehaviorEnum value) =>
+        value.Value;
+
+    public static explicit operator ClientMyOrganizationDeletionBehaviorEnum(string value) =>
+        new(value);
+
+    internal class ClientMyOrganizationDeletionBehaviorEnumSerializer
+        : JsonConverter<ClientMyOrganizationDeletionBehaviorEnum>
+    {
+        public override ClientMyOrganizationDeletionBehaviorEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ClientMyOrganizationDeletionBehaviorEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ClientMyOrganizationDeletionBehaviorEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ClientMyOrganizationDeletionBehaviorEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ClientMyOrganizationDeletionBehaviorEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ClientMyOrganizationDeletionBehaviorEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Allow = "allow";
+
+        public const string AllowIfEmpty = "allow_if_empty";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientMyOrganizationPatchConfiguration.cs
+++ b/src/Auth0.ManagementApi/Types/ClientMyOrganizationPatchConfiguration.cs
@@ -1,0 +1,52 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Configuration related to the My Organization Configuration for the client.
+/// </summary>
+[Serializable]
+public record ClientMyOrganizationPatchConfiguration : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The connection profile ID that this client should validate against.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("connection_profile_id")]
+    public string? ConnectionProfileId { get; set; }
+
+    /// <summary>
+    /// The user attribute profile ID that this client should validate against.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("user_attribute_profile_id")]
+    public string? UserAttributeProfileId { get; set; }
+
+    /// <summary>
+    /// The allowed connection strategies for the My Organization Configuration.
+    /// </summary>
+    [JsonPropertyName("allowed_strategies")]
+    public IEnumerable<ClientMyOrganizationConfigurationAllowedStrategiesEnum> AllowedStrategies { get; set; } =
+        new List<ClientMyOrganizationConfigurationAllowedStrategiesEnum>();
+
+    [JsonPropertyName("connection_deletion_behavior")]
+    public required ClientMyOrganizationDeletionBehaviorEnum ConnectionDeletionBehavior { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientMyOrganizationPostConfiguration.cs
+++ b/src/Auth0.ManagementApi/Types/ClientMyOrganizationPostConfiguration.cs
@@ -1,0 +1,52 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Configuration related to the My Organization Configuration for the client.
+/// </summary>
+[Serializable]
+public record ClientMyOrganizationPostConfiguration : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The connection profile ID that this client should validate against.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("connection_profile_id")]
+    public string? ConnectionProfileId { get; set; }
+
+    /// <summary>
+    /// The user attribute profile ID that this client should validate against.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("user_attribute_profile_id")]
+    public string? UserAttributeProfileId { get; set; }
+
+    /// <summary>
+    /// The allowed connection strategies for the My Organization Configuration.
+    /// </summary>
+    [JsonPropertyName("allowed_strategies")]
+    public IEnumerable<ClientMyOrganizationConfigurationAllowedStrategiesEnum> AllowedStrategies { get; set; } =
+        new List<ClientMyOrganizationConfigurationAllowedStrategiesEnum>();
+
+    [JsonPropertyName("connection_deletion_behavior")]
+    public required ClientMyOrganizationDeletionBehaviorEnum ConnectionDeletionBehavior { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientMyOrganizationResponseConfiguration.cs
+++ b/src/Auth0.ManagementApi/Types/ClientMyOrganizationResponseConfiguration.cs
@@ -1,0 +1,52 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Configuration related to the My Organization Configuration for the client.
+/// </summary>
+[Serializable]
+public record ClientMyOrganizationResponseConfiguration : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The connection profile ID that this client should validate against.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("connection_profile_id")]
+    public string? ConnectionProfileId { get; set; }
+
+    /// <summary>
+    /// The user attribute profile ID that this client should validate against.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("user_attribute_profile_id")]
+    public string? UserAttributeProfileId { get; set; }
+
+    /// <summary>
+    /// The allowed connection strategies for the My Organization Configuration.
+    /// </summary>
+    [JsonPropertyName("allowed_strategies")]
+    public IEnumerable<ClientMyOrganizationConfigurationAllowedStrategiesEnum> AllowedStrategies { get; set; } =
+        new List<ClientMyOrganizationConfigurationAllowedStrategiesEnum>();
+
+    [JsonPropertyName("connection_deletion_behavior")]
+    public required ClientMyOrganizationDeletionBehaviorEnum ConnectionDeletionBehavior { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientRedirectionPolicyEnum.cs
+++ b/src/Auth0.ManagementApi/Types/ClientRedirectionPolicyEnum.cs
@@ -1,0 +1,118 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(ClientRedirectionPolicyEnum.ClientRedirectionPolicyEnumSerializer))]
+[Serializable]
+public readonly record struct ClientRedirectionPolicyEnum : IStringEnum
+{
+    public static readonly ClientRedirectionPolicyEnum AllowAlways = new(Values.AllowAlways);
+
+    public static readonly ClientRedirectionPolicyEnum OpenRedirectProtection = new(
+        Values.OpenRedirectProtection
+    );
+
+    public ClientRedirectionPolicyEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ClientRedirectionPolicyEnum FromCustom(string value)
+    {
+        return new ClientRedirectionPolicyEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(ClientRedirectionPolicyEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(ClientRedirectionPolicyEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(ClientRedirectionPolicyEnum value) => value.Value;
+
+    public static explicit operator ClientRedirectionPolicyEnum(string value) => new(value);
+
+    internal class ClientRedirectionPolicyEnumSerializer
+        : JsonConverter<ClientRedirectionPolicyEnum>
+    {
+        public override ClientRedirectionPolicyEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ClientRedirectionPolicyEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ClientRedirectionPolicyEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ClientRedirectionPolicyEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ClientRedirectionPolicyEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ClientRedirectionPolicyEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string AllowAlways = "allow_always";
+
+        public const string OpenRedirectProtection = "open_redirect_protection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientSessionTransferConfiguration.cs
+++ b/src/Auth0.ManagementApi/Types/ClientSessionTransferConfiguration.cs
@@ -53,6 +53,10 @@ public record ClientSessionTransferConfiguration : IJsonOnDeserialized
     [JsonPropertyName("enforce_online_refresh_tokens")]
     public bool? EnforceOnlineRefreshTokens { get; set; }
 
+    [Nullable, Optional]
+    [JsonPropertyName("delegation")]
+    public Optional<ClientSessionTransferDelegationConfiguration?> Delegation { get; set; }
+
     [JsonIgnore]
     public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
 

--- a/src/Auth0.ManagementApi/Types/ClientSessionTransferDelegationConfiguration.cs
+++ b/src/Auth0.ManagementApi/Types/ClientSessionTransferDelegationConfiguration.cs
@@ -1,0 +1,39 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Configuration for delegation (impersonation) access using Session Transfer Tokens
+/// </summary>
+[Serializable]
+public record ClientSessionTransferDelegationConfiguration : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Indicates whether delegation (impersonation) access is allowed using Session Transfer Tokens. Default value is `false`.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("allow_delegated_access")]
+    public bool? AllowDelegatedAccess { get; set; }
+
+    [Optional]
+    [JsonPropertyName("enforce_device_binding")]
+    public ClientSessionTransferDelegationDeviceBindingEnum? EnforceDeviceBinding { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientSessionTransferDelegationDeviceBindingEnum.cs
+++ b/src/Auth0.ManagementApi/Types/ClientSessionTransferDelegationDeviceBindingEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(ClientSessionTransferDelegationDeviceBindingEnum.ClientSessionTransferDelegationDeviceBindingEnumSerializer)
+)]
+[Serializable]
+public readonly record struct ClientSessionTransferDelegationDeviceBindingEnum : IStringEnum
+{
+    public static readonly ClientSessionTransferDelegationDeviceBindingEnum Ip = new(Values.Ip);
+
+    public static readonly ClientSessionTransferDelegationDeviceBindingEnum Asn = new(Values.Asn);
+
+    public ClientSessionTransferDelegationDeviceBindingEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ClientSessionTransferDelegationDeviceBindingEnum FromCustom(string value)
+    {
+        return new ClientSessionTransferDelegationDeviceBindingEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        ClientSessionTransferDelegationDeviceBindingEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        ClientSessionTransferDelegationDeviceBindingEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        ClientSessionTransferDelegationDeviceBindingEnum value
+    ) => value.Value;
+
+    public static explicit operator ClientSessionTransferDelegationDeviceBindingEnum(
+        string value
+    ) => new(value);
+
+    internal class ClientSessionTransferDelegationDeviceBindingEnumSerializer
+        : JsonConverter<ClientSessionTransferDelegationDeviceBindingEnum>
+    {
+        public override ClientSessionTransferDelegationDeviceBindingEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ClientSessionTransferDelegationDeviceBindingEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ClientSessionTransferDelegationDeviceBindingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ClientSessionTransferDelegationDeviceBindingEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ClientSessionTransferDelegationDeviceBindingEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ClientSessionTransferDelegationDeviceBindingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Ip = "ip";
+
+        public const string Asn = "asn";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ClientThirdPartySecurityModeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/ClientThirdPartySecurityModeEnum.cs
@@ -1,0 +1,116 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(ClientThirdPartySecurityModeEnum.ClientThirdPartySecurityModeEnumSerializer))]
+[Serializable]
+public readonly record struct ClientThirdPartySecurityModeEnum : IStringEnum
+{
+    public static readonly ClientThirdPartySecurityModeEnum Strict = new(Values.Strict);
+
+    public static readonly ClientThirdPartySecurityModeEnum Permissive = new(Values.Permissive);
+
+    public ClientThirdPartySecurityModeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ClientThirdPartySecurityModeEnum FromCustom(string value)
+    {
+        return new ClientThirdPartySecurityModeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(ClientThirdPartySecurityModeEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(ClientThirdPartySecurityModeEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(ClientThirdPartySecurityModeEnum value) => value.Value;
+
+    public static explicit operator ClientThirdPartySecurityModeEnum(string value) => new(value);
+
+    internal class ClientThirdPartySecurityModeEnumSerializer
+        : JsonConverter<ClientThirdPartySecurityModeEnum>
+    {
+        public override ClientThirdPartySecurityModeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ClientThirdPartySecurityModeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ClientThirdPartySecurityModeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ClientThirdPartySecurityModeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ClientThirdPartySecurityModeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ClientThirdPartySecurityModeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Strict = "strict";
+
+        public const string Permissive = "permissive";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ConnectedAccount.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectedAccount.cs
@@ -58,6 +58,13 @@ public record ConnectedAccount : IJsonOnDeserialized
     [JsonPropertyName("expires_at")]
     public DateTime? ExpiresAt { get; set; }
 
+    /// <summary>
+    /// The identifier of the organization associated with the connected account.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("organization_id")]
+    public string? OrganizationId { get; set; }
+
     [JsonIgnore]
     public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
 

--- a/src/Auth0.ManagementApi/Types/ConnectionDpopSigningAlgEnum.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionDpopSigningAlgEnum.cs
@@ -1,0 +1,116 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(ConnectionDpopSigningAlgEnum.ConnectionDpopSigningAlgEnumSerializer))]
+[Serializable]
+public readonly record struct ConnectionDpopSigningAlgEnum : IStringEnum
+{
+    public static readonly ConnectionDpopSigningAlgEnum Es256 = new(Values.Es256);
+
+    public static readonly ConnectionDpopSigningAlgEnum Ed25519 = new(Values.Ed25519);
+
+    public ConnectionDpopSigningAlgEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ConnectionDpopSigningAlgEnum FromCustom(string value)
+    {
+        return new ConnectionDpopSigningAlgEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(ConnectionDpopSigningAlgEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(ConnectionDpopSigningAlgEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(ConnectionDpopSigningAlgEnum value) => value.Value;
+
+    public static explicit operator ConnectionDpopSigningAlgEnum(string value) => new(value);
+
+    internal class ConnectionDpopSigningAlgEnumSerializer
+        : JsonConverter<ConnectionDpopSigningAlgEnum>
+    {
+        public override ConnectionDpopSigningAlgEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ConnectionDpopSigningAlgEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ConnectionDpopSigningAlgEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ConnectionDpopSigningAlgEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ConnectionDpopSigningAlgEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ConnectionDpopSigningAlgEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Es256 = "ES256";
+
+        public const string Ed25519 = "Ed25519";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ConnectionOptionsCommonOidc.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionOptionsCommonOidc.cs
@@ -32,6 +32,10 @@ public record ConnectionOptionsCommonOidc : IJsonOnDeserialized, IJsonOnSerializ
     [JsonPropertyName("domain_aliases")]
     public IEnumerable<string>? DomainAliases { get; set; }
 
+    [Optional]
+    [JsonPropertyName("dpop_signing_alg")]
+    public ConnectionDpopSigningAlgEnum? DpopSigningAlg { get; set; }
+
     [Nullable, Optional]
     [JsonPropertyName("federated_connections_access_tokens")]
     public Optional<ConnectionFederatedConnectionsAccessTokens?> FederatedConnectionsAccessTokens { get; set; }

--- a/src/Auth0.ManagementApi/Types/ConnectionOptionsOidc.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionOptionsOidc.cs
@@ -44,6 +44,10 @@ public record ConnectionOptionsOidc : IJsonOnDeserialized, IJsonOnSerializing
     [JsonPropertyName("domain_aliases")]
     public IEnumerable<string>? DomainAliases { get; set; }
 
+    [Optional]
+    [JsonPropertyName("dpop_signing_alg")]
+    public ConnectionDpopSigningAlgEnum? DpopSigningAlg { get; set; }
+
     [Nullable, Optional]
     [JsonPropertyName("federated_connections_access_tokens")]
     public Optional<ConnectionFederatedConnectionsAccessTokens?> FederatedConnectionsAccessTokens { get; set; }

--- a/src/Auth0.ManagementApi/Types/ConnectionOptionsOkta.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionOptionsOkta.cs
@@ -48,6 +48,10 @@ public record ConnectionOptionsOkta : IJsonOnDeserialized, IJsonOnSerializing
     [JsonPropertyName("domain_aliases")]
     public IEnumerable<string>? DomainAliases { get; set; }
 
+    [Optional]
+    [JsonPropertyName("dpop_signing_alg")]
+    public ConnectionDpopSigningAlgEnum? DpopSigningAlg { get; set; }
+
     [Nullable, Optional]
     [JsonPropertyName("federated_connections_access_tokens")]
     public Optional<ConnectionFederatedConnectionsAccessTokens?> FederatedConnectionsAccessTokens { get; set; }

--- a/src/Auth0.ManagementApi/Types/ConnectionPropertiesOptions.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionPropertiesOptions.cs
@@ -100,6 +100,10 @@ public record ConnectionPropertiesOptions : IJsonOnDeserialized, IJsonOnSerializ
     public bool? ApiEnableUsers { get; set; }
 
     [Optional]
+    [JsonPropertyName("api_enable_groups")]
+    public bool? ApiEnableGroups { get; set; }
+
+    [Optional]
     [JsonPropertyName("basic_profile")]
     public bool? BasicProfile { get; set; }
 

--- a/src/Auth0.ManagementApi/Types/CreateClientGrantResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/CreateClientGrantResponseContent.cs
@@ -50,6 +50,10 @@ public record CreateClientGrantResponseContent : IJsonOnDeserialized
     [JsonPropertyName("allow_any_organization")]
     public bool? AllowAnyOrganization { get; set; }
 
+    [Optional]
+    [JsonPropertyName("default_for")]
+    public ClientGrantDefaultForEnum? DefaultFor { get; set; }
+
     /// <summary>
     /// If enabled, this grant is a special grant created by Auth0. It cannot be modified or deleted directly.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/CreateClientResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/CreateClientResponseContent.cs
@@ -309,6 +309,18 @@ public record CreateClientResponseContent : IJsonOnDeserialized, IJsonOnSerializ
     [JsonPropertyName("express_configuration")]
     public ExpressConfiguration? ExpressConfiguration { get; set; }
 
+    [Optional]
+    [JsonPropertyName("my_organization_configuration")]
+    public ClientMyOrganizationResponseConfiguration? MyOrganizationConfiguration { get; set; }
+
+    [Optional]
+    [JsonPropertyName("third_party_security_mode")]
+    public ClientThirdPartySecurityModeEnum? ThirdPartySecurityMode { get; set; }
+
+    [Optional]
+    [JsonPropertyName("redirection_policy")]
+    public ClientRedirectionPolicyEnum? RedirectionPolicy { get; set; }
+
     /// <summary>
     /// The identifier of the resource server that this client is linked to.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/EventStreamDeliveryEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamDeliveryEventTypeEnum.cs
@@ -8,22 +8,54 @@ namespace Auth0.ManagementApi;
 [Serializable]
 public readonly record struct EventStreamDeliveryEventTypeEnum : IStringEnum
 {
-    public static readonly EventStreamDeliveryEventTypeEnum UserCreated = new(Values.UserCreated);
+    public static readonly EventStreamDeliveryEventTypeEnum GroupCreated = new(Values.GroupCreated);
 
-    public static readonly EventStreamDeliveryEventTypeEnum UserDeleted = new(Values.UserDeleted);
+    public static readonly EventStreamDeliveryEventTypeEnum GroupDeleted = new(Values.GroupDeleted);
 
-    public static readonly EventStreamDeliveryEventTypeEnum UserUpdated = new(Values.UserUpdated);
+    public static readonly EventStreamDeliveryEventTypeEnum GroupMemberAdded = new(
+        Values.GroupMemberAdded
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum GroupMemberDeleted = new(
+        Values.GroupMemberDeleted
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum GroupRoleAssigned = new(
+        Values.GroupRoleAssigned
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum GroupRoleDeleted = new(
+        Values.GroupRoleDeleted
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum GroupUpdated = new(Values.GroupUpdated);
+
+    public static readonly EventStreamDeliveryEventTypeEnum OrganizationConnectionAdded = new(
+        Values.OrganizationConnectionAdded
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum OrganizationConnectionRemoved = new(
+        Values.OrganizationConnectionRemoved
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum OrganizationConnectionUpdated = new(
+        Values.OrganizationConnectionUpdated
+    );
 
     public static readonly EventStreamDeliveryEventTypeEnum OrganizationCreated = new(
         Values.OrganizationCreated
     );
 
-    public static readonly EventStreamDeliveryEventTypeEnum OrganizationUpdated = new(
-        Values.OrganizationUpdated
-    );
-
     public static readonly EventStreamDeliveryEventTypeEnum OrganizationDeleted = new(
         Values.OrganizationDeleted
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum OrganizationGroupRoleAssigned = new(
+        Values.OrganizationGroupRoleAssigned
+    );
+
+    public static readonly EventStreamDeliveryEventTypeEnum OrganizationGroupRoleDeleted = new(
+        Values.OrganizationGroupRoleDeleted
     );
 
     public static readonly EventStreamDeliveryEventTypeEnum OrganizationMemberAdded = new(
@@ -42,31 +74,15 @@ public readonly record struct EventStreamDeliveryEventTypeEnum : IStringEnum
         Values.OrganizationMemberRoleDeleted
     );
 
-    public static readonly EventStreamDeliveryEventTypeEnum OrganizationConnectionAdded = new(
-        Values.OrganizationConnectionAdded
+    public static readonly EventStreamDeliveryEventTypeEnum OrganizationUpdated = new(
+        Values.OrganizationUpdated
     );
 
-    public static readonly EventStreamDeliveryEventTypeEnum OrganizationConnectionUpdated = new(
-        Values.OrganizationConnectionUpdated
-    );
+    public static readonly EventStreamDeliveryEventTypeEnum UserCreated = new(Values.UserCreated);
 
-    public static readonly EventStreamDeliveryEventTypeEnum OrganizationConnectionRemoved = new(
-        Values.OrganizationConnectionRemoved
-    );
+    public static readonly EventStreamDeliveryEventTypeEnum UserDeleted = new(Values.UserDeleted);
 
-    public static readonly EventStreamDeliveryEventTypeEnum GroupCreated = new(Values.GroupCreated);
-
-    public static readonly EventStreamDeliveryEventTypeEnum GroupUpdated = new(Values.GroupUpdated);
-
-    public static readonly EventStreamDeliveryEventTypeEnum GroupDeleted = new(Values.GroupDeleted);
-
-    public static readonly EventStreamDeliveryEventTypeEnum GroupMemberAdded = new(
-        Values.GroupMemberAdded
-    );
-
-    public static readonly EventStreamDeliveryEventTypeEnum GroupMemberDeleted = new(
-        Values.GroupMemberDeleted
-    );
+    public static readonly EventStreamDeliveryEventTypeEnum UserUpdated = new(Values.UserUpdated);
 
     public EventStreamDeliveryEventTypeEnum(string value)
     {
@@ -165,17 +181,33 @@ public readonly record struct EventStreamDeliveryEventTypeEnum : IStringEnum
     [Serializable]
     public static class Values
     {
-        public const string UserCreated = "user.created";
+        public const string GroupCreated = "group.created";
 
-        public const string UserDeleted = "user.deleted";
+        public const string GroupDeleted = "group.deleted";
 
-        public const string UserUpdated = "user.updated";
+        public const string GroupMemberAdded = "group.member.added";
+
+        public const string GroupMemberDeleted = "group.member.deleted";
+
+        public const string GroupRoleAssigned = "group.role.assigned";
+
+        public const string GroupRoleDeleted = "group.role.deleted";
+
+        public const string GroupUpdated = "group.updated";
+
+        public const string OrganizationConnectionAdded = "organization.connection.added";
+
+        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+
+        public const string OrganizationConnectionUpdated = "organization.connection.updated";
 
         public const string OrganizationCreated = "organization.created";
 
-        public const string OrganizationUpdated = "organization.updated";
-
         public const string OrganizationDeleted = "organization.deleted";
+
+        public const string OrganizationGroupRoleAssigned = "organization.group.role.assigned";
+
+        public const string OrganizationGroupRoleDeleted = "organization.group.role.deleted";
 
         public const string OrganizationMemberAdded = "organization.member.added";
 
@@ -185,20 +217,12 @@ public readonly record struct EventStreamDeliveryEventTypeEnum : IStringEnum
 
         public const string OrganizationMemberRoleDeleted = "organization.member.role.deleted";
 
-        public const string OrganizationConnectionAdded = "organization.connection.added";
+        public const string OrganizationUpdated = "organization.updated";
 
-        public const string OrganizationConnectionUpdated = "organization.connection.updated";
+        public const string UserCreated = "user.created";
 
-        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+        public const string UserDeleted = "user.deleted";
 
-        public const string GroupCreated = "group.created";
-
-        public const string GroupUpdated = "group.updated";
-
-        public const string GroupDeleted = "group.deleted";
-
-        public const string GroupMemberAdded = "group.member.added";
-
-        public const string GroupMemberDeleted = "group.member.deleted";
+        public const string UserUpdated = "user.updated";
     }
 }

--- a/src/Auth0.ManagementApi/Types/EventStreamEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamEventTypeEnum.cs
@@ -8,22 +8,50 @@ namespace Auth0.ManagementApi;
 [Serializable]
 public readonly record struct EventStreamEventTypeEnum : IStringEnum
 {
-    public static readonly EventStreamEventTypeEnum UserCreated = new(Values.UserCreated);
+    public static readonly EventStreamEventTypeEnum GroupCreated = new(Values.GroupCreated);
 
-    public static readonly EventStreamEventTypeEnum UserDeleted = new(Values.UserDeleted);
+    public static readonly EventStreamEventTypeEnum GroupDeleted = new(Values.GroupDeleted);
 
-    public static readonly EventStreamEventTypeEnum UserUpdated = new(Values.UserUpdated);
+    public static readonly EventStreamEventTypeEnum GroupMemberAdded = new(Values.GroupMemberAdded);
+
+    public static readonly EventStreamEventTypeEnum GroupMemberDeleted = new(
+        Values.GroupMemberDeleted
+    );
+
+    public static readonly EventStreamEventTypeEnum GroupRoleAssigned = new(
+        Values.GroupRoleAssigned
+    );
+
+    public static readonly EventStreamEventTypeEnum GroupRoleDeleted = new(Values.GroupRoleDeleted);
+
+    public static readonly EventStreamEventTypeEnum GroupUpdated = new(Values.GroupUpdated);
+
+    public static readonly EventStreamEventTypeEnum OrganizationConnectionAdded = new(
+        Values.OrganizationConnectionAdded
+    );
+
+    public static readonly EventStreamEventTypeEnum OrganizationConnectionRemoved = new(
+        Values.OrganizationConnectionRemoved
+    );
+
+    public static readonly EventStreamEventTypeEnum OrganizationConnectionUpdated = new(
+        Values.OrganizationConnectionUpdated
+    );
 
     public static readonly EventStreamEventTypeEnum OrganizationCreated = new(
         Values.OrganizationCreated
     );
 
-    public static readonly EventStreamEventTypeEnum OrganizationUpdated = new(
-        Values.OrganizationUpdated
-    );
-
     public static readonly EventStreamEventTypeEnum OrganizationDeleted = new(
         Values.OrganizationDeleted
+    );
+
+    public static readonly EventStreamEventTypeEnum OrganizationGroupRoleAssigned = new(
+        Values.OrganizationGroupRoleAssigned
+    );
+
+    public static readonly EventStreamEventTypeEnum OrganizationGroupRoleDeleted = new(
+        Values.OrganizationGroupRoleDeleted
     );
 
     public static readonly EventStreamEventTypeEnum OrganizationMemberAdded = new(
@@ -42,29 +70,15 @@ public readonly record struct EventStreamEventTypeEnum : IStringEnum
         Values.OrganizationMemberRoleDeleted
     );
 
-    public static readonly EventStreamEventTypeEnum OrganizationConnectionAdded = new(
-        Values.OrganizationConnectionAdded
+    public static readonly EventStreamEventTypeEnum OrganizationUpdated = new(
+        Values.OrganizationUpdated
     );
 
-    public static readonly EventStreamEventTypeEnum OrganizationConnectionUpdated = new(
-        Values.OrganizationConnectionUpdated
-    );
+    public static readonly EventStreamEventTypeEnum UserCreated = new(Values.UserCreated);
 
-    public static readonly EventStreamEventTypeEnum OrganizationConnectionRemoved = new(
-        Values.OrganizationConnectionRemoved
-    );
+    public static readonly EventStreamEventTypeEnum UserDeleted = new(Values.UserDeleted);
 
-    public static readonly EventStreamEventTypeEnum GroupCreated = new(Values.GroupCreated);
-
-    public static readonly EventStreamEventTypeEnum GroupUpdated = new(Values.GroupUpdated);
-
-    public static readonly EventStreamEventTypeEnum GroupDeleted = new(Values.GroupDeleted);
-
-    public static readonly EventStreamEventTypeEnum GroupMemberAdded = new(Values.GroupMemberAdded);
-
-    public static readonly EventStreamEventTypeEnum GroupMemberDeleted = new(
-        Values.GroupMemberDeleted
-    );
+    public static readonly EventStreamEventTypeEnum UserUpdated = new(Values.UserUpdated);
 
     public EventStreamEventTypeEnum(string value)
     {
@@ -162,17 +176,33 @@ public readonly record struct EventStreamEventTypeEnum : IStringEnum
     [Serializable]
     public static class Values
     {
-        public const string UserCreated = "user.created";
+        public const string GroupCreated = "group.created";
 
-        public const string UserDeleted = "user.deleted";
+        public const string GroupDeleted = "group.deleted";
 
-        public const string UserUpdated = "user.updated";
+        public const string GroupMemberAdded = "group.member.added";
+
+        public const string GroupMemberDeleted = "group.member.deleted";
+
+        public const string GroupRoleAssigned = "group.role.assigned";
+
+        public const string GroupRoleDeleted = "group.role.deleted";
+
+        public const string GroupUpdated = "group.updated";
+
+        public const string OrganizationConnectionAdded = "organization.connection.added";
+
+        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+
+        public const string OrganizationConnectionUpdated = "organization.connection.updated";
 
         public const string OrganizationCreated = "organization.created";
 
-        public const string OrganizationUpdated = "organization.updated";
-
         public const string OrganizationDeleted = "organization.deleted";
+
+        public const string OrganizationGroupRoleAssigned = "organization.group.role.assigned";
+
+        public const string OrganizationGroupRoleDeleted = "organization.group.role.deleted";
 
         public const string OrganizationMemberAdded = "organization.member.added";
 
@@ -182,20 +212,12 @@ public readonly record struct EventStreamEventTypeEnum : IStringEnum
 
         public const string OrganizationMemberRoleDeleted = "organization.member.role.deleted";
 
-        public const string OrganizationConnectionAdded = "organization.connection.added";
+        public const string OrganizationUpdated = "organization.updated";
 
-        public const string OrganizationConnectionUpdated = "organization.connection.updated";
+        public const string UserCreated = "user.created";
 
-        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+        public const string UserDeleted = "user.deleted";
 
-        public const string GroupCreated = "group.created";
-
-        public const string GroupUpdated = "group.updated";
-
-        public const string GroupDeleted = "group.deleted";
-
-        public const string GroupMemberAdded = "group.member.added";
-
-        public const string GroupMemberDeleted = "group.member.deleted";
+        public const string UserUpdated = "user.updated";
     }
 }

--- a/src/Auth0.ManagementApi/Types/EventStreamTestEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamTestEventTypeEnum.cs
@@ -8,22 +8,54 @@ namespace Auth0.ManagementApi;
 [Serializable]
 public readonly record struct EventStreamTestEventTypeEnum : IStringEnum
 {
-    public static readonly EventStreamTestEventTypeEnum UserCreated = new(Values.UserCreated);
+    public static readonly EventStreamTestEventTypeEnum GroupCreated = new(Values.GroupCreated);
 
-    public static readonly EventStreamTestEventTypeEnum UserDeleted = new(Values.UserDeleted);
+    public static readonly EventStreamTestEventTypeEnum GroupDeleted = new(Values.GroupDeleted);
 
-    public static readonly EventStreamTestEventTypeEnum UserUpdated = new(Values.UserUpdated);
+    public static readonly EventStreamTestEventTypeEnum GroupMemberAdded = new(
+        Values.GroupMemberAdded
+    );
+
+    public static readonly EventStreamTestEventTypeEnum GroupMemberDeleted = new(
+        Values.GroupMemberDeleted
+    );
+
+    public static readonly EventStreamTestEventTypeEnum GroupRoleAssigned = new(
+        Values.GroupRoleAssigned
+    );
+
+    public static readonly EventStreamTestEventTypeEnum GroupRoleDeleted = new(
+        Values.GroupRoleDeleted
+    );
+
+    public static readonly EventStreamTestEventTypeEnum GroupUpdated = new(Values.GroupUpdated);
+
+    public static readonly EventStreamTestEventTypeEnum OrganizationConnectionAdded = new(
+        Values.OrganizationConnectionAdded
+    );
+
+    public static readonly EventStreamTestEventTypeEnum OrganizationConnectionRemoved = new(
+        Values.OrganizationConnectionRemoved
+    );
+
+    public static readonly EventStreamTestEventTypeEnum OrganizationConnectionUpdated = new(
+        Values.OrganizationConnectionUpdated
+    );
 
     public static readonly EventStreamTestEventTypeEnum OrganizationCreated = new(
         Values.OrganizationCreated
     );
 
-    public static readonly EventStreamTestEventTypeEnum OrganizationUpdated = new(
-        Values.OrganizationUpdated
-    );
-
     public static readonly EventStreamTestEventTypeEnum OrganizationDeleted = new(
         Values.OrganizationDeleted
+    );
+
+    public static readonly EventStreamTestEventTypeEnum OrganizationGroupRoleAssigned = new(
+        Values.OrganizationGroupRoleAssigned
+    );
+
+    public static readonly EventStreamTestEventTypeEnum OrganizationGroupRoleDeleted = new(
+        Values.OrganizationGroupRoleDeleted
     );
 
     public static readonly EventStreamTestEventTypeEnum OrganizationMemberAdded = new(
@@ -42,31 +74,15 @@ public readonly record struct EventStreamTestEventTypeEnum : IStringEnum
         Values.OrganizationMemberRoleDeleted
     );
 
-    public static readonly EventStreamTestEventTypeEnum OrganizationConnectionAdded = new(
-        Values.OrganizationConnectionAdded
+    public static readonly EventStreamTestEventTypeEnum OrganizationUpdated = new(
+        Values.OrganizationUpdated
     );
 
-    public static readonly EventStreamTestEventTypeEnum OrganizationConnectionUpdated = new(
-        Values.OrganizationConnectionUpdated
-    );
+    public static readonly EventStreamTestEventTypeEnum UserCreated = new(Values.UserCreated);
 
-    public static readonly EventStreamTestEventTypeEnum OrganizationConnectionRemoved = new(
-        Values.OrganizationConnectionRemoved
-    );
+    public static readonly EventStreamTestEventTypeEnum UserDeleted = new(Values.UserDeleted);
 
-    public static readonly EventStreamTestEventTypeEnum GroupCreated = new(Values.GroupCreated);
-
-    public static readonly EventStreamTestEventTypeEnum GroupUpdated = new(Values.GroupUpdated);
-
-    public static readonly EventStreamTestEventTypeEnum GroupDeleted = new(Values.GroupDeleted);
-
-    public static readonly EventStreamTestEventTypeEnum GroupMemberAdded = new(
-        Values.GroupMemberAdded
-    );
-
-    public static readonly EventStreamTestEventTypeEnum GroupMemberDeleted = new(
-        Values.GroupMemberDeleted
-    );
+    public static readonly EventStreamTestEventTypeEnum UserUpdated = new(Values.UserUpdated);
 
     public EventStreamTestEventTypeEnum(string value)
     {
@@ -165,17 +181,33 @@ public readonly record struct EventStreamTestEventTypeEnum : IStringEnum
     [Serializable]
     public static class Values
     {
-        public const string UserCreated = "user.created";
+        public const string GroupCreated = "group.created";
 
-        public const string UserDeleted = "user.deleted";
+        public const string GroupDeleted = "group.deleted";
 
-        public const string UserUpdated = "user.updated";
+        public const string GroupMemberAdded = "group.member.added";
+
+        public const string GroupMemberDeleted = "group.member.deleted";
+
+        public const string GroupRoleAssigned = "group.role.assigned";
+
+        public const string GroupRoleDeleted = "group.role.deleted";
+
+        public const string GroupUpdated = "group.updated";
+
+        public const string OrganizationConnectionAdded = "organization.connection.added";
+
+        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+
+        public const string OrganizationConnectionUpdated = "organization.connection.updated";
 
         public const string OrganizationCreated = "organization.created";
 
-        public const string OrganizationUpdated = "organization.updated";
-
         public const string OrganizationDeleted = "organization.deleted";
+
+        public const string OrganizationGroupRoleAssigned = "organization.group.role.assigned";
+
+        public const string OrganizationGroupRoleDeleted = "organization.group.role.deleted";
 
         public const string OrganizationMemberAdded = "organization.member.added";
 
@@ -185,20 +217,12 @@ public readonly record struct EventStreamTestEventTypeEnum : IStringEnum
 
         public const string OrganizationMemberRoleDeleted = "organization.member.role.deleted";
 
-        public const string OrganizationConnectionAdded = "organization.connection.added";
+        public const string OrganizationUpdated = "organization.updated";
 
-        public const string OrganizationConnectionUpdated = "organization.connection.updated";
+        public const string UserCreated = "user.created";
 
-        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+        public const string UserDeleted = "user.deleted";
 
-        public const string GroupCreated = "group.created";
-
-        public const string GroupUpdated = "group.updated";
-
-        public const string GroupDeleted = "group.deleted";
-
-        public const string GroupMemberAdded = "group.member.added";
-
-        public const string GroupMemberDeleted = "group.member.deleted";
+        public const string UserUpdated = "user.updated";
     }
 }

--- a/src/Auth0.ManagementApi/Types/GetClientGrantResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/GetClientGrantResponseContent.cs
@@ -50,6 +50,10 @@ public record GetClientGrantResponseContent : IJsonOnDeserialized
     [JsonPropertyName("allow_any_organization")]
     public bool? AllowAnyOrganization { get; set; }
 
+    [Optional]
+    [JsonPropertyName("default_for")]
+    public ClientGrantDefaultForEnum? DefaultFor { get; set; }
+
     /// <summary>
     /// If enabled, this grant is a special grant created by Auth0. It cannot be modified or deleted directly.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/GetClientResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/GetClientResponseContent.cs
@@ -309,6 +309,18 @@ public record GetClientResponseContent : IJsonOnDeserialized, IJsonOnSerializing
     [JsonPropertyName("express_configuration")]
     public ExpressConfiguration? ExpressConfiguration { get; set; }
 
+    [Optional]
+    [JsonPropertyName("my_organization_configuration")]
+    public ClientMyOrganizationResponseConfiguration? MyOrganizationConfiguration { get; set; }
+
+    [Optional]
+    [JsonPropertyName("third_party_security_mode")]
+    public ClientThirdPartySecurityModeEnum? ThirdPartySecurityMode { get; set; }
+
+    [Optional]
+    [JsonPropertyName("redirection_policy")]
+    public ClientRedirectionPolicyEnum? RedirectionPolicy { get; set; }
+
     /// <summary>
     /// The identifier of the resource server that this client is linked to.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/GetTenantSettingsResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/GetTenantSettingsResponseContent.cs
@@ -212,6 +212,13 @@ public record GetTenantSettingsResponseContent : IJsonOnDeserialized
     public TenantSettingsResourceParameterProfile? ResourceParameterProfile { get; set; }
 
     /// <summary>
+    /// Whether the authorization server supports retrieving client metadata from a client_id URL.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("client_id_metadata_document_supported")]
+    public bool? ClientIdMetadataDocumentSupported { get; set; }
+
+    /// <summary>
     /// Whether Phone Consolidated Experience is enabled for this tenant.
     /// </summary>
     [Optional]
@@ -224,6 +231,10 @@ public record GetTenantSettingsResponseContent : IJsonOnDeserialized
     [Optional]
     [JsonPropertyName("enable_ai_guide")]
     public bool? EnableAiGuide { get; set; }
+
+    [Optional]
+    [JsonPropertyName("dynamic_client_registration_security_mode")]
+    public TenantSettingsDynamicClientRegistrationSecurityMode? DynamicClientRegistrationSecurityMode { get; set; }
 
     [JsonIgnore]
     public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();

--- a/src/Auth0.ManagementApi/Types/ListSynchronizedGroupsResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/ListSynchronizedGroupsResponseContent.cs
@@ -1,0 +1,39 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[Serializable]
+public record ListSynchronizedGroupsResponseContent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Array of Google Workspace group ids configured for synchronization.
+    /// </summary>
+    [JsonPropertyName("groups")]
+    public IEnumerable<SynchronizedGroupPayload> Groups { get; set; } =
+        new List<SynchronizedGroupPayload>();
+
+    /// <summary>
+    /// The cursor to be used as the "from" query parameter for the next page of results.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("next")]
+    public string? Next { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/NetworkAclMatch.cs
+++ b/src/Auth0.ManagementApi/Types/NetworkAclMatch.cs
@@ -16,10 +16,6 @@ public record NetworkAclMatch : IJsonOnDeserialized
     public IEnumerable<int>? Asns { get; set; }
 
     [Optional]
-    [JsonPropertyName("auth0_managed")]
-    public IEnumerable<string>? Auth0Managed { get; set; }
-
-    [Optional]
     [JsonPropertyName("geo_country_codes")]
     public IEnumerable<string>? GeoCountryCodes { get; set; }
 

--- a/src/Auth0.ManagementApi/Types/RotateClientSecretResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/RotateClientSecretResponseContent.cs
@@ -309,6 +309,18 @@ public record RotateClientSecretResponseContent : IJsonOnDeserialized, IJsonOnSe
     [JsonPropertyName("express_configuration")]
     public ExpressConfiguration? ExpressConfiguration { get; set; }
 
+    [Optional]
+    [JsonPropertyName("my_organization_configuration")]
+    public ClientMyOrganizationResponseConfiguration? MyOrganizationConfiguration { get; set; }
+
+    [Optional]
+    [JsonPropertyName("third_party_security_mode")]
+    public ClientThirdPartySecurityModeEnum? ThirdPartySecurityMode { get; set; }
+
+    [Optional]
+    [JsonPropertyName("redirection_policy")]
+    public ClientRedirectionPolicyEnum? RedirectionPolicy { get; set; }
+
     /// <summary>
     /// The identifier of the resource server that this client is linked to.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketDomainAliasesConfig.cs
+++ b/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketDomainAliasesConfig.cs
@@ -17,6 +17,13 @@ public record SelfServiceProfileSsoTicketDomainAliasesConfig : IJsonOnDeserializ
     [JsonPropertyName("domain_verification")]
     public required SelfServiceProfileSsoTicketDomainVerificationEnum DomainVerification { get; set; }
 
+    /// <summary>
+    /// List of domains that will be submitted for verification during the self-service SSO flow.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("pending_domains")]
+    public IEnumerable<string>? PendingDomains { get; set; }
+
     [JsonIgnore]
     public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
 

--- a/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketEnabledFeatures.cs
+++ b/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketEnabledFeatures.cs
@@ -1,0 +1,49 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Specifies which features are enabled for an "edit connection" ticket. Only applicable when connection ID is provided.
+/// </summary>
+[Serializable]
+public record SelfServiceProfileSsoTicketEnabledFeatures : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Whether SSO configuration is enabled in this ticket.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("sso")]
+    public bool? Sso { get; set; }
+
+    /// <summary>
+    /// Whether domain verification is enabled in this ticket.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("domain_verification")]
+    public bool? DomainVerification { get; set; }
+
+    /// <summary>
+    /// Whether provisioning configuration is enabled in this ticket.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("provisioning")]
+    public bool? Provisioning { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/SynchronizeGroupsEnum.cs
+++ b/src/Auth0.ManagementApi/Types/SynchronizeGroupsEnum.cs
@@ -12,6 +12,8 @@ public readonly record struct SynchronizeGroupsEnum : IStringEnum
 
     public static readonly SynchronizeGroupsEnum Off = new(Values.Off);
 
+    public static readonly SynchronizeGroupsEnum Selected = new(Values.Selected);
+
     public SynchronizeGroupsEnum(string value)
     {
         Value = value;
@@ -111,5 +113,7 @@ public readonly record struct SynchronizeGroupsEnum : IStringEnum
         public const string All = "all";
 
         public const string Off = "off";
+
+        public const string Selected = "selected";
     }
 }

--- a/src/Auth0.ManagementApi/Types/SynchronizedGroupPayload.cs
+++ b/src/Auth0.ManagementApi/Types/SynchronizedGroupPayload.cs
@@ -1,0 +1,31 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[Serializable]
+public record SynchronizedGroupPayload : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Google Workspace Directory group ID.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/TenantSettingsDynamicClientRegistrationSecurityMode.cs
+++ b/src/Auth0.ManagementApi/Types/TenantSettingsDynamicClientRegistrationSecurityMode.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(TenantSettingsDynamicClientRegistrationSecurityMode.TenantSettingsDynamicClientRegistrationSecurityModeSerializer)
+)]
+[Serializable]
+public readonly record struct TenantSettingsDynamicClientRegistrationSecurityMode : IStringEnum
+{
+    public static readonly TenantSettingsDynamicClientRegistrationSecurityMode Strict = new(
+        Values.Strict
+    );
+
+    public static readonly TenantSettingsDynamicClientRegistrationSecurityMode Permissive = new(
+        Values.Permissive
+    );
+
+    public TenantSettingsDynamicClientRegistrationSecurityMode(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static TenantSettingsDynamicClientRegistrationSecurityMode FromCustom(string value)
+    {
+        return new TenantSettingsDynamicClientRegistrationSecurityMode(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        TenantSettingsDynamicClientRegistrationSecurityMode value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        TenantSettingsDynamicClientRegistrationSecurityMode value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        TenantSettingsDynamicClientRegistrationSecurityMode value
+    ) => value.Value;
+
+    public static explicit operator TenantSettingsDynamicClientRegistrationSecurityMode(
+        string value
+    ) => new(value);
+
+    internal class TenantSettingsDynamicClientRegistrationSecurityModeSerializer
+        : JsonConverter<TenantSettingsDynamicClientRegistrationSecurityMode>
+    {
+        public override TenantSettingsDynamicClientRegistrationSecurityMode Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new TenantSettingsDynamicClientRegistrationSecurityMode(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            TenantSettingsDynamicClientRegistrationSecurityMode value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override TenantSettingsDynamicClientRegistrationSecurityMode ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new TenantSettingsDynamicClientRegistrationSecurityMode(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            TenantSettingsDynamicClientRegistrationSecurityMode value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Strict = "strict";
+
+        public const string Permissive = "permissive";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/UpdateClientGrantResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateClientGrantResponseContent.cs
@@ -50,6 +50,10 @@ public record UpdateClientGrantResponseContent : IJsonOnDeserialized
     [JsonPropertyName("allow_any_organization")]
     public bool? AllowAnyOrganization { get; set; }
 
+    [Optional]
+    [JsonPropertyName("default_for")]
+    public ClientGrantDefaultForEnum? DefaultFor { get; set; }
+
     /// <summary>
     /// If enabled, this grant is a special grant created by Auth0. It cannot be modified or deleted directly.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/UpdateClientResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateClientResponseContent.cs
@@ -309,6 +309,18 @@ public record UpdateClientResponseContent : IJsonOnDeserialized, IJsonOnSerializ
     [JsonPropertyName("express_configuration")]
     public ExpressConfiguration? ExpressConfiguration { get; set; }
 
+    [Optional]
+    [JsonPropertyName("my_organization_configuration")]
+    public ClientMyOrganizationResponseConfiguration? MyOrganizationConfiguration { get; set; }
+
+    [Optional]
+    [JsonPropertyName("third_party_security_mode")]
+    public ClientThirdPartySecurityModeEnum? ThirdPartySecurityMode { get; set; }
+
+    [Optional]
+    [JsonPropertyName("redirection_policy")]
+    public ClientRedirectionPolicyEnum? RedirectionPolicy { get; set; }
+
     /// <summary>
     /// The identifier of the resource server that this client is linked to.
     /// </summary>

--- a/src/Auth0.ManagementApi/Types/UpdateConnectionOptions.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateConnectionOptions.cs
@@ -100,6 +100,10 @@ public record UpdateConnectionOptions : IJsonOnDeserialized, IJsonOnSerializing
     public bool? ApiEnableUsers { get; set; }
 
     [Optional]
+    [JsonPropertyName("api_enable_groups")]
+    public bool? ApiEnableGroups { get; set; }
+
+    [Optional]
     [JsonPropertyName("basic_profile")]
     public bool? BasicProfile { get; set; }
 

--- a/src/Auth0.ManagementApi/Types/UpdateTenantSettingsResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateTenantSettingsResponseContent.cs
@@ -212,6 +212,13 @@ public record UpdateTenantSettingsResponseContent : IJsonOnDeserialized
     public TenantSettingsResourceParameterProfile? ResourceParameterProfile { get; set; }
 
     /// <summary>
+    /// Whether the authorization server supports retrieving client metadata from a client_id URL.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("client_id_metadata_document_supported")]
+    public bool? ClientIdMetadataDocumentSupported { get; set; }
+
+    /// <summary>
     /// Whether Phone Consolidated Experience is enabled for this tenant.
     /// </summary>
     [Optional]
@@ -224,6 +231,10 @@ public record UpdateTenantSettingsResponseContent : IJsonOnDeserialized
     [Optional]
     [JsonPropertyName("enable_ai_guide")]
     public bool? EnableAiGuide { get; set; }
+
+    [Optional]
+    [JsonPropertyName("dynamic_client_registration_security_mode")]
+    public TenantSettingsDynamicClientRegistrationSecurityMode? DynamicClientRegistrationSecurityMode { get; set; }
 
     [JsonIgnore]
     public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();

--- a/src/Auth0.ManagementApi/Wrapper/ManagementClient.cs
+++ b/src/Auth0.ManagementApi/Wrapper/ManagementClient.cs
@@ -1,3 +1,5 @@
+using Auth0.ManagementApi.Core;
+
 namespace Auth0.ManagementApi;
 
 /// <summary>
@@ -65,12 +67,21 @@ public sealed class ManagementClient : ManagementApiClient, IDisposable
         return options;
     }
 
+    private static HttpClient CreateHttpClient(ManagementClientOptions options) =>
+        options.CustomDomain != null
+            ? new HttpClient(new CustomDomainInterceptor())
+            : new HttpClient();
+
     private static ClientOptions BuildClientOptions(ManagementClientOptions options)
     {
+        // When a custom domain is configured and no HttpClient is supplied, automatically
+        // inject CustomDomainInterceptor so the header is stripped from non-whitelisted paths.
+        var httpClient = options.HttpClient ?? CreateHttpClient(options);
+
         var clientOptions = new ClientOptions
         {
             BaseUrl = $"https://{options.Domain}/api/v2",
-            HttpClient = options.HttpClient ?? new HttpClient(),
+            HttpClient = httpClient,
             Timeout = options.Timeout ?? TimeSpan.FromSeconds(30),
             MaxRetries = options.MaxRetries ?? 2,
         };
@@ -82,6 +93,9 @@ public sealed class ManagementClient : ManagementApiClient, IDisposable
                 clientOptions.Headers[header.Key] = header.Value;
             }
         }
+
+        if (!string.IsNullOrEmpty(options.CustomDomain))
+            clientOptions.Headers[CustomDomainInterceptor.HeaderName] = options.CustomDomain;
 
         return clientOptions;
     }

--- a/src/Auth0.ManagementApi/Wrapper/ManagementClientOptions.cs
+++ b/src/Auth0.ManagementApi/Wrapper/ManagementClientOptions.cs
@@ -43,4 +43,18 @@ public class ManagementClientOptions
     /// Additional headers to include with every request.
     /// </summary>
     public IDictionary<string, string>? AdditionalHeaders { get; init; }
+
+    /// <summary>
+    /// Custom domain to include as the <c>Auth0-Custom-Domain</c> header on Management API
+    /// endpoints that generate user-facing links (email verification, password reset,
+    /// invitations, MFA enrollment tickets, etc.).
+    ///
+    /// <para>
+    /// When set and no <see cref="HttpClient"/> is provided, a <see cref="Core.CustomDomainInterceptor"/>
+    /// is automatically configured to strip the header from non-applicable endpoints.
+    /// When a custom <see cref="HttpClient"/> is supplied, the header is still included on
+    /// every request but stripping is the caller's responsibility.
+    /// </para>
+    /// </summary>
+    public string? CustomDomain { get; init; }
 }

--- a/tests/Auth0.ManagementApi.Test/Core/CustomDomainInterceptorTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Core/CustomDomainInterceptorTest.cs
@@ -1,0 +1,185 @@
+using Auth0.ManagementApi.Core;
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Core;
+
+[TestFixture]
+public class CustomDomainInterceptorTest
+{
+    [Test]
+    [TestCase("/tickets/email-verification")]
+    [TestCase("/api/v2/tickets/email-verification")]
+    public void IsWhitelisted_EmailVerificationTicket_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/tickets/password-change")]
+    [TestCase("/api/v2/tickets/password-change")]
+    public void IsWhitelisted_PasswordChangeTicket_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/organizations/org_abc123/invitations")]
+    [TestCase("/api/v2/organizations/org_abc123/invitations")]
+    [TestCase("/organizations/org_abc123/invitations/inv_xyz789")]
+    [TestCase("/api/v2/organizations/org_abc123/invitations/inv_xyz789")]
+    public void IsWhitelisted_OrganizationInvitations_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/guardian/enrollments/ticket")]
+    [TestCase("/api/v2/guardian/enrollments/ticket")]
+    public void IsWhitelisted_GuardianEnrollmentTicket_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/jobs/verification-email")]
+    [TestCase("/api/v2/jobs/verification-email")]
+    public void IsWhitelisted_VerificationEmailJob_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/jobs/users-imports")]
+    [TestCase("/api/v2/jobs/users-imports")]
+    public void IsWhitelisted_UsersImportsJob_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/users")]
+    [TestCase("/api/v2/users")]
+    [TestCase("/users/auth0|abc123")]
+    [TestCase("/api/v2/users/auth0|abc123")]
+    public void IsWhitelisted_Users_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/self-service-profiles/ssp_1/sso-ticket")]
+    [TestCase("/api/v2/self-service-profiles/ssp_1/sso-ticket")]
+    [TestCase("/self-service-profiles/ssp_1/sso-ticket/t_1/revoke")]
+    [TestCase("/api/v2/self-service-profiles/ssp_1/sso-ticket/t_1/revoke")]
+    public void IsWhitelisted_SelfServiceProfileSsoTicket_ReturnsTrue(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.True);
+
+    [Test]
+    [TestCase("/clients")]
+    [TestCase("/api/v2/clients")]
+    [TestCase("/clients/client_123")]
+    [TestCase("/connections")]
+    [TestCase("/api/v2/connections/conn_abc/status")]
+    [TestCase("/roles")]
+    [TestCase("/logs")]
+    [TestCase("/stats/active-users")]
+    [TestCase("/api/v2/organizations/org_abc123/members")]
+    [TestCase("/api/v2/organizations/org_abc123/connections")]
+    [TestCase("/jobs/users-exports")]
+    [TestCase("/api/v2/jobs/abc123")]
+    [TestCase("/guardian/enrollments")]
+    [TestCase("/api/v2/guardian/factors")]
+    [TestCase("/api/v2/users/auth0|abc123/roles")]
+    [TestCase("/api/v2/users/auth0|abc123/permissions")]
+    [TestCase("/users-by-email")]
+    [TestCase("/api/v2/users-by-email")]
+    public void IsWhitelisted_NonWhitelistedPath_ReturnsFalse(string path) =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(path), Is.False);
+
+    [Test]
+    public void IsWhitelisted_NullPath_ReturnsFalse() =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(null), Is.False);
+
+    [Test]
+    public void IsWhitelisted_EmptyPath_ReturnsFalse() =>
+        Assert.That(CustomDomainInterceptor.IsWhitelisted(string.Empty), Is.False);
+
+    [Test]
+    public async Task SendAsync_NonWhitelistedPath_StripsHeader()
+    {
+        var testHandler = new TestHandler();
+        var interceptor = new CustomDomainInterceptor(testHandler);
+        var httpClient = new HttpClient(interceptor);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/clients");
+        request.Headers.Add(CustomDomainInterceptor.HeaderName, "login.mycompany.com");
+
+        await httpClient.SendAsync(request);
+
+        Assert.That(testHandler.LastRequest!.Headers.Contains(CustomDomainInterceptor.HeaderName), Is.False);
+    }
+
+    [Test]
+    public async Task SendAsync_WhitelistedPath_PreservesHeader()
+    {
+        var testHandler = new TestHandler();
+        var interceptor = new CustomDomainInterceptor(testHandler);
+        var httpClient = new HttpClient(interceptor);
+
+        var request = new HttpRequestMessage(HttpMethod.Post,
+            "http://localhost/tickets/email-verification");
+        request.Headers.Add(CustomDomainInterceptor.HeaderName, "login.mycompany.com");
+
+        await httpClient.SendAsync(request);
+
+        Assert.That(testHandler.LastRequest!.Headers.Contains(CustomDomainInterceptor.HeaderName), Is.True);
+        Assert.That(
+            testHandler.LastRequest.Headers.GetValues(CustomDomainInterceptor.HeaderName).First(),
+            Is.EqualTo("login.mycompany.com"));
+    }
+
+    [Test]
+    public async Task SendAsync_NoHeader_DoesNotAddHeader()
+    {
+        var testHandler = new TestHandler();
+        var interceptor = new CustomDomainInterceptor(testHandler);
+        var httpClient = new HttpClient(interceptor);
+
+        var request = new HttpRequestMessage(HttpMethod.Post,
+            "http://localhost/tickets/email-verification");
+
+        await httpClient.SendAsync(request);
+
+        Assert.That(testHandler.LastRequest!.Headers.Contains(CustomDomainInterceptor.HeaderName), Is.False);
+    }
+
+    [Test]
+    public async Task SendAsync_NonWhitelistedPath_OnlyStripsCustomDomainHeader_LeavesOtherHeadersIntact()
+    {
+        // Verifies the interceptor is surgical: it removes only Auth0-Custom-Domain and does
+        // not disturb any other headers present on the same request.
+        var testHandler = new TestHandler();
+        var interceptor = new CustomDomainInterceptor(testHandler);
+        var httpClient = new HttpClient(interceptor);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "http://localhost/clients");
+        request.Headers.Add(CustomDomainInterceptor.HeaderName, "login.mycompany.com");
+        request.Headers.Add("X-Correlation-Id", "abc-123");
+        request.Headers.Add("X-Custom-Header", "custom-value");
+
+        await httpClient.SendAsync(request);
+
+        Assert.That(testHandler.LastRequest!.Headers.Contains(CustomDomainInterceptor.HeaderName),
+            Is.False, "Auth0-Custom-Domain should be stripped");
+        Assert.That(testHandler.LastRequest.Headers.Contains("X-Correlation-Id"),
+            Is.True, "X-Correlation-Id should be preserved");
+        Assert.That(testHandler.LastRequest.Headers.GetValues("X-Correlation-Id").First(),
+            Is.EqualTo("abc-123"));
+        Assert.That(testHandler.LastRequest.Headers.Contains("X-Custom-Header"),
+            Is.True, "X-Custom-Header should be preserved");
+        Assert.That(testHandler.LastRequest.Headers.GetValues("X-Custom-Header").First(),
+            Is.EqualTo("custom-value"));
+    }
+
+    /// <summary>
+    /// Helper handler to capture the outgoing request after passing through the interceptor for assertion.
+    /// </summary>
+    private sealed class TestHandler : HttpMessageHandler
+    {
+        public HttpRequestMessage? LastRequest { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            return Task.FromResult(new HttpResponseMessage(System.Net.HttpStatusCode.OK));
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/CreateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/CreateTest.cs
@@ -28,6 +28,7 @@ public class CreateTest : BaseMockServerTest
               ],
               "organization_usage": "deny",
               "allow_any_organization": true,
+              "default_for": "third_party_clients",
               "is_system": true,
               "subject_type": "client",
               "authorization_details_types": [

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/GetTest.cs
@@ -21,6 +21,7 @@ public class GetTest : BaseMockServerTest
               ],
               "organization_usage": "deny",
               "allow_any_organization": true,
+              "default_for": "third_party_clients",
               "is_system": true,
               "subject_type": "client",
               "authorization_details_types": [

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/ListTest.cs
@@ -24,6 +24,7 @@ public class ListTest : BaseMockServerTest
                   ],
                   "organization_usage": "deny",
                   "allow_any_organization": true,
+                  "default_for": "third_party_clients",
                   "is_system": true,
                   "subject_type": "client",
                   "authorization_details_types": [
@@ -45,6 +46,7 @@ public class ListTest : BaseMockServerTest
                     .WithParam("audience", "audience")
                     .WithParam("client_id", "client_id")
                     .WithParam("subject_type", "client")
+                    .WithParam("default_for", "third_party_clients")
                     .UsingGet()
             )
             .RespondWith(
@@ -63,6 +65,7 @@ public class ListTest : BaseMockServerTest
                 ClientId = "client_id",
                 AllowAnyOrganization = true,
                 SubjectType = ClientGrantSubjectTypeEnum.Client,
+                DefaultFor = ClientGrantDefaultForEnum.ThirdPartyClients,
             }
         );
         await foreach (var item in items)

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/UpdateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/ClientGrants/UpdateTest.cs
@@ -26,6 +26,7 @@ public class UpdateTest : BaseMockServerTest
               ],
               "organization_usage": "deny",
               "allow_any_organization": true,
+              "default_for": "third_party_clients",
               "is_system": true,
               "subject_type": "client",
               "authorization_details_types": [

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/CreateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/CreateTest.cs
@@ -56,7 +56,11 @@ public class CreateTest : BaseMockServerTest
                 ],
                 "enforce_device_binding": "ip",
                 "allow_refresh_token": true,
-                "enforce_online_refresh_tokens": true
+                "enforce_online_refresh_tokens": true,
+                "delegation": {
+                  "allow_delegated_access": true,
+                  "enforce_device_binding": "ip"
+                }
               },
               "oidc_logout": {
                 "backchannel_logout_urls": [
@@ -363,6 +367,16 @@ public class CreateTest : BaseMockServerTest
                 "admin_login_domain": "admin_login_domain",
                 "oin_submission_id": "oin_submission_id"
               },
+              "my_organization_configuration": {
+                "connection_profile_id": "connection_profile_id",
+                "user_attribute_profile_id": "user_attribute_profile_id",
+                "allowed_strategies": [
+                  "pingfederate"
+                ],
+                "connection_deletion_behavior": "allow"
+              },
+              "third_party_security_mode": "strict",
+              "redirection_policy": "allow_always",
               "resource_server_identifier": "resource_server_identifier",
               "async_approval_notification_channels": [
                 "guardian-push"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/GetTest.cs
@@ -50,7 +50,11 @@ public class GetTest : BaseMockServerTest
                 ],
                 "enforce_device_binding": "ip",
                 "allow_refresh_token": true,
-                "enforce_online_refresh_tokens": true
+                "enforce_online_refresh_tokens": true,
+                "delegation": {
+                  "allow_delegated_access": true,
+                  "enforce_device_binding": "ip"
+                }
               },
               "oidc_logout": {
                 "backchannel_logout_urls": [
@@ -357,6 +361,16 @@ public class GetTest : BaseMockServerTest
                 "admin_login_domain": "admin_login_domain",
                 "oin_submission_id": "oin_submission_id"
               },
+              "my_organization_configuration": {
+                "connection_profile_id": "connection_profile_id",
+                "user_attribute_profile_id": "user_attribute_profile_id",
+                "allowed_strategies": [
+                  "pingfederate"
+                ],
+                "connection_deletion_behavior": "allow"
+              },
+              "third_party_security_mode": "strict",
+              "redirection_policy": "allow_always",
               "resource_server_identifier": "resource_server_identifier",
               "async_approval_notification_channels": [
                 "guardian-push"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/ListTest.cs
@@ -98,6 +98,14 @@ public class ListTest : BaseMockServerTest
                     "okta_oin_client_id": "okta_oin_client_id",
                     "admin_login_domain": "admin_login_domain"
                   },
+                  "my_organization_configuration": {
+                    "allowed_strategies": [
+                      "pingfederate"
+                    ],
+                    "connection_deletion_behavior": "allow"
+                  },
+                  "third_party_security_mode": "strict",
+                  "redirection_policy": "allow_always",
                   "resource_server_identifier": "resource_server_identifier",
                   "async_approval_notification_channels": [
                     "guardian-push"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/RotateSecretTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/RotateSecretTest.cs
@@ -49,7 +49,11 @@ public class RotateSecretTest : BaseMockServerTest
                 ],
                 "enforce_device_binding": "ip",
                 "allow_refresh_token": true,
-                "enforce_online_refresh_tokens": true
+                "enforce_online_refresh_tokens": true,
+                "delegation": {
+                  "allow_delegated_access": true,
+                  "enforce_device_binding": "ip"
+                }
               },
               "oidc_logout": {
                 "backchannel_logout_urls": [
@@ -356,6 +360,16 @@ public class RotateSecretTest : BaseMockServerTest
                 "admin_login_domain": "admin_login_domain",
                 "oin_submission_id": "oin_submission_id"
               },
+              "my_organization_configuration": {
+                "connection_profile_id": "connection_profile_id",
+                "user_attribute_profile_id": "user_attribute_profile_id",
+                "allowed_strategies": [
+                  "pingfederate"
+                ],
+                "connection_deletion_behavior": "allow"
+              },
+              "third_party_security_mode": "strict",
+              "redirection_policy": "allow_always",
               "resource_server_identifier": "resource_server_identifier",
               "async_approval_notification_channels": [
                 "guardian-push"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/UpdateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/UpdateTest.cs
@@ -54,7 +54,11 @@ public class UpdateTest : BaseMockServerTest
                 ],
                 "enforce_device_binding": "ip",
                 "allow_refresh_token": true,
-                "enforce_online_refresh_tokens": true
+                "enforce_online_refresh_tokens": true,
+                "delegation": {
+                  "allow_delegated_access": true,
+                  "enforce_device_binding": "ip"
+                }
               },
               "oidc_logout": {
                 "backchannel_logout_urls": [
@@ -361,6 +365,16 @@ public class UpdateTest : BaseMockServerTest
                 "admin_login_domain": "admin_login_domain",
                 "oin_submission_id": "oin_submission_id"
               },
+              "my_organization_configuration": {
+                "connection_profile_id": "connection_profile_id",
+                "user_attribute_profile_id": "user_attribute_profile_id",
+                "allowed_strategies": [
+                  "pingfederate"
+                ],
+                "connection_deletion_behavior": "allow"
+              },
+              "third_party_security_mode": "strict",
+              "redirection_policy": "allow_always",
               "resource_server_identifier": "resource_server_identifier",
               "async_approval_notification_channels": [
                 "guardian-push"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Connections/DirectoryProvisioning/ListSynchronizedGroupsTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Connections/DirectoryProvisioning/ListSynchronizedGroupsTest.cs
@@ -1,0 +1,51 @@
+using Auth0.ManagementApi.Connections;
+using Auth0.ManagementApi.Test.Unit.MockServer;
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Unit.MockServer.Connections.DirectoryProvisioning;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class ListSynchronizedGroupsTest : BaseMockServerTest
+{
+    [NUnit.Framework.Test]
+    public async Task MockServerTest()
+    {
+        const string mockResponse = """
+            {
+              "groups": [
+                {
+                  "id": "id"
+                }
+              ],
+              "next": "next"
+            }
+            """;
+
+        Server
+            .Given(
+                WireMock
+                    .RequestBuilders.Request.Create()
+                    .WithPath("/connections/id/directory-provisioning/synchronized-groups")
+                    .WithParam("from", "from")
+                    .WithParam("take", "1")
+                    .UsingGet()
+            )
+            .RespondWith(
+                WireMock
+                    .ResponseBuilders.Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody(mockResponse)
+            );
+
+        var items = await Client.Connections.DirectoryProvisioning.ListSynchronizedGroupsAsync(
+            "id",
+            new ListSynchronizedGroupsRequestParameters { From = "from", Take = 1 }
+        );
+        await foreach (var item in items)
+        {
+            Assert.That(item, Is.Not.Null);
+            break; // Only check the first item
+        }
+    }
+}

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Connections/DirectoryProvisioning/SetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Connections/DirectoryProvisioning/SetTest.cs
@@ -1,0 +1,49 @@
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Connections;
+using Auth0.ManagementApi.Test.Unit.MockServer;
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Unit.MockServer.Connections.DirectoryProvisioning;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class SetTest : BaseMockServerTest
+{
+    [NUnit.Framework.Test]
+    public void MockServerTest()
+    {
+        const string requestJson = """
+            {
+              "groups": [
+                {
+                  "id": "id"
+                }
+              ]
+            }
+            """;
+
+        Server
+            .Given(
+                WireMock
+                    .RequestBuilders.Request.Create()
+                    .WithPath("/connections/id/directory-provisioning/synchronized-groups")
+                    .WithHeader("Content-Type", "application/json")
+                    .UsingPut()
+                    .WithBodyAsJson(requestJson)
+            )
+            .RespondWith(WireMock.ResponseBuilders.Response.Create().WithStatusCode(200));
+
+        Assert.DoesNotThrowAsync(async () =>
+            await Client.Connections.DirectoryProvisioning.SetAsync(
+                "id",
+                new ReplaceSynchronizedGroupsRequestContent
+                {
+                    Groups = new List<SynchronizedGroupPayload>()
+                    {
+                        new SynchronizedGroupPayload { Id = "id" },
+                    },
+                }
+            )
+        );
+    }
+}

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/CustomDomainHeaderTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/CustomDomainHeaderTest.cs
@@ -1,0 +1,251 @@
+using Auth0.ManagementApi.Core;
+using NUnit.Framework;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+using WireMock.Settings;
+using WireMock.Logging;
+
+namespace Auth0.ManagementApi.Test.Unit.MockServer;
+
+/// <summary>
+/// End-to-end tests for the Auth0-Custom-Domain header feature using WireMock as the HTTP backend.
+/// </summary>
+[TestFixture]
+public class CustomDomainHeaderTest
+{
+    private WireMockServer _server = null!;
+
+    [OneTimeSetUp]
+    public void GlobalSetup()
+    {
+        _server = WireMockServer.Start(
+            new WireMockServerSettings { Logger = new WireMockConsoleLogger() });
+    }
+
+    [OneTimeTearDown]
+    public void GlobalTeardown()
+    {
+        _server.Stop();
+        _server.Dispose();
+    }
+
+    [SetUp]
+    public void Setup() => _server.Reset();
+
+    private ManagementApiClient BuildClient(string? customDomain = null, bool withInterceptor = false)
+    {
+        var httpClient = withInterceptor
+            ? new HttpClient(new CustomDomainInterceptor(new HttpClientHandler()))
+            : new HttpClient();
+
+        return new ManagementApiClient(
+            "TOKEN",
+            new ClientOptions
+            {
+                BaseUrl = _server.Urls[0],
+                MaxRetries = 0,
+                CustomDomain = customDomain,
+                HttpClient = httpClient,
+            });
+    }
+
+    private void StubAny(string path, string method = "GET") =>
+        _server
+            .Given(Request.Create().WithPath(path).UsingMethod(method))
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+    private bool HasCustomDomainHeader(string domain) =>
+        _server.LogEntries.Any(e =>
+            e.RequestMessage.Headers.ContainsKey(CustomDomainInterceptor.HeaderName) &&
+            e.RequestMessage.Headers[CustomDomainInterceptor.HeaderName]
+                .Contains(domain, StringComparer.OrdinalIgnoreCase));
+
+    private bool HasNoCustomDomainHeader() =>
+        _server.LogEntries.All(e =>
+            !e.RequestMessage.Headers.ContainsKey(CustomDomainInterceptor.HeaderName));
+
+    [Test]
+    public async Task GlobalConfig_WhitelistedEndpoint_HeaderPresent()
+    {
+        StubAny("/tickets/email-verification", "POST");
+        var client = BuildClient(customDomain: "login.mycompany.com");
+
+        try
+        {
+            await client.Tickets.VerifyEmailAsync(
+                new VerifyEmailTicketRequestContent { UserId = "auth0|123" });
+        }
+        catch { /* ignore deserialization of empty body */ }
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+        Assert.That(HasCustomDomainHeader("login.mycompany.com"), Is.True);
+    }
+
+    [Test]
+    public async Task GlobalConfig_NoInterceptor_NonWhitelistedEndpoint_HeaderStillSent()
+    {
+        // Without the interceptor, the header is present on ALL requests (including non-whitelisted).
+        // Servers ignore unknown headers, so this is acceptable. Document the behaviour here.
+        StubAny("/connections/conn_1/status");
+        var client = BuildClient(customDomain: "login.mycompany.com");
+
+        await client.Connections.CheckStatusAsync("conn_1");
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+        Assert.That(HasCustomDomainHeader("login.mycompany.com"), Is.True,
+            "Without CustomDomainInterceptor the header is present on all requests.");
+    }
+
+    [Test]
+    public async Task GlobalConfig_WithInterceptor_WhitelistedEndpoint_HeaderPresent()
+    {
+        StubAny("/tickets/email-verification", "POST");
+        var client = BuildClient(customDomain: "login.mycompany.com", withInterceptor: true);
+
+        try
+        {
+            await client.Tickets.VerifyEmailAsync(
+                new VerifyEmailTicketRequestContent { UserId = "auth0|123" });
+        }
+        catch { /* ignore deserialization of empty body */ }
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+        Assert.That(HasCustomDomainHeader("login.mycompany.com"), Is.True);
+    }
+
+    [Test]
+    public async Task GlobalConfig_WithInterceptor_NonWhitelistedEndpoint_HeaderStripped()
+    {
+        StubAny("/connections/conn_1/status");
+        var client = BuildClient(customDomain: "login.mycompany.com", withInterceptor: true);
+
+        await client.Connections.CheckStatusAsync("conn_1");
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+        Assert.That(HasNoCustomDomainHeader(), Is.True,
+            "CustomDomainInterceptor should strip the header from non-whitelisted paths.");
+    }
+
+    [Test]
+    public async Task PerRequest_WhitelistedEndpoint_HeaderPresent()
+    {
+        StubAny("/tickets/email-verification", "POST");
+        var client = BuildClient(); // no global custom domain
+
+        try
+        {
+            await client.Tickets.VerifyEmailAsync(
+                new VerifyEmailTicketRequestContent { UserId = "auth0|123" },
+                CustomDomainHeader.For("login.mycompany.com"));
+        }
+        catch { /* ignore deserialization of empty body */ }
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+        Assert.That(HasCustomDomainHeader("login.mycompany.com"), Is.True);
+    }
+
+    [Test]
+    public async Task PerRequest_OverridesGlobalDomain()
+    {
+        StubAny("/tickets/email-verification", "POST");
+        var client = BuildClient(customDomain: "global.mycompany.com");
+
+        try
+        {
+            await client.Tickets.VerifyEmailAsync(
+                new VerifyEmailTicketRequestContent { UserId = "auth0|123" },
+                CustomDomainHeader.For("override.mycompany.com"));
+        }
+        catch { /* ignore deserialization of empty body */ }
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+        // The per-request value should appear (AdditionalHeaders override Options.Headers)
+        Assert.That(HasCustomDomainHeader("override.mycompany.com"), Is.True);
+    }
+
+    [Test]
+    public async Task NoCustomDomain_HeaderAbsent()
+    {
+        StubAny("/connections/conn_1/status");
+        var client = BuildClient(); // no custom domain
+
+        await client.Connections.CheckStatusAsync("conn_1");
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+        Assert.That(HasNoCustomDomainHeader(), Is.True);
+    }
+
+    [Test]
+    public async Task PerRequest_WithOtherAdditionalHeaders_AllHeadersPresent()
+    {
+        // Users who need custom domain AND other per-request headers construct RequestOptions
+        // directly rather than using CustomDomainHeader.For(), which only sets the custom domain.
+        StubAny("/tickets/email-verification", "POST");
+        var client = BuildClient();
+
+        try
+        {
+            await client.Tickets.VerifyEmailAsync(
+                new VerifyEmailTicketRequestContent { UserId = "auth0|123" },
+                new RequestOptions
+                {
+                    AdditionalHeaders = new[]
+                    {
+                        new KeyValuePair<string, string?>(
+                            CustomDomainInterceptor.HeaderName, "login.mycompany.com"),
+                        new KeyValuePair<string, string?>(
+                            "X-Correlation-Id", "test-correlation-id"),
+                    },
+                });
+        }
+        catch { /* ignore deserialization of empty body */ }
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+
+        var headers = _server.LogEntries[0].RequestMessage.Headers;
+
+        Assert.That(HasCustomDomainHeader("login.mycompany.com"), Is.True,
+            "Auth0-Custom-Domain header should be present");
+        Assert.That(headers.ContainsKey("X-Correlation-Id"), Is.True,
+            "X-Correlation-Id should be present alongside Auth0-Custom-Domain");
+        Assert.That(headers["X-Correlation-Id"].First(), Is.EqualTo("test-correlation-id"));
+    }
+
+    [Test]
+    public async Task GlobalConfig_WithInterceptor_NonWhitelistedEndpoint_OtherHeadersPreserved()
+    {
+        // The interceptor must only strip Auth0-Custom-Domain; it must not affect other
+        // custom headers the caller has added to the request.
+        _server
+            .Given(Request.Create().WithPath("/connections/conn_1/status").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("{}"));
+
+        var httpClient = new HttpClient(new CustomDomainInterceptor(new HttpClientHandler()));
+        var client = new ManagementApiClient(
+            "TOKEN",
+            new ClientOptions
+            {
+                BaseUrl = _server.Urls[0],
+                MaxRetries = 0,
+                CustomDomain = "login.mycompany.com",
+                HttpClient = httpClient,
+                AdditionalHeaders = new[]
+                {
+                    new KeyValuePair<string, string?>("X-Custom-Global", "global-value"),
+                },
+            });
+
+        await client.Connections.CheckStatusAsync("conn_1");
+
+        Assert.That(_server.LogEntries, Has.Count.GreaterThan(0));
+
+        var headers = _server.LogEntries[0].RequestMessage.Headers;
+
+        Assert.That(headers.ContainsKey(CustomDomainInterceptor.HeaderName), Is.False,
+            "Auth0-Custom-Domain should be stripped from non-whitelisted endpoint");
+        Assert.That(headers.ContainsKey("X-Custom-Global"), Is.True,
+            "Other custom headers must not be removed by the interceptor");
+        Assert.That(headers["X-Custom-Global"].First(), Is.EqualTo("global-value"));
+    }
+}

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Deliveries/GetHistoryTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Deliveries/GetHistoryTest.cs
@@ -16,7 +16,7 @@ public class GetHistoryTest : BaseMockServerTest
               "id": "id",
               "event_stream_id": "event_stream_id",
               "status": "failed",
-              "event_type": "user.created",
+              "event_type": "group.created",
               "attempts": [
                 {
                   "status": "failed",

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Deliveries/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Deliveries/ListTest.cs
@@ -18,7 +18,7 @@ public class ListTest : BaseMockServerTest
                 "id": "id",
                 "event_stream_id": "event_stream_id",
                 "status": "failed",
-                "event_type": "user.created",
+                "event_type": "group.created",
                 "attempts": [
                   {
                     "status": "failed",

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Redeliveries/CreateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Redeliveries/CreateTest.cs
@@ -24,7 +24,7 @@ public class CreateTest : BaseMockServerTest
                 "failed"
               ],
               "event_types": [
-                "user.created"
+                "group.created"
               ]
             }
             """;

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/TestTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/TestTest.cs
@@ -14,7 +14,7 @@ public class TestTest : BaseMockServerTest
     {
         const string requestJson = """
             {
-              "event_type": "user.created"
+              "event_type": "group.created"
             }
             """;
 
@@ -23,7 +23,7 @@ public class TestTest : BaseMockServerTest
               "id": "id",
               "event_stream_id": "event_stream_id",
               "status": "failed",
-              "event_type": "user.created",
+              "event_type": "group.created",
               "attempts": [
                 {
                   "status": "failed",
@@ -62,7 +62,7 @@ public class TestTest : BaseMockServerTest
             "id",
             new CreateEventStreamTestEventRequestContent
             {
-                EventType = EventStreamTestEventTypeEnum.UserCreated,
+                EventType = EventStreamTestEventTypeEnum.GroupCreated,
             }
         );
         JsonAssert.AreEqual(response, mockResponse);

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/NetworkAcls/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/NetworkAcls/GetTest.cs
@@ -29,9 +29,6 @@ public class GetTest : BaseMockServerTest
                   "asns": [
                     1
                   ],
-                  "auth0_managed": [
-                    "auth0_managed"
-                  ],
                   "geo_country_codes": [
                     "geo_country_codes"
                   ],
@@ -66,9 +63,6 @@ public class GetTest : BaseMockServerTest
                 "not_match": {
                   "asns": [
                     1
-                  ],
-                  "auth0_managed": [
-                    "auth0_managed"
                   ],
                   "geo_country_codes": [
                     "geo_country_codes"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/NetworkAcls/SetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/NetworkAcls/SetTest.cs
@@ -41,9 +41,6 @@ public class SetTest : BaseMockServerTest
                   "asns": [
                     1
                   ],
-                  "auth0_managed": [
-                    "auth0_managed"
-                  ],
                   "geo_country_codes": [
                     "geo_country_codes"
                   ],
@@ -78,9 +75,6 @@ public class SetTest : BaseMockServerTest
                 "not_match": {
                   "asns": [
                     1
-                  ],
-                  "auth0_managed": [
-                    "auth0_managed"
                   ],
                   "geo_country_codes": [
                     "geo_country_codes"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/NetworkAcls/UpdateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/NetworkAcls/UpdateTest.cs
@@ -34,9 +34,6 @@ public class UpdateTest : BaseMockServerTest
                   "asns": [
                     1
                   ],
-                  "auth0_managed": [
-                    "auth0_managed"
-                  ],
                   "geo_country_codes": [
                     "geo_country_codes"
                   ],
@@ -71,9 +68,6 @@ public class UpdateTest : BaseMockServerTest
                 "not_match": {
                   "asns": [
                     1
-                  ],
-                  "auth0_managed": [
-                    "auth0_managed"
                   ],
                   "geo_country_codes": [
                     "geo_country_codes"

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Tenants/Settings/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Tenants/Settings/GetTest.cs
@@ -113,8 +113,10 @@ public class GetTest : BaseMockServerTest
               "authorization_response_iss_parameter_supported": true,
               "skip_non_verifiable_callback_uri_confirmation_prompt": true,
               "resource_parameter_profile": "audience",
+              "client_id_metadata_document_supported": true,
               "phone_consolidated_experience": true,
-              "enable_ai_guide": true
+              "enable_ai_guide": true,
+              "dynamic_client_registration_security_mode": "strict"
             }
             """;
 

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Tenants/Settings/UpdateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Tenants/Settings/UpdateTest.cs
@@ -117,8 +117,10 @@ public class UpdateTest : BaseMockServerTest
               "authorization_response_iss_parameter_supported": true,
               "skip_non_verifiable_callback_uri_confirmation_prompt": true,
               "resource_parameter_profile": "audience",
+              "client_id_metadata_document_supported": true,
               "phone_consolidated_experience": true,
-              "enable_ai_guide": true
+              "enable_ai_guide": true,
+              "dynamic_client_registration_security_mode": "strict"
             }
             """;
 

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Users/ConnectedAccounts/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Users/ConnectedAccounts/ListTest.cs
@@ -24,7 +24,8 @@ public class ListTest : BaseMockServerTest
                     "scopes"
                   ],
                   "created_at": "2024-01-15T09:30:00.000Z",
-                  "expires_at": "2024-01-15T09:30:00.000Z"
+                  "expires_at": "2024-01-15T09:30:00.000Z",
+                  "organization_id": "organization_id"
                 }
               ],
               "next": "next"


### PR DESCRIPTION
### Changes

  **1. Auth0-Custom-Header support on allow-listed Management API endpoints**

  Adds support for forwarding a custom header (`Auth0-Custom-Header`) on requests to allow-listed Management API endpoints. This enables routing requests through custom domains when
  configured.

  - New `CustomDomainHeader` class for header configuration
  - New `CustomDomainInterceptor` that intercepts outgoing HTTP requests and injects the custom header on allow-listed endpoints
  - `ManagementClientOptions` updated with a new `CustomDomain` option to configure the custom domain header
  - `ManagementClient` updated to register the interceptor when a custom domain is configured

  **2. SDK generation (Fern `v2.60.2`)**

  SDK-generated updates adding new endpoints, types, and properties across several API areas.

  *Endpoints added:*
  - `DirectoryProvisioningClient.ListSynchronizedGroupsAsync` — list synchronized groups for a connection with pagination support
  - `DirectoryProvisioningClient.SetAsync` — replace the synchronized groups for a connection (`PUT`)

  *Classes added:*
  - `ListSynchronizedGroupsRequestParameters`, `ReplaceSynchronizedGroupsRequestContent`
  - `ListSynchronizedGroupsResponseContent`, `SynchronizedGroupPayload`
  - `ClientMyOrganizationPostConfiguration`, `ClientMyOrganizationPatchConfiguration`, `ClientMyOrganizationResponseConfiguration`
  - `ClientSessionTransferDelegationConfiguration`, `SelfServiceProfileSsoTicketEnabledFeatures`
  - `TenantSettingsDynamicClientRegistrationSecurityMode`

  *Enums added:*
  - `ClientGrantDefaultForEnum`, `ClientRedirectionPolicyEnum`, `ClientThirdPartySecurityModeEnum`
  - `ClientMyOrganizationConfigurationAllowedStrategiesEnum`, `ClientMyOrganizationDeletionBehaviorEnum`
  - `ClientSessionTransferDelegationDeviceBindingEnum`, `ConnectionDpopSigningAlgEnum`

  *Properties added to existing types:*
  - `Client` / `CreateClientRequestContent` / `UpdateClientRequestContent` and response types: `ThirdPartySecurityMode`, `RedirectionPolicy`, `MyOrganizationConfiguration`
  - `ClientGrant` types: `DefaultFor` (on request, create, get, update response types)
  - `ClientGrants.ListClientGrantsRequestParameters`: `DefaultFor` filter
  - `ConnectionOptionsOidc` / `ConnectionOptionsOkta` / `ConnectionPropertiesOptions`: `DpopSigningAlg`
  - `UpdateTenantSettingsRequestContent` / response types: `DynamicClientRegistrationSecurityMode`, `ClientIdMetadataDocumentSupported`
  - `SelfServiceProfileSsoTicketDomainAliasesConfig`: `EnabledFeatures`
  - `ConnectedAccount`: additional fields

  *Other changes:*
  - `LogStreamsClient` / `ILogStreamsClient`: regenerated with updated signatures
  - `EventStreamEventTypeEnum` / `EventStreamDeliveryEventTypeEnum` / `EventStreamTestEventTypeEnum`: updated enum values
  - `NetworkAclMatch`: removed obsolete fields
  - `reference.md` and `Examples.md`: updated documentation

  ### References

  - Fern C# generator version `v2.60.2`

  ### Testing

  - [x] This change adds unit test coverage

  - [ ] This change adds integration test coverage

  - [x] This change has been tested on the latest version of the platform/language

  ### Checklist

  - [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

  - [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

  - [x] All existing and new tests complete without errors