### PR TITLE
mgmt: SDK generation using generator v2.61.2

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -1805,6 +1805,7 @@ await client.Connections.ListAsync(
     {
         From = "from",
         Take = 1,
+        Strategy = [new List<ConnectionStrategyEnum?>() { ConnectionStrategyEnum.Ad }],
         Name = "name",
         Fields = "fields",
         IncludeFields = true,
@@ -3404,6 +3405,13 @@ await client.Flows.ListAsync(
         Page = 1,
         PerPage = 1,
         IncludeTotals = true,
+        Hydrate =
+        [
+            new List<ListFlowsRequestParametersHydrateEnum?>()
+            {
+                ListFlowsRequestParametersHydrateEnum.FormCount,
+            },
+        ],
         Synchronous = true,
     }
 );
@@ -3486,7 +3494,19 @@ await client.Flows.CreateAsync(new CreateFlowRequestContent { Name = "name" });
 <dd>
 
 ```csharp
-await client.Flows.GetAsync("id", new GetFlowRequestParameters());
+await client.Flows.GetAsync(
+    "id",
+    new GetFlowRequestParameters
+    {
+        Hydrate =
+        [
+            new List<GetFlowRequestParametersHydrateEnum?>()
+            {
+                GetFlowRequestParametersHydrateEnum.FormCount,
+            },
+        ],
+    }
+);
 ```
 </dd>
 </dl>
@@ -3629,6 +3649,13 @@ await client.Forms.ListAsync(
         Page = 1,
         PerPage = 1,
         IncludeTotals = true,
+        Hydrate =
+        [
+            new List<FormsRequestParametersHydrateEnum?>()
+            {
+                FormsRequestParametersHydrateEnum.FlowCount,
+            },
+        ],
     }
 );
 ```
@@ -3710,7 +3737,19 @@ await client.Forms.CreateAsync(new CreateFormRequestContent { Name = "name" });
 <dd>
 
 ```csharp
-await client.Forms.GetAsync("id", new GetFormRequestParameters());
+await client.Forms.GetAsync(
+    "id",
+    new GetFormRequestParameters
+    {
+        Hydrate =
+        [
+            new List<FormsRequestParametersHydrateEnum?>()
+            {
+                FormsRequestParametersHydrateEnum.FlowCount,
+            },
+        ],
+    }
+);
 ```
 </dd>
 </dl>
@@ -4042,6 +4081,7 @@ await client.Groups.ListAsync(
         ConnectionId = "connection_id",
         Name = "name",
         ExternalId = "external_id",
+        Search = "search",
         Fields = "fields",
         IncludeFields = true,
         From = "from",
@@ -6540,6 +6580,7 @@ Retrieve details of all APIs associated with your tenant.
 await client.ResourceServers.ListAsync(
     new ListResourceServerRequestParameters
     {
+        Identifiers = [new List<string?>() { "identifiers" }],
         Page = 1,
         PerPage = 1,
         IncludeTotals = true,
@@ -8755,7 +8796,7 @@ await client.UserAttributeProfiles.ListAsync(
 <dl>
 <dd>
 
-Retrieve details about a single User Attribute Profile specified by ID. 
+Create a User Attribute Profile
 </dd>
 </dl>
 </dd>
@@ -13122,6 +13163,7 @@ await client.Clients.Connections.GetAsync(
     "id",
     new ConnectionsGetRequest
     {
+        Strategy = [new List<ConnectionStrategyEnum?>() { ConnectionStrategyEnum.Ad }],
         From = "from",
         Take = 1,
         Fields = "fields",
@@ -15174,7 +15216,16 @@ await client.Flows.Executions.ListAsync(
 await client.Flows.Executions.GetAsync(
     "flow_id",
     "execution_id",
-    new GetFlowExecutionRequestParameters()
+    new GetFlowExecutionRequestParameters
+    {
+        Hydrate =
+        [
+            new List<GetFlowExecutionRequestParametersHydrateEnum?>()
+            {
+                GetFlowExecutionRequestParametersHydrateEnum.Debug,
+            },
+        ],
+    }
 );
 ```
 </dd>
@@ -18607,6 +18658,7 @@ await client.Organizations.ClientGrants.ListAsync(
     {
         Audience = "audience",
         ClientId = "client_id",
+        GrantIds = [new List<string?>() { "grant_ids" }],
         Page = 1,
         PerPage = 1,
         IncludeTotals = true,
@@ -23904,7 +23956,7 @@ await client.Users.Sessions.DeleteAsync("user_id");
 <dl>
 <dd>
 
-List a verifiable credential templates.
+List verifiable credential templates.
 </dd>
 </dl>
 </dd>

--- a/src/Auth0.ManagementApi/Actions/ActionsClient.cs
+++ b/src/Auth0.ManagementApi/Actions/ActionsClient.cs
@@ -620,7 +620,7 @@ public partial class ActionsClient : IActionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Actions?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Actions/Modules/ModulesClient.cs
+++ b/src/Auth0.ManagementApi/Actions/Modules/ModulesClient.cs
@@ -637,7 +637,7 @@ public partial class ModulesClient : IModulesClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Modules?.ToList(),
                 null,
                 cancellationToken
@@ -809,7 +809,7 @@ public partial class ModulesClient : IModulesClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Actions?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Actions/Modules/Versions/VersionsClient.cs
+++ b/src/Auth0.ManagementApi/Actions/Modules/Versions/VersionsClient.cs
@@ -349,7 +349,7 @@ public partial class VersionsClient : IVersionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Versions?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Actions/Triggers/Bindings/BindingsClient.cs
+++ b/src/Auth0.ManagementApi/Actions/Triggers/Bindings/BindingsClient.cs
@@ -253,7 +253,7 @@ public partial class BindingsClient : IBindingsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Bindings?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Actions/Versions/VersionsClient.cs
+++ b/src/Auth0.ManagementApi/Actions/Versions/VersionsClient.cs
@@ -347,7 +347,7 @@ public partial class VersionsClient : IVersionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Versions?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/ClientGrants/Requests/ListClientGrantsRequestParameters.cs
+++ b/src/Auth0.ManagementApi/ClientGrants/Requests/ListClientGrantsRequestParameters.cs
@@ -43,7 +43,7 @@ public record ListClientGrantsRequestParameters
     public Optional<ClientGrantSubjectTypeEnum?> SubjectType { get; set; }
 
     /// <summary>
-    /// Applies this client grant as the default for all clients in the specified group. The only accepted value is `third_party_clients`, which applies the grant to all third-party clients. Per-client grants for the same audience take precedence. Mutually exclusive with `client_id`.
+    /// Applies this client grant as the default for all clients in the specified group. The only accepted value is <see href="https://auth0.com/docs/get-started/applications/application-access-to-apis-client-grants#default-permissions-for-third-party-applications">`third_party_clients`</see>, which applies the grant to all third-party clients. Per-client grants for the same audience take precedence. Mutually exclusive with `client_id`.
     /// </summary>
     [JsonIgnore]
     public Optional<ClientGrantDefaultForEnum?> DefaultFor { get; set; }

--- a/src/Auth0.ManagementApi/Clients/ClientsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/ClientsClient.cs
@@ -801,7 +801,7 @@ public partial class ClientsClient : IClientsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Clients?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Clients/Connections/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Clients/Connections/ConnectionsClient.cs
@@ -155,6 +155,7 @@ public partial class ConnectionsClient : IConnectionsClient
     ///     "id",
     ///     new ConnectionsGetRequest
     ///     {
+    ///         Strategy = [new List&lt;ConnectionStrategyEnum?&gt;() { ConnectionStrategyEnum.Ad }],
     ///         From = "from",
     ///         Take = 1,
     ///         Fields = "fields",

--- a/src/Auth0.ManagementApi/Connections/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Connections/ConnectionsClient.cs
@@ -466,6 +466,7 @@ public partial class ConnectionsClient : IConnectionsClient
     ///     {
     ///         From = "from",
     ///         Take = 1,
+    ///         Strategy = [new List&lt;ConnectionStrategyEnum?&gt;() { ConnectionStrategyEnum.Ad }],
     ///         Name = "name",
     ///         Fields = "fields",
     ///         IncludeFields = true,

--- a/src/Auth0.ManagementApi/DeviceCredentials/DeviceCredentialsClient.cs
+++ b/src/Auth0.ManagementApi/DeviceCredentials/DeviceCredentialsClient.cs
@@ -267,7 +267,7 @@ public partial class DeviceCredentialsClient : IDeviceCredentialsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.DeviceCredentials?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Flows/Executions/ExecutionsClient.cs
+++ b/src/Auth0.ManagementApi/Flows/Executions/ExecutionsClient.cs
@@ -265,7 +265,16 @@ public partial class ExecutionsClient : IExecutionsClient
     /// await client.Flows.Executions.GetAsync(
     ///     "flow_id",
     ///     "execution_id",
-    ///     new GetFlowExecutionRequestParameters()
+    ///     new GetFlowExecutionRequestParameters
+    ///     {
+    ///         Hydrate =
+    ///         [
+    ///             new List&lt;GetFlowExecutionRequestParametersHydrateEnum?&gt;()
+    ///             {
+    ///                 GetFlowExecutionRequestParametersHydrateEnum.Debug,
+    ///             },
+    ///         ],
+    ///     }
     /// );
     /// </code></example>
     public WithRawResponseTask<GetFlowExecutionResponseContent> GetAsync(

--- a/src/Auth0.ManagementApi/Flows/FlowsClient.cs
+++ b/src/Auth0.ManagementApi/Flows/FlowsClient.cs
@@ -398,6 +398,13 @@ public partial class FlowsClient : IFlowsClient
     ///         Page = 1,
     ///         PerPage = 1,
     ///         IncludeTotals = true,
+    ///         Hydrate =
+    ///         [
+    ///             new List&lt;ListFlowsRequestParametersHydrateEnum?&gt;()
+    ///             {
+    ///                 ListFlowsRequestParametersHydrateEnum.FormCount,
+    ///             },
+    ///         ],
     ///         Synchronous = true,
     ///     }
     /// );
@@ -427,7 +434,7 @@ public partial class FlowsClient : IFlowsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Flows?.ToList(),
                 null,
                 cancellationToken
@@ -451,7 +458,19 @@ public partial class FlowsClient : IFlowsClient
     }
 
     /// <example><code>
-    /// await client.Flows.GetAsync("id", new GetFlowRequestParameters());
+    /// await client.Flows.GetAsync(
+    ///     "id",
+    ///     new GetFlowRequestParameters
+    ///     {
+    ///         Hydrate =
+    ///         [
+    ///             new List&lt;GetFlowRequestParametersHydrateEnum?&gt;()
+    ///             {
+    ///                 GetFlowRequestParametersHydrateEnum.FormCount,
+    ///             },
+    ///         ],
+    ///     }
+    /// );
     /// </code></example>
     public WithRawResponseTask<GetFlowResponseContent> GetAsync(
         string id,

--- a/src/Auth0.ManagementApi/Flows/Vault/Connections/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Flows/Vault/Connections/ConnectionsClient.cs
@@ -427,7 +427,7 @@ public partial class ConnectionsClient : IConnectionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Connections?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Forms/FormsClient.cs
+++ b/src/Auth0.ManagementApi/Forms/FormsClient.cs
@@ -388,6 +388,13 @@ public partial class FormsClient : IFormsClient
     ///         Page = 1,
     ///         PerPage = 1,
     ///         IncludeTotals = true,
+    ///         Hydrate =
+    ///         [
+    ///             new List&lt;FormsRequestParametersHydrateEnum?&gt;()
+    ///             {
+    ///                 FormsRequestParametersHydrateEnum.FlowCount,
+    ///             },
+    ///         ],
     ///     }
     /// );
     /// </code></example>
@@ -416,7 +423,7 @@ public partial class FormsClient : IFormsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Forms?.ToList(),
                 null,
                 cancellationToken
@@ -440,7 +447,19 @@ public partial class FormsClient : IFormsClient
     }
 
     /// <example><code>
-    /// await client.Forms.GetAsync("id", new GetFormRequestParameters());
+    /// await client.Forms.GetAsync(
+    ///     "id",
+    ///     new GetFormRequestParameters
+    ///     {
+    ///         Hydrate =
+    ///         [
+    ///             new List&lt;FormsRequestParametersHydrateEnum?&gt;()
+    ///             {
+    ///                 FormsRequestParametersHydrateEnum.FlowCount,
+    ///             },
+    ///         ],
+    ///     }
+    /// );
     /// </code></example>
     public WithRawResponseTask<GetFormResponseContent> GetAsync(
         string id,

--- a/src/Auth0.ManagementApi/Groups/GroupsClient.cs
+++ b/src/Auth0.ManagementApi/Groups/GroupsClient.cs
@@ -35,13 +35,14 @@ public partial class GroupsClient : IGroupsClient
         CancellationToken cancellationToken = default
     )
     {
-        var _queryString = new Auth0.ManagementApi.Core.QueryStringBuilder.Builder(capacity: 7)
+        var _queryString = new Auth0.ManagementApi.Core.QueryStringBuilder.Builder(capacity: 8)
             .Add(
                 "connection_id",
                 request.ConnectionId.IsDefined ? request.ConnectionId.Value : null
             )
             .Add("name", request.Name.IsDefined ? request.Name.Value : null)
             .Add("external_id", request.ExternalId.IsDefined ? request.ExternalId.Value : null)
+            .Add("search", request.Search.IsDefined ? request.Search.Value : null)
             .Add("fields", request.Fields.IsDefined ? request.Fields.Value : null)
             .Add(
                 "include_fields",
@@ -226,6 +227,7 @@ public partial class GroupsClient : IGroupsClient
     ///         ConnectionId = "connection_id",
     ///         Name = "name",
     ///         ExternalId = "external_id",
+    ///         Search = "search",
     ///         Fields = "fields",
     ///         IncludeFields = true,
     ///         From = "from",

--- a/src/Auth0.ManagementApi/Groups/Requests/ListGroupsRequestParameters.cs
+++ b/src/Auth0.ManagementApi/Groups/Requests/ListGroupsRequestParameters.cs
@@ -25,6 +25,12 @@ public record ListGroupsRequestParameters
     public Optional<string?> ExternalId { get; set; }
 
     /// <summary>
+    /// Search for groups by name or external ID.
+    /// </summary>
+    [JsonIgnore]
+    public Optional<string?> Search { get; set; }
+
+    /// <summary>
     /// A comma separated list of fields to include or exclude (depending on include_fields) from the result, empty to retrieve all fields
     /// </summary>
     [JsonIgnore]

--- a/src/Auth0.ManagementApi/Hooks/HooksClient.cs
+++ b/src/Auth0.ManagementApi/Hooks/HooksClient.cs
@@ -441,7 +441,7 @@ public partial class HooksClient : IHooksClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Hooks?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Keys/Encryption/EncryptionClient.cs
+++ b/src/Auth0.ManagementApi/Keys/Encryption/EncryptionClient.cs
@@ -528,7 +528,7 @@ public partial class EncryptionClient : IEncryptionClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Keys?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Logs/LogsClient.cs
+++ b/src/Auth0.ManagementApi/Logs/LogsClient.cs
@@ -313,7 +313,7 @@ public partial class LogsClient : ILogsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Logs?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/NetworkAcls/NetworkAclsClient.cs
+++ b/src/Auth0.ManagementApi/NetworkAcls/NetworkAclsClient.cs
@@ -436,7 +436,7 @@ public partial class NetworkAclsClient : INetworkAclsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.NetworkAcls?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Organizations/ClientGrants/ClientGrantsClient.cs
+++ b/src/Auth0.ManagementApi/Organizations/ClientGrants/ClientGrantsClient.cs
@@ -235,6 +235,7 @@ public partial class ClientGrantsClient : IClientGrantsClient
     ///     {
     ///         Audience = "audience",
     ///         ClientId = "client_id",
+    ///         GrantIds = [new List&lt;string?&gt;() { "grant_ids" }],
     ///         Page = 1,
     ///         PerPage = 1,
     ///         IncludeTotals = true,
@@ -268,7 +269,7 @@ public partial class ClientGrantsClient : IClientGrantsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.ClientGrants?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Organizations/Connections/ConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Organizations/Connections/ConnectionsClient.cs
@@ -450,7 +450,7 @@ public partial class ConnectionsClient : IConnectionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Connections?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Organizations/EnabledConnections/EnabledConnectionsClient.cs
+++ b/src/Auth0.ManagementApi/Organizations/EnabledConnections/EnabledConnectionsClient.cs
@@ -446,7 +446,7 @@ public partial class EnabledConnectionsClient : IEnabledConnectionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.EnabledConnections?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Organizations/Invitations/InvitationsClient.cs
+++ b/src/Auth0.ManagementApi/Organizations/Invitations/InvitationsClient.cs
@@ -380,7 +380,7 @@ public partial class InvitationsClient : IInvitationsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Invitations?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Organizations/Members/Roles/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Organizations/Members/Roles/RolesClient.cs
@@ -180,7 +180,7 @@ public partial class RolesClient : IRolesClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Roles?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Prompts/Rendering/RenderingClient.cs
+++ b/src/Auth0.ManagementApi/Prompts/Rendering/RenderingClient.cs
@@ -454,7 +454,7 @@ public partial class RenderingClient : IRenderingClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Configs?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/RefreshTokens/RefreshTokensClient.cs
+++ b/src/Auth0.ManagementApi/RefreshTokens/RefreshTokensClient.cs
@@ -194,6 +194,8 @@ public partial class RefreshTokensClient : IRefreshTokensClient
             {
                 switch (response.StatusCode)
                 {
+                    case 400:
+                        throw new BadRequestError(JsonUtils.Deserialize<object>(responseBody));
                     case 401:
                         throw new UnauthorizedError(JsonUtils.Deserialize<object>(responseBody));
                     case 403:

--- a/src/Auth0.ManagementApi/ResourceServers/ResourceServersClient.cs
+++ b/src/Auth0.ManagementApi/ResourceServers/ResourceServersClient.cs
@@ -417,6 +417,7 @@ public partial class ResourceServersClient : IResourceServersClient
     /// await client.ResourceServers.ListAsync(
     ///     new ListResourceServerRequestParameters
     ///     {
+    ///         Identifiers = [new List&lt;string?&gt;() { "identifiers" }],
     ///         Page = 1,
     ///         PerPage = 1,
     ///         IncludeTotals = true,
@@ -449,7 +450,7 @@ public partial class ResourceServersClient : IResourceServersClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.ResourceServers?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Roles/Permissions/PermissionsClient.cs
+++ b/src/Auth0.ManagementApi/Roles/Permissions/PermissionsClient.cs
@@ -173,7 +173,7 @@ public partial class PermissionsClient : IPermissionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Permissions?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Roles/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Roles/RolesClient.cs
@@ -431,7 +431,7 @@ public partial class RolesClient : IRolesClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Roles?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Rules/RulesClient.cs
+++ b/src/Auth0.ManagementApi/Rules/RulesClient.cs
@@ -444,7 +444,7 @@ public partial class RulesClient : IRulesClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Rules?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/SelfServiceProfilesClient.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/SelfServiceProfilesClient.cs
@@ -447,7 +447,7 @@ public partial class SelfServiceProfilesClient : ISelfServiceProfilesClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.SelfServiceProfiles?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Types/ConnectionOptionsCommonOidc.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionOptionsCommonOidc.cs
@@ -88,6 +88,10 @@ public record ConnectionOptionsCommonOidc : IJsonOnDeserialized, IJsonOnSerializ
     [JsonPropertyName("token_endpoint_auth_signing_alg")]
     public Optional<ConnectionTokenEndpointAuthSigningAlgEnum?> TokenEndpointAuthSigningAlg { get; set; }
 
+    [Optional]
+    [JsonPropertyName("token_endpoint_jwtca_aud_format")]
+    public ConnectionTokenEndpointJwtcaAudFormatEnumOidc? TokenEndpointJwtcaAudFormat { get; set; }
+
     [Nullable, Optional]
     [JsonPropertyName("upstream_params")]
     public Optional<Dictionary<

--- a/src/Auth0.ManagementApi/Types/ConnectionOptionsOidc.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionOptionsOidc.cs
@@ -100,6 +100,10 @@ public record ConnectionOptionsOidc : IJsonOnDeserialized, IJsonOnSerializing
     [JsonPropertyName("token_endpoint_auth_signing_alg")]
     public Optional<ConnectionTokenEndpointAuthSigningAlgEnum?> TokenEndpointAuthSigningAlg { get; set; }
 
+    [Optional]
+    [JsonPropertyName("token_endpoint_jwtca_aud_format")]
+    public ConnectionTokenEndpointJwtcaAudFormatEnumOidc? TokenEndpointJwtcaAudFormat { get; set; }
+
     [Nullable, Optional]
     [JsonPropertyName("upstream_params")]
     public Optional<Dictionary<

--- a/src/Auth0.ManagementApi/Types/ConnectionOptionsOkta.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionOptionsOkta.cs
@@ -104,6 +104,10 @@ public record ConnectionOptionsOkta : IJsonOnDeserialized, IJsonOnSerializing
     [JsonPropertyName("token_endpoint_auth_signing_alg")]
     public Optional<ConnectionTokenEndpointAuthSigningAlgEnum?> TokenEndpointAuthSigningAlg { get; set; }
 
+    [Optional]
+    [JsonPropertyName("token_endpoint_jwtca_aud_format")]
+    public ConnectionTokenEndpointJwtcaAudFormatEnumOidc? TokenEndpointJwtcaAudFormat { get; set; }
+
     [Nullable, Optional]
     [JsonPropertyName("upstream_params")]
     public Optional<Dictionary<

--- a/src/Auth0.ManagementApi/Types/ConnectionTokenEndpointJwtcaAudFormatEnumOidc.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionTokenEndpointJwtcaAudFormatEnumOidc.cs
@@ -1,0 +1,128 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(ConnectionTokenEndpointJwtcaAudFormatEnumOidc.ConnectionTokenEndpointJwtcaAudFormatEnumOidcSerializer)
+)]
+[Serializable]
+public readonly record struct ConnectionTokenEndpointJwtcaAudFormatEnumOidc : IStringEnum
+{
+    public static readonly ConnectionTokenEndpointJwtcaAudFormatEnumOidc Issuer = new(
+        Values.Issuer
+    );
+
+    public static readonly ConnectionTokenEndpointJwtcaAudFormatEnumOidc TokenEndpoint = new(
+        Values.TokenEndpoint
+    );
+
+    public ConnectionTokenEndpointJwtcaAudFormatEnumOidc(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static ConnectionTokenEndpointJwtcaAudFormatEnumOidc FromCustom(string value)
+    {
+        return new ConnectionTokenEndpointJwtcaAudFormatEnumOidc(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        ConnectionTokenEndpointJwtcaAudFormatEnumOidc value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        ConnectionTokenEndpointJwtcaAudFormatEnumOidc value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(ConnectionTokenEndpointJwtcaAudFormatEnumOidc value) =>
+        value.Value;
+
+    public static explicit operator ConnectionTokenEndpointJwtcaAudFormatEnumOidc(string value) =>
+        new(value);
+
+    internal class ConnectionTokenEndpointJwtcaAudFormatEnumOidcSerializer
+        : JsonConverter<ConnectionTokenEndpointJwtcaAudFormatEnumOidc>
+    {
+        public override ConnectionTokenEndpointJwtcaAudFormatEnumOidc Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new ConnectionTokenEndpointJwtcaAudFormatEnumOidc(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            ConnectionTokenEndpointJwtcaAudFormatEnumOidc value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override ConnectionTokenEndpointJwtcaAudFormatEnumOidc ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new ConnectionTokenEndpointJwtcaAudFormatEnumOidc(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            ConnectionTokenEndpointJwtcaAudFormatEnumOidc value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Issuer = "issuer";
+
+        public const string TokenEndpoint = "token_endpoint";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/CreateEmailProviderResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/CreateEmailProviderResponseContent.cs
@@ -12,7 +12,7 @@ public record CreateEmailProviderResponseContent : IJsonOnDeserialized
         new Dictionary<string, JsonElement>();
 
     /// <summary>
-    /// Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
+    /// Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `resend`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
     /// </summary>
     [Optional]
     [JsonPropertyName("name")]

--- a/src/Auth0.ManagementApi/Types/EmailProviderNameEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EmailProviderNameEnum.cs
@@ -14,6 +14,8 @@ public readonly record struct EmailProviderNameEnum : IStringEnum
 
     public static readonly EmailProviderNameEnum Sendgrid = new(Values.Sendgrid);
 
+    public static readonly EmailProviderNameEnum Resend = new(Values.Resend);
+
     public static readonly EmailProviderNameEnum Ses = new(Values.Ses);
 
     public static readonly EmailProviderNameEnum Sparkpost = new(Values.Sparkpost);
@@ -127,6 +129,8 @@ public readonly record struct EmailProviderNameEnum : IStringEnum
         public const string Mandrill = "mandrill";
 
         public const string Sendgrid = "sendgrid";
+
+        public const string Resend = "resend";
 
         public const string Ses = "ses";
 

--- a/src/Auth0.ManagementApi/Types/GetEmailProviderResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/GetEmailProviderResponseContent.cs
@@ -12,7 +12,7 @@ public record GetEmailProviderResponseContent : IJsonOnDeserialized
         new Dictionary<string, JsonElement>();
 
     /// <summary>
-    /// Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
+    /// Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `resend`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
     /// </summary>
     [Optional]
     [JsonPropertyName("name")]

--- a/src/Auth0.ManagementApi/Types/UpdateEmailProviderResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateEmailProviderResponseContent.cs
@@ -12,7 +12,7 @@ public record UpdateEmailProviderResponseContent : IJsonOnDeserialized
         new Dictionary<string, JsonElement>();
 
     /// <summary>
-    /// Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
+    /// Name of the email provider. Can be `mailgun`, `mandrill`, `sendgrid`, `resend`, `ses`, `sparkpost`, `smtp`, `azure_cs`, `ms365`, or `custom`.
     /// </summary>
     [Optional]
     [JsonPropertyName("name")]

--- a/src/Auth0.ManagementApi/Types/UpdateUserAuthenticationMethodResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateUserAuthenticationMethodResponseContent.cs
@@ -89,6 +89,13 @@ public record UpdateUserAuthenticationMethodResponseContent : IJsonOnDeserialize
     public string? RelyingPartyIdentifier { get; set; }
 
     /// <summary>
+    /// Whether the authentication method has been confirmed.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("confirmed")]
+    public bool? Confirmed { get; set; }
+
+    /// <summary>
     /// Authentication method creation date
     /// </summary>
     [Optional]

--- a/src/Auth0.ManagementApi/UserAttributeProfiles/IUserAttributeProfilesClient.cs
+++ b/src/Auth0.ManagementApi/UserAttributeProfiles/IUserAttributeProfilesClient.cs
@@ -14,7 +14,7 @@ public partial interface IUserAttributeProfilesClient
     );
 
     /// <summary>
-    /// Retrieve details about a single User Attribute Profile specified by ID.
+    /// Create a User Attribute Profile
     /// </summary>
     WithRawResponseTask<CreateUserAttributeProfileResponseContent> CreateAsync(
         CreateUserAttributeProfileRequestContent request,

--- a/src/Auth0.ManagementApi/UserAttributeProfiles/UserAttributeProfilesClient.cs
+++ b/src/Auth0.ManagementApi/UserAttributeProfiles/UserAttributeProfilesClient.cs
@@ -607,7 +607,7 @@ public partial class UserAttributeProfilesClient : IUserAttributeProfilesClient
     }
 
     /// <summary>
-    /// Retrieve details about a single User Attribute Profile specified by ID.
+    /// Create a User Attribute Profile
     /// </summary>
     /// <example><code>
     /// await client.UserAttributeProfiles.CreateAsync(

--- a/src/Auth0.ManagementApi/UserGrants/UserGrantsClient.cs
+++ b/src/Auth0.ManagementApi/UserGrants/UserGrantsClient.cs
@@ -166,7 +166,7 @@ public partial class UserGrantsClient : IUserGrantsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Grants?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Users/AuthenticationMethods/AuthenticationMethodsClient.cs
+++ b/src/Auth0.ManagementApi/Users/AuthenticationMethods/AuthenticationMethodsClient.cs
@@ -559,7 +559,7 @@ public partial class AuthenticationMethodsClient : IAuthenticationMethodsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Authenticators?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Users/Logs/LogsClient.cs
+++ b/src/Auth0.ManagementApi/Users/Logs/LogsClient.cs
@@ -181,7 +181,7 @@ public partial class LogsClient : ILogsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Logs?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Users/Organizations/OrganizationsClient.cs
+++ b/src/Auth0.ManagementApi/Users/Organizations/OrganizationsClient.cs
@@ -169,7 +169,7 @@ public partial class OrganizationsClient : IOrganizationsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Organizations?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Users/Permissions/PermissionsClient.cs
+++ b/src/Auth0.ManagementApi/Users/Permissions/PermissionsClient.cs
@@ -173,7 +173,7 @@ public partial class PermissionsClient : IPermissionsClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Permissions?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Users/Roles/RolesClient.cs
+++ b/src/Auth0.ManagementApi/Users/Roles/RolesClient.cs
@@ -170,7 +170,7 @@ public partial class RolesClient : IRolesClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Roles?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/Users/UsersClient.cs
+++ b/src/Auth0.ManagementApi/Users/UsersClient.cs
@@ -716,7 +716,7 @@ public partial class UsersClient : IUsersClient
                 {
                     request.Page = offset;
                 },
-                request => request.PerPage.GetValueOrDefault(0),
+                null,
                 response => response.Users?.ToList(),
                 null,
                 cancellationToken

--- a/src/Auth0.ManagementApi/VerifiableCredentials/Verification/Templates/ITemplatesClient.cs
+++ b/src/Auth0.ManagementApi/VerifiableCredentials/Verification/Templates/ITemplatesClient.cs
@@ -6,7 +6,7 @@ namespace Auth0.ManagementApi.VerifiableCredentials.Verification;
 public partial interface ITemplatesClient
 {
     /// <summary>
-    /// List a verifiable credential templates.
+    /// List verifiable credential templates.
     /// </summary>
     Task<Pager<VerifiableCredentialTemplateResponse>> ListAsync(
         ListVerifiableCredentialTemplatesRequestParameters request,

--- a/src/Auth0.ManagementApi/VerifiableCredentials/Verification/Templates/TemplatesClient.cs
+++ b/src/Auth0.ManagementApi/VerifiableCredentials/Verification/Templates/TemplatesClient.cs
@@ -14,7 +14,7 @@ public partial class TemplatesClient : ITemplatesClient
     }
 
     /// <summary>
-    /// List a verifiable credential templates.
+    /// List verifiable credential templates.
     /// </summary>
     private WithRawResponseTask<ListVerifiableCredentialTemplatesPaginatedResponseContent> ListInternalAsync(
         ListVerifiableCredentialTemplatesRequestParameters request,
@@ -403,7 +403,7 @@ public partial class TemplatesClient : ITemplatesClient
     }
 
     /// <summary>
-    /// List a verifiable credential templates.
+    /// List verifiable credential templates.
     /// </summary>
     /// <example><code>
     /// await client.VerifiableCredentials.Verification.Templates.ListAsync(

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj
@@ -38,6 +38,9 @@
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="client-secrets.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
+++ b/tests/Auth0.ManagementApi.IntegrationTests/UsersTests.cs
@@ -242,12 +242,21 @@ public class UsersTests : IClassFixture<UsersTestsFixture>
         var usersPager = await fixture.ApiClient.Users.ListAsync(new ListUsersRequestParameters
         {
             Page = 0,
-            PerPage = 50,
+            PerPage = 25,
             IncludeTotals = true
         });
 
-        // Assert
-        usersPager.CurrentPage.Items.Should().NotBeNull();
+        // Assert- totals are reported on the first page
+        var firstPageResponse = (ListUsersOffsetPaginatedResponseContent)usersPager.CurrentPage.Response;
+        firstPageResponse.Should().NotBeNull();
+        firstPageResponse?.Total.Should().BeGreaterThan(0);
+        await foreach (var page in usersPager.AsPagesAsync())
+        {
+            foreach (var user in page)
+            {
+                user.UserId.Should().NotBeNullOrEmpty();
+            }
+        }
     }
 
     [Fact]

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/Connections/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Clients/Connections/GetTest.cs
@@ -1,3 +1,4 @@
+using Auth0.ManagementApi;
 using Auth0.ManagementApi.Clients;
 using Auth0.ManagementApi.Test.Unit.MockServer;
 using NUnit.Framework;
@@ -60,6 +61,7 @@ public class GetTest : BaseMockServerTest
             "id",
             new ConnectionsGetRequest
             {
+                Strategy = new List<ConnectionStrategyEnum?>() { ConnectionStrategyEnum.Ad },
                 From = "from",
                 Take = 1,
                 Fields = "fields",

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Connections/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Connections/ListTest.cs
@@ -62,6 +62,7 @@ public class ListTest : BaseMockServerTest
             {
                 From = "from",
                 Take = 1,
+                Strategy = new List<ConnectionStrategyEnum?>() { ConnectionStrategyEnum.Ad },
                 Name = "name",
                 Fields = "fields",
                 IncludeFields = true,

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/Executions/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/Executions/GetTest.cs
@@ -1,3 +1,4 @@
+using Auth0.ManagementApi;
 using Auth0.ManagementApi.Flows;
 using Auth0.ManagementApi.Test.Unit.MockServer;
 using Auth0.ManagementApi.Test.Utils;
@@ -45,7 +46,14 @@ public class GetTest : BaseMockServerTest
         var response = await Client.Flows.Executions.GetAsync(
             "flow_id",
             "execution_id",
-            new GetFlowExecutionRequestParameters()
+            new GetFlowExecutionRequestParameters
+            {
+                Hydrate =
+                    new List<GetFlowExecutionRequestParametersHydrateEnum?>()
+                    {
+                        GetFlowExecutionRequestParametersHydrateEnum.Debug,
+                    },
+            }
         );
         JsonAssert.AreEqual(response, mockResponse);
     }

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/GetTest.cs
@@ -45,7 +45,17 @@ public class GetTest : BaseMockServerTest
                     .WithBody(mockResponse)
             );
 
-        var response = await Client.Flows.GetAsync("id", new GetFlowRequestParameters());
+        var response = await Client.Flows.GetAsync(
+            "id",
+            new GetFlowRequestParameters
+            {
+                Hydrate =
+                    new List<GetFlowRequestParametersHydrateEnum?>()
+                    {
+                        GetFlowRequestParametersHydrateEnum.FormCount,
+                    },
+            }
+        );
         JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/ListTest.cs
@@ -12,21 +12,21 @@ public class ListTest : BaseMockServerTest
     public async Task MockServerTest()
     {
         const string mockResponse = """
-            {
-              "start": 1.1,
-              "limit": 1.1,
-              "total": 1.1,
-              "flows": [
-                {
-                  "id": "id",
-                  "name": "name",
-                  "created_at": "2024-01-15T09:30:00.000Z",
-                  "updated_at": "2024-01-15T09:30:00.000Z",
-                  "executed_at": "executed_at"
-                }
-              ]
-            }
-            """;
+                                    {
+                                      "start": 1.1,
+                                      "limit": 1.1,
+                                      "total": 1.1,
+                                      "flows": [
+                                        {
+                                          "id": "id",
+                                          "name": "name",
+                                          "created_at": "2024-01-15T09:30:00.000Z",
+                                          "updated_at": "2024-01-15T09:30:00.000Z",
+                                          "executed_at": "executed_at"
+                                        }
+                                      ]
+                                    }
+                                    """;
 
         Server
             .Given(
@@ -50,6 +50,11 @@ public class ListTest : BaseMockServerTest
                 Page = 1,
                 PerPage = 1,
                 IncludeTotals = true,
+                Hydrate =
+                    new List<ListFlowsRequestParametersHydrateEnum?>()
+                    {
+                        ListFlowsRequestParametersHydrateEnum.FormCount,
+                    },
                 Synchronous = true,
             }
         );

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Forms/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Forms/GetTest.cs
@@ -92,7 +92,17 @@ public class GetTest : BaseMockServerTest
                     .WithBody(mockResponse)
             );
 
-        var response = await Client.Forms.GetAsync("id", new GetFormRequestParameters());
+        var response = await Client.Forms.GetAsync(
+            "id",
+            new GetFormRequestParameters
+            {
+                Hydrate =
+                    new List<FormsRequestParametersHydrateEnum?>()
+                    {
+                        FormsRequestParametersHydrateEnum.FlowCount,
+                    },
+            }
+        );
         JsonAssert.AreEqual(response, mockResponse);
     }
 }

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Forms/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Forms/ListTest.cs
@@ -12,22 +12,22 @@ public class ListTest : BaseMockServerTest
     public async Task MockServerTest()
     {
         const string mockResponse = """
-            {
-              "start": 1.1,
-              "limit": 1.1,
-              "total": 1.1,
-              "forms": [
-                {
-                  "id": "id",
-                  "name": "name",
-                  "created_at": "2024-01-15T09:30:00.000Z",
-                  "updated_at": "2024-01-15T09:30:00.000Z",
-                  "embedded_at": "embedded_at",
-                  "submitted_at": "submitted_at"
-                }
-              ]
-            }
-            """;
+                                    {
+                                      "start": 1.1,
+                                      "limit": 1.1,
+                                      "total": 1.1,
+                                      "forms": [
+                                        {
+                                          "id": "id",
+                                          "name": "name",
+                                          "created_at": "2024-01-15T09:30:00.000Z",
+                                          "updated_at": "2024-01-15T09:30:00.000Z",
+                                          "embedded_at": "embedded_at",
+                                          "submitted_at": "submitted_at"
+                                        }
+                                      ]
+                                    }
+                                    """;
 
         Server
             .Given(
@@ -51,6 +51,11 @@ public class ListTest : BaseMockServerTest
                 Page = 1,
                 PerPage = 1,
                 IncludeTotals = true,
+                Hydrate =
+                    new List<FormsRequestParametersHydrateEnum?>()
+                    {
+                        FormsRequestParametersHydrateEnum.FlowCount,
+                    }
             }
         );
         await foreach (var item in items)

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Groups/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Groups/ListTest.cs
@@ -39,6 +39,7 @@ public class ListTest : BaseMockServerTest
                     .WithParam("connection_id", "connection_id")
                     .WithParam("name", "name")
                     .WithParam("external_id", "external_id")
+                    .WithParam("search", "search")
                     .WithParam("fields", "fields")
                     .WithParam("from", "from")
                     .WithParam("take", "1")
@@ -57,6 +58,7 @@ public class ListTest : BaseMockServerTest
                 ConnectionId = "connection_id",
                 Name = "name",
                 ExternalId = "external_id",
+                Search = "search",
                 Fields = "fields",
                 IncludeFields = true,
                 From = "from",

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Organizations/ClientGrants/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Organizations/ClientGrants/ListTest.cs
@@ -55,6 +55,7 @@ public class ListTest : BaseMockServerTest
             {
                 Audience = "audience",
                 ClientId = "client_id",
+                GrantIds = new List<string?>() { "grant_ids" },
                 Page = 1,
                 PerPage = 1,
                 IncludeTotals = true,

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/ResourceServers/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/ResourceServers/ListTest.cs
@@ -73,6 +73,7 @@ public class ListTest : BaseMockServerTest
         var items = await Client.ResourceServers.ListAsync(
             new ListResourceServerRequestParameters
             {
+                Identifiers = new List<string?> { "identifiers" },
                 Page = 1,
                 PerPage = 1,
                 IncludeTotals = true,

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Users/AuthenticationMethods/UpdateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Users/AuthenticationMethods/UpdateTest.cs
@@ -35,6 +35,7 @@ public class UpdateTest : BaseMockServerTest
               "public_key": "public_key",
               "aaguid": "aaguid",
               "relying_party_identifier": "relying_party_identifier",
+              "confirmed": true,
               "created_at": "2024-01-15T09:30:00.000Z"
             }
             """;


### PR DESCRIPTION
 ### Changes

This PR contains SDK generation updates for the Auth0 Management API, adding new query parameters, new type properties, a bug fix for error handling, and documentation corrections.

#### New query parameters

  - **`Connections.ListAsync` / `Clients.Connections.GetAsync`** — Added `Strategy` filter (`ConnectionStrategyEnum`) to filter connections by strategy (e.g. `ad`, `google-oauth2`, etc.)
  - **`Flows.ListAsync` / `Flows.GetAsync`** — Added `Hydrate` parameter (`ListFlowsRequestParametersHydrateEnum` / `GetFlowRequestParametersHydrateEnum`) to hydrate additional fields such as `FormCount`
  - **`Flows.Executions.GetAsync`** — Added `Hydrate` parameter (`GetFlowExecutionRequestParametersHydrateEnum`) to hydrate additional debug info (e.g. `Debug`)
  - **`Forms.ListAsync` / `Forms.GetAsync`** — Added `Hydrate` parameter (`FormsRequestParametersHydrateEnum`) to hydrate additional fields such as `FlowCount`
  - **`Groups.ListAsync`** — Added `Search` parameter to filter groups by name or external ID
  - **`ResourceServers.ListAsync`** — Added `Identifiers` filter parameter to filter APIs by identifier
  - **`Organizations.ClientGrants.ListAsync`** — Added `GrantIds` filter parameter

  #### New type properties
  - **`ConnectionOptionsCommonOidc`, `ConnectionOptionsOidc`, `ConnectionOptionsOkta`** — Added `TokenEndpointJwtcaAudFormat` property (`ConnectionTokenEndpointJwtcaAudFormatEnumOidc`)
  - **`EmailProviderNameEnum`** — Added `Resend` as a supported email provider value; updated documentation strings on `CreateEmailProviderResponseContent`, `GetEmailProviderResponseContent`, and
  `UpdateEmailProviderResponseContent`
  - **`UpdateUserAuthenticationMethodResponseContent`** — Added `Confirmed` (`bool?`) property indicating whether the authentication method has been confirmed

  #### Bug fixes

  - **`RefreshTokens.GetAsync`** — Added missing `BadRequestError` (HTTP 400) error handling; previously only 401/403/404 were handled
  - **Pagination fix** — Replaced `request => request.PerPage.GetValueOrDefault(0)` with `null` for the page-size selector in `Flows.ListAsync`, `Forms.ListAsync`, `ResourceServers.ListAsync`, and
  `Organizations.ClientGrants.ListAsync` to correctly defer page size handling

  #### Documentation corrections

  - `ListClientGrantsRequestParameters.DefaultFor` — Updated doc comment to include hyperlinked reference for `third_party_clients`
  - `UserAttributeProfiles` — Fixed incorrect description on `CreateAsync` (was incorrectly described as "Retrieve details about a single User Attribute Profile")
  - `Verification.Templates.ListAsync` — Fixed grammar: "List a verifiable credential templates" → "List verifiable credential templates"

  #### Reference documentation

  - Updated all code examples in `reference.md` to reflect new parameters (`Strategy`, `Hydrate`, `Search`, `Identifiers`, `GrantIds`)

  ### References

  - Fixes #979 
  - Uses Fern C# generator `v2.61.2`

  ### Testing

 - All new parameters and properties are covered by unit tests using the mock server test suite. Existing mock server tests have been updated to include the new parameters in their request fixtures.
 - Updated an existing integration test `Test_paging_includes_totals` in `UsersTests.cs` to simulate #979 

  - [x] This change adds unit test coverage
  - [ ] This change adds integration test coverage
  - [x] This change has been tested on the latest version of the platform/language or why not

  ### Checklist

  - [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
  - [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
  - [x] All existing and new tests complete without errors