### PR TITLE
SDK generator 2026-04-28

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -3385,6 +3385,68 @@ await client.EventStreams.TestAsync(
 </dl>
 </details>
 
+## Events
+<details><summary><code>client.Events.<a href="/src/Auth0.ManagementApi/Events/EventsClient.cs">SubscribeAsync</a>(SubscribeEventsRequestParameters { ... }) -> IAsyncEnumerable&lt;EventStreamSubscribeEventsResponseContent&gt;</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Subscribe to events via Server-Sent Events (SSE)
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```csharp
+client.Events.SubscribeAsync(
+    new SubscribeEventsRequestParameters
+    {
+        From = "from",
+        FromTimestamp = "from_timestamp",
+        EventType = EventStreamSubscribeEventsEventTypeEnum.GroupCreated,
+    }
+);
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request:** `SubscribeEventsRequestParameters` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
 ## Flows
 <details><summary><code>client.Flows.<a href="/src/Auth0.ManagementApi/Flows/FlowsClient.cs">ListAsync</a>(ListFlowsRequestParameters { ... }) -> Pager&lt;FlowSummary&gt;</code></summary>
 <dl>
@@ -6368,6 +6430,60 @@ await client.RefreshTokens.ListAsync(
 <dd>
 
 **request:** `GetRefreshTokensRequestParameters` 
+    
+</dd>
+</dl>
+</dd>
+</dl>
+
+
+</dd>
+</dl>
+</details>
+
+<details><summary><code>client.RefreshTokens.<a href="/src/Auth0.ManagementApi/RefreshTokens/RefreshTokensClient.cs">RevokeAsync</a>(RevokeRefreshTokensRequestContent { ... })</code></summary>
+<dl>
+<dd>
+
+#### 📝 Description
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+Revoke refresh tokens in bulk by ID list, user, user+client, or client.
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### 🔌 Usage
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+```csharp
+await client.RefreshTokens.RevokeAsync(new RevokeRefreshTokensRequestContent());
+```
+</dd>
+</dl>
+</dd>
+</dl>
+
+#### ⚙️ Parameters
+
+<dl>
+<dd>
+
+<dl>
+<dd>
+
+**request:** `RevokeRefreshTokensRequestContent` 
     
 </dd>
 </dl>
@@ -21594,7 +21710,7 @@ await client.Roles.Users.AssignAsync(
 <dl>
 <dd>
 
-Retrieves text customizations for a given self-service profile, language and Self Service SSO Flow page.
+Retrieves text customizations for a given self-service profile, language and Self-Service Enterprise Configuration flow page.
 </dd>
 </dl>
 </dd>
@@ -21668,7 +21784,7 @@ await client.SelfServiceProfiles.CustomText.ListAsync(
 <dl>
 <dd>
 
-Updates text customizations for a given self-service profile, language and Self Service SSO Flow page.
+Updates text customizations for a given self-service profile, language and Self-Service Enterprise Configuration flow page.
 </dd>
 </dl>
 </dd>
@@ -21752,7 +21868,7 @@ await client.SelfServiceProfiles.CustomText.SetAsync(
 <dl>
 <dd>
 
-Creates an SSO access ticket to initiate the Self Service SSO Flow using a self-service profile.
+Creates an access ticket to initiate the Self-Service Enterprise Configuration flow using a self-service profile.
 </dd>
 </dl>
 </dd>
@@ -21817,7 +21933,7 @@ await client.SelfServiceProfiles.SsoTicket.CreateAsync(
 <dl>
 <dd>
 
-Revokes an SSO access ticket and invalidates associated sessions. The ticket will no longer be accepted to initiate a Self-Service SSO session. If any users have already started a session through this ticket, their session will be terminated. Clients should expect a `202 Accepted` response upon successful processing, indicating that the request has been acknowledged and that the revocation is underway but may not be fully completed at the time of response. If the specified ticket does not exist, a `202 Accepted` response is also returned, signaling that no further action is required.
+Revokes a Self-Service Enterprise Configuration access ticket and invalidates associated sessions. The ticket will no longer be accepted to initiate a Self-Service Enterprise Configuration session. If any users have already started a session through this ticket, their session will be terminated. Clients should expect a `202 Accepted` response upon successful processing, indicating that the request has been acknowledged and that the revocation is underway but may not be fully completed at the time of response. If the specified ticket does not exist, a `202 Accepted` response is also returned, signaling that no further action is required.
 Clients should treat these `202` responses as an acknowledgment that the request has been accepted and is in progress, even if the ticket was not found.
 </dd>
 </dl>

--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.Custom.props
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.Custom.props
@@ -22,6 +22,11 @@
     <ProjectReference Include="..\Auth0.AuthenticationApi\Auth0.AuthenticationApi.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
+    <PackageReference Include="System.Net.ServerSentEvents" Version="9.0.14" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.14" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <Version>8.1.0</Version>

--- a/src/Auth0.ManagementApi/Branding/Requests/UpdateBrandingRequestContent.cs
+++ b/src/Auth0.ManagementApi/Branding/Requests/UpdateBrandingRequestContent.cs
@@ -25,6 +25,10 @@ public record UpdateBrandingRequestContent
     public Optional<string?> LogoUrl { get; set; }
 
     [Nullable, Optional]
+    [JsonPropertyName("identifiers")]
+    public Optional<UpdateBrandingIdentifiers?> Identifiers { get; set; }
+
+    [Nullable, Optional]
     [JsonPropertyName("font")]
     public Optional<UpdateBrandingFont?> Font { get; set; }
 

--- a/src/Auth0.ManagementApi/Core/JsonConfiguration.cs
+++ b/src/Auth0.ManagementApi/Core/JsonConfiguration.cs
@@ -268,4 +268,64 @@ internal static class JsonUtils
 
     internal static T Deserialize<T>(string json) =>
         JsonSerializer.Deserialize<T>(json, JsonOptions.JsonSerializerOptions)!;
+
+    internal static bool TryDeserialize<T>(string json, out T? result)
+        where T : class
+    {
+        try
+        {
+            result = Deserialize<T>(json);
+            return true;
+        }
+        catch (global::System.Exception)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    internal static bool TryDeserialize<T>(string json, out T? result)
+        where T : struct
+    {
+        try
+        {
+            result = Deserialize<T>(json);
+            return true;
+        }
+        catch (global::System.Exception)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    internal static bool TryDeserialize<T>(JsonDocument json, out T? result)
+        where T : class
+    {
+        try
+        {
+            result = json.Deserialize<T>(JsonOptions.JsonSerializerOptions);
+            return true;
+        }
+        catch (global::System.Exception)
+        {
+            result = null;
+            return false;
+        }
+    }
+
+    internal static bool TryDeserialize<T>(JsonDocument json, out T? result)
+        where T : struct
+    {
+        try
+        {
+            result = json.Deserialize<T>(JsonOptions.JsonSerializerOptions);
+            return true;
+        }
+        catch (global::System.Exception)
+        {
+            result = null;
+            return false;
+        }
+    }
 }

--- a/src/Auth0.ManagementApi/Events/EventsClient.cs
+++ b/src/Auth0.ManagementApi/Events/EventsClient.cs
@@ -1,0 +1,127 @@
+using Auth0.ManagementApi.Core;
+using global::System.Net.ServerSentEvents;
+using global::System.Text.Json;
+
+namespace Auth0.ManagementApi;
+
+public partial class EventsClient : IEventsClient
+{
+    private readonly RawClient _client;
+
+    internal EventsClient(RawClient client)
+    {
+        _client = client;
+    }
+
+    /// <summary>
+    /// Subscribe to events via Server-Sent Events (SSE)
+    /// </summary>
+    /// <example><code>
+    /// client.Events.SubscribeAsync(
+    ///     new SubscribeEventsRequestParameters
+    ///     {
+    ///         From = "from",
+    ///         FromTimestamp = "from_timestamp",
+    ///         EventType = EventStreamSubscribeEventsEventTypeEnum.GroupCreated,
+    ///     }
+    /// );
+    /// </code></example>
+    public async IAsyncEnumerable<EventStreamSubscribeEventsResponseContent> SubscribeAsync(
+        SubscribeEventsRequestParameters request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var _queryString = new Auth0.ManagementApi.Core.QueryStringBuilder.Builder(capacity: 3)
+            .Add("from", request.From.IsDefined ? request.From.Value : null)
+            .Add(
+                "from_timestamp",
+                request.FromTimestamp.IsDefined ? request.FromTimestamp.Value : null
+            )
+            .AddDeepObject(
+                "event_type",
+                request.EventType.IsDefined ? request.EventType.Value : null
+            )
+            .MergeAdditional(options?.AdditionalQueryParameters)
+            .Build();
+        var _headers = await new Auth0.ManagementApi.Core.HeadersBuilder.Builder()
+            .Add(_client.Options.Headers)
+            .Add(_client.Options.AdditionalHeaders)
+            .Add(options?.AdditionalHeaders)
+            .BuildAsync()
+            .ConfigureAwait(false);
+        var response = await _client
+            .SendRequestAsync(
+                new JsonRequest
+                {
+                    Method = HttpMethod.Get,
+                    Path = "events",
+                    QueryString = _queryString,
+                    Headers = _headers,
+                    Options = options,
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        if (response.StatusCode is >= 200 and < 400)
+        {
+            await foreach (
+                var item in SseParser
+                    .Create(await response.Raw.Content.ReadAsStreamAsync())
+                    .EnumerateAsync(cancellationToken)
+            )
+            {
+                if (!string.IsNullOrEmpty(item.Data))
+                {
+                    EventStreamSubscribeEventsResponseContent? result;
+                    try
+                    {
+                        result = JsonUtils.Deserialize<EventStreamSubscribeEventsResponseContent>(
+                            item.Data
+                        );
+                    }
+                    catch (JsonException e)
+                    {
+                        throw new ManagementException(
+                            "Failed to deserialize streaming response",
+                            e
+                        );
+                    }
+                }
+            }
+            yield break;
+        }
+        {
+            var responseBody = await response
+                .Raw.Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                switch (response.StatusCode)
+                {
+                    case 400:
+                        throw new BadRequestError(JsonUtils.Deserialize<object>(responseBody));
+                    case 401:
+                        throw new UnauthorizedError(JsonUtils.Deserialize<object>(responseBody));
+                    case 403:
+                        throw new ForbiddenError(JsonUtils.Deserialize<object>(responseBody));
+                    case 404:
+                        throw new NotFoundError(JsonUtils.Deserialize<object>(responseBody));
+                    case 410:
+                        throw new GoneError(JsonUtils.Deserialize<object>(responseBody));
+                    case 429:
+                        throw new TooManyRequestsError(JsonUtils.Deserialize<object>(responseBody));
+                }
+            }
+            catch (JsonException)
+            {
+                // unable to map error response, throwing generic error
+            }
+            throw new ManagementApiException(
+                $"Error with status code {response.StatusCode}",
+                response.StatusCode,
+                responseBody
+            );
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Events/IEventsClient.cs
+++ b/src/Auth0.ManagementApi/Events/IEventsClient.cs
@@ -1,0 +1,13 @@
+namespace Auth0.ManagementApi;
+
+public partial interface IEventsClient
+{
+    /// <summary>
+    /// Subscribe to events via Server-Sent Events (SSE)
+    /// </summary>
+    IAsyncEnumerable<EventStreamSubscribeEventsResponseContent> SubscribeAsync(
+        SubscribeEventsRequestParameters request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
+}

--- a/src/Auth0.ManagementApi/Events/Requests/SubscribeEventsRequestParameters.cs
+++ b/src/Auth0.ManagementApi/Events/Requests/SubscribeEventsRequestParameters.cs
@@ -1,0 +1,32 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[Serializable]
+public record SubscribeEventsRequestParameters
+{
+    /// <summary>
+    /// Opaque token representing position in the stream. If not provided, stream will start from the latest events.
+    /// </summary>
+    [JsonIgnore]
+    public Optional<string?> From { get; set; }
+
+    /// <summary>
+    /// RFC-3339 timestamp indicating where to start streaming events from. This should only be used on the initial query when a cursor may not be available. Subsequent requests should use the cursor (from) as it will be more accurate.
+    /// </summary>
+    [JsonIgnore]
+    public Optional<string?> FromTimestamp { get; set; }
+
+    /// <summary>
+    /// Event type(s) to listen for. Specify multiple times for multiple types (e.g., ?event_type=user.created&event_type=user.updated). If not provided, all event types will be streamed.
+    /// </summary>
+    [JsonIgnore]
+    public Optional<EventStreamSubscribeEventsEventTypeParam?> EventType { get; set; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Exceptions/GoneError.cs
+++ b/src/Auth0.ManagementApi/Exceptions/GoneError.cs
@@ -1,0 +1,7 @@
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// This exception type will be thrown for any non-2XX API responses.
+/// </summary>
+[Serializable]
+public class GoneError(object body) : ManagementApiException("GoneError", 410, body);

--- a/src/Auth0.ManagementApi/IManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/IManagementApiClient.cs
@@ -19,6 +19,7 @@ public partial interface IManagementApiClient
     public IDeviceCredentialsClient DeviceCredentials { get; }
     public IEmailTemplatesClient EmailTemplates { get; }
     public IEventStreamsClient EventStreams { get; }
+    public IEventsClient Events { get; }
     public IFlowsClient Flows { get; }
     public IFormsClient Forms { get; }
     public IUserGrantsClient UserGrants { get; }

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -42,6 +42,7 @@ public partial class ManagementApiClient : IManagementApiClient
         DeviceCredentials = new DeviceCredentialsClient(_client);
         EmailTemplates = new EmailTemplatesClient(_client);
         EventStreams = new EventStreamsClient(_client);
+        Events = new EventsClient(_client);
         Flows = new FlowsClient(_client);
         Forms = new FormsClient(_client);
         UserGrants = new UserGrantsClient(_client);
@@ -96,6 +97,8 @@ public partial class ManagementApiClient : IManagementApiClient
     public IEmailTemplatesClient EmailTemplates { get; }
 
     public IEventStreamsClient EventStreams { get; }
+
+    public IEventsClient Events { get; }
 
     public IFlowsClient Flows { get; }
 

--- a/src/Auth0.ManagementApi/RefreshTokens/IRefreshTokensClient.cs
+++ b/src/Auth0.ManagementApi/RefreshTokens/IRefreshTokensClient.cs
@@ -14,6 +14,15 @@ public partial interface IRefreshTokensClient
     );
 
     /// <summary>
+    /// Revoke refresh tokens in bulk by ID list, user, user+client, or client.
+    /// </summary>
+    Task RevokeAsync(
+        RevokeRefreshTokensRequestContent request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    );
+
+    /// <summary>
     /// Retrieve refresh token information.
     /// </summary>
     WithRawResponseTask<GetRefreshTokenResponseContent> GetAsync(

--- a/src/Auth0.ManagementApi/RefreshTokens/RefreshTokensClient.cs
+++ b/src/Auth0.ManagementApi/RefreshTokens/RefreshTokensClient.cs
@@ -362,6 +362,72 @@ public partial class RefreshTokensClient : IRefreshTokensClient
     }
 
     /// <summary>
+    /// Revoke refresh tokens in bulk by ID list, user, user+client, or client.
+    /// </summary>
+    /// <example><code>
+    /// await client.RefreshTokens.RevokeAsync(new RevokeRefreshTokensRequestContent());
+    /// </code></example>
+    public async Task RevokeAsync(
+        RevokeRefreshTokensRequestContent request,
+        RequestOptions? options = null,
+        CancellationToken cancellationToken = default
+    )
+    {
+        var _headers = await new Auth0.ManagementApi.Core.HeadersBuilder.Builder()
+            .Add(_client.Options.Headers)
+            .Add(_client.Options.AdditionalHeaders)
+            .Add(options?.AdditionalHeaders)
+            .BuildAsync()
+            .ConfigureAwait(false);
+        var response = await _client
+            .SendRequestAsync(
+                new JsonRequest
+                {
+                    Method = HttpMethod.Post,
+                    Path = "refresh-tokens/revoke",
+                    Body = request,
+                    Headers = _headers,
+                    ContentType = "application/json",
+                    Options = options,
+                },
+                cancellationToken
+            )
+            .ConfigureAwait(false);
+        if (response.StatusCode is >= 200 and < 400)
+        {
+            return;
+        }
+        {
+            var responseBody = await response
+                .Raw.Content.ReadAsStringAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                switch (response.StatusCode)
+                {
+                    case 400:
+                        throw new BadRequestError(JsonUtils.Deserialize<object>(responseBody));
+                    case 401:
+                        throw new UnauthorizedError(JsonUtils.Deserialize<object>(responseBody));
+                    case 403:
+                        throw new ForbiddenError(JsonUtils.Deserialize<object>(responseBody));
+                    case 429:
+                        throw new TooManyRequestsError(JsonUtils.Deserialize<object>(responseBody));
+                }
+            }
+            catch (JsonException)
+            {
+                // unable to map error response, throwing generic error
+            }
+            throw new ManagementApiException(
+                $"Error with status code {response.StatusCode}",
+                response.StatusCode,
+                responseBody
+            );
+        }
+    }
+
+    /// <summary>
     /// Retrieve refresh token information.
     /// </summary>
     /// <example><code>

--- a/src/Auth0.ManagementApi/RefreshTokens/Requests/RevokeRefreshTokensRequestContent.cs
+++ b/src/Auth0.ManagementApi/RefreshTokens/Requests/RevokeRefreshTokensRequestContent.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[Serializable]
+public record RevokeRefreshTokensRequestContent
+{
+    /// <summary>
+    /// Array of refresh token IDs to revoke. Limited to 100 at a time.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("ids")]
+    public IEnumerable<string>? Ids { get; set; }
+
+    /// <summary>
+    /// Revoke all refresh tokens for this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("user_id")]
+    public string? UserId { get; set; }
+
+    /// <summary>
+    /// Revoke all refresh tokens for this client.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("client_id")]
+    public string? ClientId { get; set; }
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/CustomText/CustomTextClient.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/CustomText/CustomTextClient.cs
@@ -197,7 +197,7 @@ public partial class CustomTextClient : ICustomTextClient
     }
 
     /// <summary>
-    /// Retrieves text customizations for a given self-service profile, language and Self Service SSO Flow page.
+    /// Retrieves text customizations for a given self-service profile, language and Self-Service Enterprise Configuration flow page.
     /// </summary>
     /// <example><code>
     /// await client.SelfServiceProfiles.CustomText.ListAsync(
@@ -220,7 +220,7 @@ public partial class CustomTextClient : ICustomTextClient
     }
 
     /// <summary>
-    /// Updates text customizations for a given self-service profile, language and Self Service SSO Flow page.
+    /// Updates text customizations for a given self-service profile, language and Self-Service Enterprise Configuration flow page.
     /// </summary>
     /// <example><code>
     /// await client.SelfServiceProfiles.CustomText.SetAsync(

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/CustomText/ICustomTextClient.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/CustomText/ICustomTextClient.cs
@@ -5,7 +5,7 @@ namespace Auth0.ManagementApi.SelfServiceProfiles;
 public partial interface ICustomTextClient
 {
     /// <summary>
-    /// Retrieves text customizations for a given self-service profile, language and Self Service SSO Flow page.
+    /// Retrieves text customizations for a given self-service profile, language and Self-Service Enterprise Configuration flow page.
     /// </summary>
     WithRawResponseTask<Dictionary<string, string>> ListAsync(
         string id,
@@ -16,7 +16,7 @@ public partial interface ICustomTextClient
     );
 
     /// <summary>
-    /// Updates text customizations for a given self-service profile, language and Self Service SSO Flow page.
+    /// Updates text customizations for a given self-service profile, language and Self-Service Enterprise Configuration flow page.
     /// </summary>
     WithRawResponseTask<Dictionary<string, string>> SetAsync(
         string id,

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/Requests/CreateSelfServiceProfileRequestContent.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/Requests/CreateSelfServiceProfileRequestContent.cs
@@ -24,14 +24,14 @@ public record CreateSelfServiceProfileRequestContent
     public SelfServiceProfileBrandingProperties? Branding { get; set; }
 
     /// <summary>
-    /// List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
+    /// List of IdP strategies that will be shown to users during the Self-Service Enterprise Configuration flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
     /// </summary>
     [Optional]
     [JsonPropertyName("allowed_strategies")]
     public IEnumerable<SelfServiceProfileAllowedStrategyEnum>? AllowedStrategies { get; set; }
 
     /// <summary>
-    /// List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
+    /// List of attributes to be mapped that will be shown to the user during the Self-Service Enterprise Configuration flow.
     /// </summary>
     [Optional]
     [JsonPropertyName("user_attributes")]

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/Requests/UpdateSelfServiceProfileRequestContent.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/Requests/UpdateSelfServiceProfileRequestContent.cs
@@ -22,7 +22,7 @@ public record UpdateSelfServiceProfileRequestContent
     public Optional<SelfServiceProfileBrandingProperties?> Branding { get; set; }
 
     /// <summary>
-    /// List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
+    /// List of IdP strategies that will be shown to users during the Self-Service Enterprise Configuration flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
     /// </summary>
     [Optional]
     [JsonPropertyName("allowed_strategies")]

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/ISsoTicketClient.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/ISsoTicketClient.cs
@@ -5,7 +5,7 @@ namespace Auth0.ManagementApi.SelfServiceProfiles;
 public partial interface ISsoTicketClient
 {
     /// <summary>
-    /// Creates an SSO access ticket to initiate the Self Service SSO Flow using a self-service profile.
+    /// Creates an access ticket to initiate the Self-Service Enterprise Configuration flow using a self-service profile.
     /// </summary>
     WithRawResponseTask<CreateSelfServiceProfileSsoTicketResponseContent> CreateAsync(
         string id,
@@ -15,7 +15,7 @@ public partial interface ISsoTicketClient
     );
 
     /// <summary>
-    /// Revokes an SSO access ticket and invalidates associated sessions. The ticket will no longer be accepted to initiate a Self-Service SSO session. If any users have already started a session through this ticket, their session will be terminated. Clients should expect a `202 Accepted` response upon successful processing, indicating that the request has been acknowledged and that the revocation is underway but may not be fully completed at the time of response. If the specified ticket does not exist, a `202 Accepted` response is also returned, signaling that no further action is required.
+    /// Revokes a Self-Service Enterprise Configuration access ticket and invalidates associated sessions. The ticket will no longer be accepted to initiate a Self-Service Enterprise Configuration session. If any users have already started a session through this ticket, their session will be terminated. Clients should expect a `202 Accepted` response upon successful processing, indicating that the request has been acknowledged and that the revocation is underway but may not be fully completed at the time of response. If the specified ticket does not exist, a `202 Accepted` response is also returned, signaling that no further action is required.
     /// Clients should treat these `202` responses as an acknowledgment that the request has been accepted and is in progress, even if the ticket was not found.
     /// </summary>
     Task RevokeAsync(

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/Requests/CreateSelfServiceProfileSsoTicketRequestContent.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/Requests/CreateSelfServiceProfileSsoTicketRequestContent.cs
@@ -8,7 +8,7 @@ namespace Auth0.ManagementApi.SelfServiceProfiles;
 public record CreateSelfServiceProfileSsoTicketRequestContent
 {
     /// <summary>
-    /// If provided, this will allow editing of the provided connection during the SSO Flow
+    /// If provided, this will allow editing of the provided connection during the Self-Service Enterprise Configuration flow
     /// </summary>
     [Optional]
     [JsonPropertyName("connection_id")]

--- a/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/SsoTicketClient.cs
+++ b/src/Auth0.ManagementApi/SelfServiceProfiles/SsoTicket/SsoTicketClient.cs
@@ -108,7 +108,7 @@ public partial class SsoTicketClient : ISsoTicketClient
     }
 
     /// <summary>
-    /// Creates an SSO access ticket to initiate the Self Service SSO Flow using a self-service profile.
+    /// Creates an access ticket to initiate the Self-Service Enterprise Configuration flow using a self-service profile.
     /// </summary>
     /// <example><code>
     /// await client.SelfServiceProfiles.SsoTicket.CreateAsync(
@@ -129,7 +129,7 @@ public partial class SsoTicketClient : ISsoTicketClient
     }
 
     /// <summary>
-    /// Revokes an SSO access ticket and invalidates associated sessions. The ticket will no longer be accepted to initiate a Self-Service SSO session. If any users have already started a session through this ticket, their session will be terminated. Clients should expect a `202 Accepted` response upon successful processing, indicating that the request has been acknowledged and that the revocation is underway but may not be fully completed at the time of response. If the specified ticket does not exist, a `202 Accepted` response is also returned, signaling that no further action is required.
+    /// Revokes a Self-Service Enterprise Configuration access ticket and invalidates associated sessions. The ticket will no longer be accepted to initiate a Self-Service Enterprise Configuration session. If any users have already started a session through this ticket, their session will be terminated. Clients should expect a `202 Accepted` response upon successful processing, indicating that the request has been acknowledged and that the revocation is underway but may not be fully completed at the time of response. If the specified ticket does not exist, a `202 Accepted` response is also returned, signaling that no further action is required.
     /// Clients should treat these `202` responses as an acknowledgment that the request has been accepted and is in progress, even if the ticket was not found.
     /// </summary>
     /// <example><code>

--- a/src/Auth0.ManagementApi/Types/BrandingIdentifiers.cs
+++ b/src/Auth0.ManagementApi/Types/BrandingIdentifiers.cs
@@ -1,0 +1,43 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Identifier input display settings.
+/// </summary>
+[Serializable]
+public record BrandingIdentifiers : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [Optional]
+    [JsonPropertyName("login_display")]
+    public BrandingLoginDisplayEnum? LoginDisplay { get; set; }
+
+    /// <summary>
+    /// Whether OTP autocomplete (autocomplete="one-time-code") is enabled.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("otp_autocomplete")]
+    public bool? OtpAutocomplete { get; set; }
+
+    [Optional]
+    [JsonPropertyName("phone_display")]
+    public BrandingPhoneDisplay? PhoneDisplay { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/BrandingLoginDisplayEnum.cs
+++ b/src/Auth0.ManagementApi/Types/BrandingLoginDisplayEnum.cs
@@ -1,0 +1,115 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(BrandingLoginDisplayEnum.BrandingLoginDisplayEnumSerializer))]
+[Serializable]
+public readonly record struct BrandingLoginDisplayEnum : IStringEnum
+{
+    public static readonly BrandingLoginDisplayEnum Unified = new(Values.Unified);
+
+    public static readonly BrandingLoginDisplayEnum Separate = new(Values.Separate);
+
+    public BrandingLoginDisplayEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static BrandingLoginDisplayEnum FromCustom(string value)
+    {
+        return new BrandingLoginDisplayEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(BrandingLoginDisplayEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(BrandingLoginDisplayEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(BrandingLoginDisplayEnum value) => value.Value;
+
+    public static explicit operator BrandingLoginDisplayEnum(string value) => new(value);
+
+    internal class BrandingLoginDisplayEnumSerializer : JsonConverter<BrandingLoginDisplayEnum>
+    {
+        public override BrandingLoginDisplayEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new BrandingLoginDisplayEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            BrandingLoginDisplayEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override BrandingLoginDisplayEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new BrandingLoginDisplayEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            BrandingLoginDisplayEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Unified = "unified";
+
+        public const string Separate = "separate";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/BrandingPhoneDisplay.cs
+++ b/src/Auth0.ManagementApi/Types/BrandingPhoneDisplay.cs
@@ -1,0 +1,36 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Phone number display settings.
+/// </summary>
+[Serializable]
+public record BrandingPhoneDisplay : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [Optional]
+    [JsonPropertyName("masking")]
+    public BrandingPhoneMaskingEnum? Masking { get; set; }
+
+    [Optional]
+    [JsonPropertyName("formatting")]
+    public BrandingPhoneFormattingEnum? Formatting { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/BrandingPhoneFormattingEnum.cs
+++ b/src/Auth0.ManagementApi/Types/BrandingPhoneFormattingEnum.cs
@@ -1,0 +1,116 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(BrandingPhoneFormattingEnum.BrandingPhoneFormattingEnumSerializer))]
+[Serializable]
+public readonly record struct BrandingPhoneFormattingEnum : IStringEnum
+{
+    public static readonly BrandingPhoneFormattingEnum Regional = new(Values.Regional);
+
+    public static readonly BrandingPhoneFormattingEnum International = new(Values.International);
+
+    public BrandingPhoneFormattingEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static BrandingPhoneFormattingEnum FromCustom(string value)
+    {
+        return new BrandingPhoneFormattingEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(BrandingPhoneFormattingEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(BrandingPhoneFormattingEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(BrandingPhoneFormattingEnum value) => value.Value;
+
+    public static explicit operator BrandingPhoneFormattingEnum(string value) => new(value);
+
+    internal class BrandingPhoneFormattingEnumSerializer
+        : JsonConverter<BrandingPhoneFormattingEnum>
+    {
+        public override BrandingPhoneFormattingEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new BrandingPhoneFormattingEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            BrandingPhoneFormattingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override BrandingPhoneFormattingEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new BrandingPhoneFormattingEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            BrandingPhoneFormattingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Regional = "regional";
+
+        public const string International = "international";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/BrandingPhoneMaskingEnum.cs
+++ b/src/Auth0.ManagementApi/Types/BrandingPhoneMaskingEnum.cs
@@ -1,0 +1,119 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(BrandingPhoneMaskingEnum.BrandingPhoneMaskingEnumSerializer))]
+[Serializable]
+public readonly record struct BrandingPhoneMaskingEnum : IStringEnum
+{
+    public static readonly BrandingPhoneMaskingEnum ShowAll = new(Values.ShowAll);
+
+    public static readonly BrandingPhoneMaskingEnum HideCountryCode = new(Values.HideCountryCode);
+
+    public static readonly BrandingPhoneMaskingEnum MaskDigits = new(Values.MaskDigits);
+
+    public BrandingPhoneMaskingEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static BrandingPhoneMaskingEnum FromCustom(string value)
+    {
+        return new BrandingPhoneMaskingEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(BrandingPhoneMaskingEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(BrandingPhoneMaskingEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(BrandingPhoneMaskingEnum value) => value.Value;
+
+    public static explicit operator BrandingPhoneMaskingEnum(string value) => new(value);
+
+    internal class BrandingPhoneMaskingEnumSerializer : JsonConverter<BrandingPhoneMaskingEnum>
+    {
+        public override BrandingPhoneMaskingEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new BrandingPhoneMaskingEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            BrandingPhoneMaskingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override BrandingPhoneMaskingEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new BrandingPhoneMaskingEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            BrandingPhoneMaskingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string ShowAll = "show_all";
+
+        public const string HideCountryCode = "hide_country_code";
+
+        public const string MaskDigits = "mask_digits";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/ConnectionPropertiesOptions.cs
+++ b/src/Auth0.ManagementApi/Types/ConnectionPropertiesOptions.cs
@@ -158,6 +158,22 @@ public record ConnectionPropertiesOptions : IJsonOnDeserialized, IJsonOnSerializ
     [JsonPropertyName("password_options")]
     public ConnectionPasswordOptions? PasswordOptions { get; set; }
 
+    [Nullable, Optional]
+    [JsonPropertyName("id_token_signed_response_algs")]
+    public Optional<IEnumerable<ConnectionIdTokenSignedResponseAlgEnum>?> IdTokenSignedResponseAlgs { get; set; }
+
+    [Nullable, Optional]
+    [JsonPropertyName("token_endpoint_auth_method")]
+    public Optional<ConnectionTokenEndpointAuthMethodEnum?> TokenEndpointAuthMethod { get; set; }
+
+    [Nullable, Optional]
+    [JsonPropertyName("token_endpoint_auth_signing_alg")]
+    public Optional<ConnectionTokenEndpointAuthSigningAlgEnum?> TokenEndpointAuthSigningAlg { get; set; }
+
+    [Optional]
+    [JsonPropertyName("token_endpoint_jwtca_aud_format")]
+    public ConnectionTokenEndpointJwtcaAudFormatEnumOidc? TokenEndpointJwtcaAudFormat { get; set; }
+
     [JsonIgnore]
     public AdditionalProperties AdditionalProperties { get; set; } = new();
 

--- a/src/Auth0.ManagementApi/Types/CreateSelfServiceProfileResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/CreateSelfServiceProfileResponseContent.cs
@@ -33,7 +33,7 @@ public record CreateSelfServiceProfileResponseContent : IJsonOnDeserialized
     public string? Description { get; set; }
 
     /// <summary>
-    /// List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
+    /// List of attributes to be mapped that will be shown to the user during the Self-Service Enterprise Configuration flow.
     /// </summary>
     [Optional]
     [JsonPropertyName("user_attributes")]
@@ -58,7 +58,7 @@ public record CreateSelfServiceProfileResponseContent : IJsonOnDeserialized
     public SelfServiceProfileBrandingProperties? Branding { get; set; }
 
     /// <summary>
-    /// List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
+    /// List of IdP strategies that will be shown to users during the Self-Service Enterprise Configuration flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
     /// </summary>
     [Optional]
     [JsonPropertyName("allowed_strategies")]

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventA0PurposeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventA0PurposeEnum.cs
@@ -1,0 +1,114 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventA0PurposeEnum.EventStreamCloudEventA0PurposeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventA0PurposeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventA0PurposeEnum Test = new(Values.Test);
+
+    public EventStreamCloudEventA0PurposeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventA0PurposeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventA0PurposeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(EventStreamCloudEventA0PurposeEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(EventStreamCloudEventA0PurposeEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventA0PurposeEnum value) => value.Value;
+
+    public static explicit operator EventStreamCloudEventA0PurposeEnum(string value) => new(value);
+
+    internal class EventStreamCloudEventA0PurposeEnumSerializer
+        : JsonConverter<EventStreamCloudEventA0PurposeEnum>
+    {
+        public override EventStreamCloudEventA0PurposeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventA0PurposeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventA0PurposeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventA0PurposeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventA0PurposeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventA0PurposeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Test = "test";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventContext.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventContext.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Information about the context in which the event was produced. This may include things like
+/// HTTP request details, client information, connection information, etc.
+///
+/// Note: This field may not be present on all events, depending on the event type and the
+/// context in which it was generated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventContext : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [Optional]
+    [JsonPropertyName("client")]
+    public EventStreamCloudEventContextClient? Client { get; set; }
+
+    [Optional]
+    [JsonPropertyName("connection")]
+    public EventStreamCloudEventContextConnection? Connection { get; set; }
+
+    [Optional]
+    [JsonPropertyName("request")]
+    public EventStreamCloudEventContextRequest? Request { get; set; }
+
+    [JsonPropertyName("tenant")]
+    public required EventStreamCloudEventContextTenant Tenant { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextClient.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextClient.cs
@@ -1,0 +1,43 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The OAuth Client requesting or presenting an access token.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventContextClient : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The client identifier.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The client name.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object?> Metadata { get; set; } = new Dictionary<string, object?>();
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextConnection.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextConnection.cs
@@ -1,0 +1,46 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The Auth0 Connection used for the authentication transaction that generated the event.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventContextConnection : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the connection.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the connection.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The auth strategy implemented by the connection.
+    /// </summary>
+    [JsonPropertyName("strategy")]
+    public required string Strategy { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextRequest.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextRequest.cs
@@ -1,0 +1,62 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// An HTTP request.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventContextRequest : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("geo")]
+    public required EventStreamCloudEventContextRequestGeo Geo { get; set; }
+
+    /// <summary>
+    /// The hostname the request is for.
+    /// </summary>
+    [JsonPropertyName("hostname")]
+    public required string Hostname { get; set; }
+
+    /// <summary>
+    /// The custom domain used in the request (if any).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("custom_domain")]
+    public string? CustomDomain { get; set; }
+
+    /// <summary>
+    /// The originating IP address of the request.
+    /// </summary>
+    [JsonPropertyName("ip")]
+    public required string Ip { get; set; }
+
+    /// <summary>
+    /// The HTTP method used for the request.
+    /// </summary>
+    [JsonPropertyName("method")]
+    public required string Method { get; set; }
+
+    /// <summary>
+    /// The value of the `User-Agent` header.
+    /// </summary>
+    [JsonPropertyName("user_agent")]
+    public required string UserAgent { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextRequestGeo.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextRequestGeo.cs
@@ -1,0 +1,91 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Geographic information about the request origin.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventContextRequestGeo : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Continent code.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("continent_code")]
+    public string? ContinentCode { get; set; }
+
+    /// <summary>
+    /// Country code.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("country_code")]
+    public string? CountryCode { get; set; }
+
+    /// <summary>
+    /// Country name.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("country_name")]
+    public string? CountryName { get; set; }
+
+    /// <summary>
+    /// Latitude coordinate.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("latitude")]
+    public double? Latitude { get; set; }
+
+    /// <summary>
+    /// Longitude coordinate.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("longitude")]
+    public double? Longitude { get; set; }
+
+    /// <summary>
+    /// Subdivision (state/province) code.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("subdivision_code")]
+    public string? SubdivisionCode { get; set; }
+
+    /// <summary>
+    /// Subdivision (state/province) name.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("subdivision_name")]
+    public string? SubdivisionName { get; set; }
+
+    /// <summary>
+    /// City name.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("city_name")]
+    public string? CityName { get; set; }
+
+    /// <summary>
+    /// Time zone.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("time_zone")]
+    public string? TimeZone { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextTenant.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventContextTenant.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a tenant in event context
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventContextTenant : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Machine-generated unique tenant identifier.
+    /// </summary>
+    [JsonPropertyName("tenant_id")]
+    public required string TenantId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorCodeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorCodeEnum.cs
@@ -1,0 +1,144 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventErrorCodeEnum.EventStreamCloudEventErrorCodeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventErrorCodeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventErrorCodeEnum InvalidCursor = new(
+        Values.InvalidCursor
+    );
+
+    public static readonly EventStreamCloudEventErrorCodeEnum CursorExpired = new(
+        Values.CursorExpired
+    );
+
+    public static readonly EventStreamCloudEventErrorCodeEnum Timeout = new(Values.Timeout);
+
+    public static readonly EventStreamCloudEventErrorCodeEnum PayloadTooLarge = new(
+        Values.PayloadTooLarge
+    );
+
+    public static readonly EventStreamCloudEventErrorCodeEnum ProcessingError = new(
+        Values.ProcessingError
+    );
+
+    public static readonly EventStreamCloudEventErrorCodeEnum ConnectionTimeout = new(
+        Values.ConnectionTimeout
+    );
+
+    public EventStreamCloudEventErrorCodeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventErrorCodeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventErrorCodeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(EventStreamCloudEventErrorCodeEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(EventStreamCloudEventErrorCodeEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventErrorCodeEnum value) => value.Value;
+
+    public static explicit operator EventStreamCloudEventErrorCodeEnum(string value) => new(value);
+
+    internal class EventStreamCloudEventErrorCodeEnumSerializer
+        : JsonConverter<EventStreamCloudEventErrorCodeEnum>
+    {
+        public override EventStreamCloudEventErrorCodeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventErrorCodeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventErrorCodeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventErrorCodeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventErrorCodeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventErrorCodeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string InvalidCursor = "invalid_cursor";
+
+        public const string CursorExpired = "cursor_expired";
+
+        public const string Timeout = "timeout";
+
+        public const string PayloadTooLarge = "payload_too_large";
+
+        public const string ProcessingError = "processing_error";
+
+        public const string ConnectionTimeout = "connection_timeout";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorDetail.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorDetail.cs
@@ -1,0 +1,44 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Error details.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventErrorDetail : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("code")]
+    public required EventStreamCloudEventErrorCodeEnum Code { get; set; }
+
+    /// <summary>
+    /// Human-readable error message.
+    /// </summary>
+    [JsonPropertyName("message")]
+    public required string Message { get; set; }
+
+    /// <summary>
+    /// The cursor at the time of the error (when available). Can be used to resume from this position.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("offset")]
+    public string? Offset { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorMessage.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorMessage.cs
@@ -1,0 +1,31 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// An error message delivered via the SSE stream. The stream closes after this message.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventErrorMessage : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("error")]
+    public required EventStreamCloudEventErrorDetail Error { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorMessageTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventErrorMessageTypeEnum.cs
@@ -1,0 +1,120 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventErrorMessageTypeEnum.EventStreamCloudEventErrorMessageTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventErrorMessageTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventErrorMessageTypeEnum Error = new(Values.Error);
+
+    public EventStreamCloudEventErrorMessageTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventErrorMessageTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventErrorMessageTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventErrorMessageTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventErrorMessageTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventErrorMessageTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventErrorMessageTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventErrorMessageTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventErrorMessageTypeEnum>
+    {
+        public override EventStreamCloudEventErrorMessageTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventErrorMessageTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventErrorMessageTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventErrorMessageTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventErrorMessageTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventErrorMessageTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Error = "error";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreated.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreated.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for group.created.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupCreated : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventGroupCreatedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a group is created.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupCreatedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupCreatedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventGroupCreatedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupCreatedCloudEventTypeEnum.EventStreamCloudEventGroupCreatedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupCreatedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupCreatedCloudEventTypeEnum GroupCreated = new(
+        Values.GroupCreated
+    );
+
+    public EventStreamCloudEventGroupCreatedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupCreatedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupCreatedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupCreatedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupCreatedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupCreatedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupCreatedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupCreatedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventGroupCreatedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupCreatedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupCreated = "group.created";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupCreatedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventGroupCreatedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject.cs
@@ -1,0 +1,359 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupCreatedObject.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupCreatedObject
+{
+    private EventStreamCloudEventGroupCreatedObject(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedObject FromEventStreamCloudEventGroupCreatedObject0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0 value
+    ) => new("eventStreamCloudEventGroupCreatedObject0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedObject FromEventStreamCloudEventGroupCreatedObject1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1 value
+    ) => new("eventStreamCloudEventGroupCreatedObject1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedObject FromEventStreamCloudEventGroupCreatedObject2(
+        Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2 value
+    ) => new("eventStreamCloudEventGroupCreatedObject2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupCreatedObject0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupCreatedObject0() =>
+        Type == "eventStreamCloudEventGroupCreatedObject0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupCreatedObject1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupCreatedObject1() =>
+        Type == "eventStreamCloudEventGroupCreatedObject1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupCreatedObject2"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupCreatedObject2() =>
+        Type == "eventStreamCloudEventGroupCreatedObject2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupCreatedObject0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupCreatedObject0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0 AsEventStreamCloudEventGroupCreatedObject0() =>
+        IsEventStreamCloudEventGroupCreatedObject0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupCreatedObject0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupCreatedObject1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupCreatedObject1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1 AsEventStreamCloudEventGroupCreatedObject1() =>
+        IsEventStreamCloudEventGroupCreatedObject1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupCreatedObject1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupCreatedObject2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupCreatedObject2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2 AsEventStreamCloudEventGroupCreatedObject2() =>
+        IsEventStreamCloudEventGroupCreatedObject2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupCreatedObject2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupCreatedObject0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupCreatedObject0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupCreatedObject1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupCreatedObject1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupCreatedObject2(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupCreatedObject2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0,
+            T
+        > onEventStreamCloudEventGroupCreatedObject0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1,
+            T
+        > onEventStreamCloudEventGroupCreatedObject1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2,
+            T
+        > onEventStreamCloudEventGroupCreatedObject2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupCreatedObject0" =>
+                onEventStreamCloudEventGroupCreatedObject0(
+                    AsEventStreamCloudEventGroupCreatedObject0()
+                ),
+            "eventStreamCloudEventGroupCreatedObject1" =>
+                onEventStreamCloudEventGroupCreatedObject1(
+                    AsEventStreamCloudEventGroupCreatedObject1()
+                ),
+            "eventStreamCloudEventGroupCreatedObject2" =>
+                onEventStreamCloudEventGroupCreatedObject2(
+                    AsEventStreamCloudEventGroupCreatedObject2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0> onEventStreamCloudEventGroupCreatedObject0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1> onEventStreamCloudEventGroupCreatedObject1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2> onEventStreamCloudEventGroupCreatedObject2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupCreatedObject0":
+                onEventStreamCloudEventGroupCreatedObject0(
+                    AsEventStreamCloudEventGroupCreatedObject0()
+                );
+                break;
+            case "eventStreamCloudEventGroupCreatedObject1":
+                onEventStreamCloudEventGroupCreatedObject1(
+                    AsEventStreamCloudEventGroupCreatedObject1()
+                );
+                break;
+            case "eventStreamCloudEventGroupCreatedObject2":
+                onEventStreamCloudEventGroupCreatedObject2(
+                    AsEventStreamCloudEventGroupCreatedObject2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupCreatedObject other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupCreatedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0 value
+    ) => new("eventStreamCloudEventGroupCreatedObject0", value);
+
+    public static implicit operator EventStreamCloudEventGroupCreatedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1 value
+    ) => new("eventStreamCloudEventGroupCreatedObject1", value);
+
+    public static implicit operator EventStreamCloudEventGroupCreatedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2 value
+    ) => new("eventStreamCloudEventGroupCreatedObject2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter : JsonConverter<EventStreamCloudEventGroupCreatedObject>
+    {
+        public override EventStreamCloudEventGroupCreatedObject? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupCreatedObject0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupCreatedObject1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject1)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupCreatedObject2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupCreatedObject2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupCreatedObject result = new(key, value);
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupCreatedObject"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupCreatedObject ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupCreatedObject result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject0.cs
@@ -1,0 +1,62 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents a connection group entity.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupCreatedObject0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupCreatedObject0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject0TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupCreatedObject0TypeEnum.EventStreamCloudEventGroupCreatedObject0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupCreatedObject0TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupCreatedObject0TypeEnum Connection = new(
+        Values.Connection
+    );
+
+    public EventStreamCloudEventGroupCreatedObject0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedObject0TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupCreatedObject0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupCreatedObject0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupCreatedObject0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupCreatedObject0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupCreatedObject0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupCreatedObject0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupCreatedObject0TypeEnum>
+    {
+        public override EventStreamCloudEventGroupCreatedObject0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedObject0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupCreatedObject0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedObject0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject1.cs
@@ -1,0 +1,62 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an organization group entity.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupCreatedObject1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupCreatedObject1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject1TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupCreatedObject1TypeEnum.EventStreamCloudEventGroupCreatedObject1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupCreatedObject1TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupCreatedObject1TypeEnum Organization = new(
+        Values.Organization
+    );
+
+    public EventStreamCloudEventGroupCreatedObject1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedObject1TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupCreatedObject1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupCreatedObject1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupCreatedObject1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupCreatedObject1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupCreatedObject1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupCreatedObject1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupCreatedObject1TypeEnum>
+    {
+        public override EventStreamCloudEventGroupCreatedObject1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedObject1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupCreatedObject1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedObject1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject2.cs
@@ -1,0 +1,56 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents a tenant group entity.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupCreatedObject2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupCreatedObject2TypeEnum Type { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedObject2TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupCreatedObject2TypeEnum.EventStreamCloudEventGroupCreatedObject2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupCreatedObject2TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupCreatedObject2TypeEnum Tenant = new(
+        Values.Tenant
+    );
+
+    public EventStreamCloudEventGroupCreatedObject2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedObject2TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupCreatedObject2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupCreatedObject2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupCreatedObject2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupCreatedObject2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupCreatedObject2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupCreatedObject2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupCreatedObject2TypeEnum>
+    {
+        public override EventStreamCloudEventGroupCreatedObject2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedObject2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupCreatedObject2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedObject2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedObject2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupCreatedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupCreatedTypeEnum.EventStreamCloudEventGroupCreatedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupCreatedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupCreatedTypeEnum GroupCreated = new(
+        Values.GroupCreated
+    );
+
+    public EventStreamCloudEventGroupCreatedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupCreatedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupCreatedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupCreatedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupCreatedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventGroupCreatedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupCreatedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventGroupCreatedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupCreatedTypeEnum>
+    {
+        public override EventStreamCloudEventGroupCreatedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupCreatedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupCreatedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupCreatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupCreated = "group.created";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for group.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventGroupDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a group is deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventGroupDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupDeletedCloudEventTypeEnum.EventStreamCloudEventGroupDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupDeletedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupDeletedCloudEventTypeEnum GroupDeleted = new(
+        Values.GroupDeleted
+    );
+
+    public EventStreamCloudEventGroupDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventGroupDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupDeleted = "group.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventGroupDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject.cs
@@ -1,0 +1,359 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupDeletedObject.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupDeletedObject
+{
+    private EventStreamCloudEventGroupDeletedObject(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedObject FromEventStreamCloudEventGroupDeletedObject0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0 value
+    ) => new("eventStreamCloudEventGroupDeletedObject0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedObject FromEventStreamCloudEventGroupDeletedObject1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1 value
+    ) => new("eventStreamCloudEventGroupDeletedObject1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedObject FromEventStreamCloudEventGroupDeletedObject2(
+        Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2 value
+    ) => new("eventStreamCloudEventGroupDeletedObject2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupDeletedObject0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupDeletedObject0() =>
+        Type == "eventStreamCloudEventGroupDeletedObject0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupDeletedObject1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupDeletedObject1() =>
+        Type == "eventStreamCloudEventGroupDeletedObject1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupDeletedObject2"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupDeletedObject2() =>
+        Type == "eventStreamCloudEventGroupDeletedObject2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupDeletedObject0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupDeletedObject0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0 AsEventStreamCloudEventGroupDeletedObject0() =>
+        IsEventStreamCloudEventGroupDeletedObject0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupDeletedObject0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupDeletedObject1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupDeletedObject1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1 AsEventStreamCloudEventGroupDeletedObject1() =>
+        IsEventStreamCloudEventGroupDeletedObject1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupDeletedObject1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupDeletedObject2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupDeletedObject2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2 AsEventStreamCloudEventGroupDeletedObject2() =>
+        IsEventStreamCloudEventGroupDeletedObject2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupDeletedObject2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupDeletedObject0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupDeletedObject0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupDeletedObject1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupDeletedObject1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupDeletedObject2(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupDeletedObject2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0,
+            T
+        > onEventStreamCloudEventGroupDeletedObject0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1,
+            T
+        > onEventStreamCloudEventGroupDeletedObject1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2,
+            T
+        > onEventStreamCloudEventGroupDeletedObject2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupDeletedObject0" =>
+                onEventStreamCloudEventGroupDeletedObject0(
+                    AsEventStreamCloudEventGroupDeletedObject0()
+                ),
+            "eventStreamCloudEventGroupDeletedObject1" =>
+                onEventStreamCloudEventGroupDeletedObject1(
+                    AsEventStreamCloudEventGroupDeletedObject1()
+                ),
+            "eventStreamCloudEventGroupDeletedObject2" =>
+                onEventStreamCloudEventGroupDeletedObject2(
+                    AsEventStreamCloudEventGroupDeletedObject2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0> onEventStreamCloudEventGroupDeletedObject0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1> onEventStreamCloudEventGroupDeletedObject1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2> onEventStreamCloudEventGroupDeletedObject2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupDeletedObject0":
+                onEventStreamCloudEventGroupDeletedObject0(
+                    AsEventStreamCloudEventGroupDeletedObject0()
+                );
+                break;
+            case "eventStreamCloudEventGroupDeletedObject1":
+                onEventStreamCloudEventGroupDeletedObject1(
+                    AsEventStreamCloudEventGroupDeletedObject1()
+                );
+                break;
+            case "eventStreamCloudEventGroupDeletedObject2":
+                onEventStreamCloudEventGroupDeletedObject2(
+                    AsEventStreamCloudEventGroupDeletedObject2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupDeletedObject other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupDeletedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0 value
+    ) => new("eventStreamCloudEventGroupDeletedObject0", value);
+
+    public static implicit operator EventStreamCloudEventGroupDeletedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1 value
+    ) => new("eventStreamCloudEventGroupDeletedObject1", value);
+
+    public static implicit operator EventStreamCloudEventGroupDeletedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2 value
+    ) => new("eventStreamCloudEventGroupDeletedObject2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter : JsonConverter<EventStreamCloudEventGroupDeletedObject>
+    {
+        public override EventStreamCloudEventGroupDeletedObject? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupDeletedObject0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupDeletedObject1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject1)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupDeletedObject2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupDeletedObject2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupDeletedObject result = new(key, value);
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupDeletedObject"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupDeletedObject ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupDeletedObject result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject0.cs
@@ -1,0 +1,68 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Connection group with updated_at timestamp
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupDeletedObject0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupDeletedObject0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject0TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupDeletedObject0TypeEnum.EventStreamCloudEventGroupDeletedObject0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupDeletedObject0TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupDeletedObject0TypeEnum Connection = new(
+        Values.Connection
+    );
+
+    public EventStreamCloudEventGroupDeletedObject0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedObject0TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupDeletedObject0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupDeletedObject0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupDeletedObject0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupDeletedObject0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupDeletedObject0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupDeletedObject0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupDeletedObject0TypeEnum>
+    {
+        public override EventStreamCloudEventGroupDeletedObject0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedObject0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupDeletedObject0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedObject0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject1.cs
@@ -1,0 +1,68 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Organization group with updated_at timestamp
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupDeletedObject1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupDeletedObject1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject1TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupDeletedObject1TypeEnum.EventStreamCloudEventGroupDeletedObject1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupDeletedObject1TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupDeletedObject1TypeEnum Organization = new(
+        Values.Organization
+    );
+
+    public EventStreamCloudEventGroupDeletedObject1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedObject1TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupDeletedObject1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupDeletedObject1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupDeletedObject1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupDeletedObject1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupDeletedObject1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupDeletedObject1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupDeletedObject1TypeEnum>
+    {
+        public override EventStreamCloudEventGroupDeletedObject1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedObject1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupDeletedObject1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedObject1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject2.cs
@@ -1,0 +1,62 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Tenant group with updated_at timestamp
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupDeletedObject2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupDeletedObject2TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedObject2TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupDeletedObject2TypeEnum.EventStreamCloudEventGroupDeletedObject2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupDeletedObject2TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupDeletedObject2TypeEnum Tenant = new(
+        Values.Tenant
+    );
+
+    public EventStreamCloudEventGroupDeletedObject2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedObject2TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupDeletedObject2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupDeletedObject2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupDeletedObject2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupDeletedObject2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupDeletedObject2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupDeletedObject2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupDeletedObject2TypeEnum>
+    {
+        public override EventStreamCloudEventGroupDeletedObject2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedObject2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupDeletedObject2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedObject2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedObject2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupDeletedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupDeletedTypeEnum.EventStreamCloudEventGroupDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupDeletedTypeEnum GroupDeleted = new(
+        Values.GroupDeleted
+    );
+
+    public EventStreamCloudEventGroupDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupDeletedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupDeletedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventGroupDeletedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupDeletedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventGroupDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventGroupDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupDeleted = "group.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAdded.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAdded.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for group.member.added.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAdded : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventGroupMemberAddedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a member is added to a group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventGroupMemberAddedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum.EventStreamCloudEventGroupMemberAddedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum GroupMemberAdded =
+        new(Values.GroupMemberAdded);
+
+    public EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberAddedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupMemberAdded = "group.member.added";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventGroupMemberAddedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObject.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("group")]
+    public required EventStreamCloudEventGroupMemberAddedObjectGroup Group { get; set; }
+
+    [JsonPropertyName("member")]
+    public required EventStreamCloudEventGroupMemberAddedObjectMember Member { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup.cs
@@ -1,0 +1,363 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The group the member belongs to.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupMemberAddedObjectGroup.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupMemberAddedObjectGroup
+{
+    private EventStreamCloudEventGroupMemberAddedObjectGroup(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectGroup FromEventStreamCloudEventGroupMemberAddedObjectGroup0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectGroup0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectGroup FromEventStreamCloudEventGroupMemberAddedObjectGroup1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectGroup1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectGroup FromEventStreamCloudEventGroupMemberAddedObjectGroup2(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectGroup2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberAddedObjectGroup0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberAddedObjectGroup0() =>
+        Type == "eventStreamCloudEventGroupMemberAddedObjectGroup0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberAddedObjectGroup1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberAddedObjectGroup1() =>
+        Type == "eventStreamCloudEventGroupMemberAddedObjectGroup1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberAddedObjectGroup2"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberAddedObjectGroup2() =>
+        Type == "eventStreamCloudEventGroupMemberAddedObjectGroup2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberAddedObjectGroup0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberAddedObjectGroup0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0 AsEventStreamCloudEventGroupMemberAddedObjectGroup0() =>
+        IsEventStreamCloudEventGroupMemberAddedObjectGroup0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberAddedObjectGroup0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberAddedObjectGroup1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberAddedObjectGroup1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1 AsEventStreamCloudEventGroupMemberAddedObjectGroup1() =>
+        IsEventStreamCloudEventGroupMemberAddedObjectGroup1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberAddedObjectGroup1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberAddedObjectGroup2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberAddedObjectGroup2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2 AsEventStreamCloudEventGroupMemberAddedObjectGroup2() =>
+        IsEventStreamCloudEventGroupMemberAddedObjectGroup2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberAddedObjectGroup2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberAddedObjectGroup0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberAddedObjectGroup0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberAddedObjectGroup1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberAddedObjectGroup1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberAddedObjectGroup2(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberAddedObjectGroup2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0,
+            T
+        > onEventStreamCloudEventGroupMemberAddedObjectGroup0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1,
+            T
+        > onEventStreamCloudEventGroupMemberAddedObjectGroup1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2,
+            T
+        > onEventStreamCloudEventGroupMemberAddedObjectGroup2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupMemberAddedObjectGroup0" =>
+                onEventStreamCloudEventGroupMemberAddedObjectGroup0(
+                    AsEventStreamCloudEventGroupMemberAddedObjectGroup0()
+                ),
+            "eventStreamCloudEventGroupMemberAddedObjectGroup1" =>
+                onEventStreamCloudEventGroupMemberAddedObjectGroup1(
+                    AsEventStreamCloudEventGroupMemberAddedObjectGroup1()
+                ),
+            "eventStreamCloudEventGroupMemberAddedObjectGroup2" =>
+                onEventStreamCloudEventGroupMemberAddedObjectGroup2(
+                    AsEventStreamCloudEventGroupMemberAddedObjectGroup2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0> onEventStreamCloudEventGroupMemberAddedObjectGroup0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1> onEventStreamCloudEventGroupMemberAddedObjectGroup1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2> onEventStreamCloudEventGroupMemberAddedObjectGroup2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupMemberAddedObjectGroup0":
+                onEventStreamCloudEventGroupMemberAddedObjectGroup0(
+                    AsEventStreamCloudEventGroupMemberAddedObjectGroup0()
+                );
+                break;
+            case "eventStreamCloudEventGroupMemberAddedObjectGroup1":
+                onEventStreamCloudEventGroupMemberAddedObjectGroup1(
+                    AsEventStreamCloudEventGroupMemberAddedObjectGroup1()
+                );
+                break;
+            case "eventStreamCloudEventGroupMemberAddedObjectGroup2":
+                onEventStreamCloudEventGroupMemberAddedObjectGroup2(
+                    AsEventStreamCloudEventGroupMemberAddedObjectGroup2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupMemberAddedObjectGroup other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupMemberAddedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectGroup0", value);
+
+    public static implicit operator EventStreamCloudEventGroupMemberAddedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectGroup1", value);
+
+    public static implicit operator EventStreamCloudEventGroupMemberAddedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectGroup2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedObjectGroup>
+    {
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupMemberAddedObjectGroup0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupMemberAddedObjectGroup1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup1)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupMemberAddedObjectGroup2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectGroup2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupMemberAddedObjectGroup result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupMemberAddedObjectGroup"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupMemberAddedObjectGroup result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup0.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a connection group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedObjectGroup0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum.EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup1.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to an organization group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedObjectGroup1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum.EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum Organization =
+        new(Values.Organization);
+
+    public EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup2.cs
@@ -1,0 +1,44 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a tenant group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedObjectGroup2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum Type { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum.cs
@@ -1,0 +1,125 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum.EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum Tenant = new(
+        Values.Tenant
+    );
+
+    public EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember.cs
@@ -1,0 +1,300 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The member that is a part of the group.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupMemberAddedObjectMember.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupMemberAddedObjectMember
+{
+    private EventStreamCloudEventGroupMemberAddedObjectMember(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectMember FromEventStreamCloudEventGroupMemberAddedObjectMember0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectMember0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectMember FromEventStreamCloudEventGroupMemberAddedObjectMember1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectMember1", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberAddedObjectMember0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberAddedObjectMember0() =>
+        Type == "eventStreamCloudEventGroupMemberAddedObjectMember0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberAddedObjectMember1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberAddedObjectMember1() =>
+        Type == "eventStreamCloudEventGroupMemberAddedObjectMember1";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberAddedObjectMember0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberAddedObjectMember0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0 AsEventStreamCloudEventGroupMemberAddedObjectMember0() =>
+        IsEventStreamCloudEventGroupMemberAddedObjectMember0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberAddedObjectMember0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberAddedObjectMember1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberAddedObjectMember1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1 AsEventStreamCloudEventGroupMemberAddedObjectMember1() =>
+        IsEventStreamCloudEventGroupMemberAddedObjectMember1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberAddedObjectMember1'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberAddedObjectMember0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberAddedObjectMember0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberAddedObjectMember1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberAddedObjectMember1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0,
+            T
+        > onEventStreamCloudEventGroupMemberAddedObjectMember0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1,
+            T
+        > onEventStreamCloudEventGroupMemberAddedObjectMember1
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupMemberAddedObjectMember0" =>
+                onEventStreamCloudEventGroupMemberAddedObjectMember0(
+                    AsEventStreamCloudEventGroupMemberAddedObjectMember0()
+                ),
+            "eventStreamCloudEventGroupMemberAddedObjectMember1" =>
+                onEventStreamCloudEventGroupMemberAddedObjectMember1(
+                    AsEventStreamCloudEventGroupMemberAddedObjectMember1()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0> onEventStreamCloudEventGroupMemberAddedObjectMember0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1> onEventStreamCloudEventGroupMemberAddedObjectMember1
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupMemberAddedObjectMember0":
+                onEventStreamCloudEventGroupMemberAddedObjectMember0(
+                    AsEventStreamCloudEventGroupMemberAddedObjectMember0()
+                );
+                break;
+            case "eventStreamCloudEventGroupMemberAddedObjectMember1":
+                onEventStreamCloudEventGroupMemberAddedObjectMember1(
+                    AsEventStreamCloudEventGroupMemberAddedObjectMember1()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupMemberAddedObjectMember other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupMemberAddedObjectMember(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectMember0", value);
+
+    public static implicit operator EventStreamCloudEventGroupMemberAddedObjectMember(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1 value
+    ) => new("eventStreamCloudEventGroupMemberAddedObjectMember1", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedObjectMember>
+    {
+        public override EventStreamCloudEventGroupMemberAddedObjectMember? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupMemberAddedObjectMember0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupMemberAddedObjectMember1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberAddedObjectMember1)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupMemberAddedObjectMember result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupMemberAddedObjectMember"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectMember value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedObjectMember ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupMemberAddedObjectMember result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectMember value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember0.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// A group member of member_type user
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedObjectMember0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("member_type")]
+    public required EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum MemberType { get; set; }
+
+    /// <summary>
+    /// The user's unique identifier
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum.EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum User =
+        new(Values.User);
+
+    public EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectMember0MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string User = "user";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember1.cs
@@ -1,0 +1,49 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// A group member of member_type group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberAddedObjectMember1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("member_type")]
+    public required EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum MemberType { get; set; }
+
+    /// <summary>
+    /// The connection member's unique identifier
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The type of the connection
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
+
+    /// <summary>
+    /// Connection ID associated with the member
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum.EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedObjectMember1MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberAddedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberAddedTypeEnum.EventStreamCloudEventGroupMemberAddedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberAddedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberAddedTypeEnum GroupMemberAdded = new(
+        Values.GroupMemberAdded
+    );
+
+    public EventStreamCloudEventGroupMemberAddedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberAddedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupMemberAddedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberAddedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberAddedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventGroupMemberAddedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberAddedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventGroupMemberAddedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberAddedTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberAddedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberAddedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberAddedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberAddedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupMemberAdded = "group.member.added";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for group.member.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventGroupMemberDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a member is removed from a group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventGroupMemberDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum.EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum GroupMemberDeleted =
+        new(Values.GroupMemberDeleted);
+
+    public EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupMemberDeleted = "group.member.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventGroupMemberDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObject.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("group")]
+    public required EventStreamCloudEventGroupMemberDeletedObjectGroup Group { get; set; }
+
+    [JsonPropertyName("member")]
+    public required EventStreamCloudEventGroupMemberDeletedObjectMember Member { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup.cs
@@ -1,0 +1,363 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The group the member belongs to.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupMemberDeletedObjectGroup.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupMemberDeletedObjectGroup
+{
+    private EventStreamCloudEventGroupMemberDeletedObjectGroup(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectGroup FromEventStreamCloudEventGroupMemberDeletedObjectGroup0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectGroup0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectGroup FromEventStreamCloudEventGroupMemberDeletedObjectGroup1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectGroup1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectGroup FromEventStreamCloudEventGroupMemberDeletedObjectGroup2(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectGroup2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberDeletedObjectGroup0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberDeletedObjectGroup0() =>
+        Type == "eventStreamCloudEventGroupMemberDeletedObjectGroup0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberDeletedObjectGroup1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberDeletedObjectGroup1() =>
+        Type == "eventStreamCloudEventGroupMemberDeletedObjectGroup1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberDeletedObjectGroup2"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberDeletedObjectGroup2() =>
+        Type == "eventStreamCloudEventGroupMemberDeletedObjectGroup2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberDeletedObjectGroup0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberDeletedObjectGroup0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0 AsEventStreamCloudEventGroupMemberDeletedObjectGroup0() =>
+        IsEventStreamCloudEventGroupMemberDeletedObjectGroup0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberDeletedObjectGroup0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberDeletedObjectGroup1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberDeletedObjectGroup1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1 AsEventStreamCloudEventGroupMemberDeletedObjectGroup1() =>
+        IsEventStreamCloudEventGroupMemberDeletedObjectGroup1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberDeletedObjectGroup1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberDeletedObjectGroup2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberDeletedObjectGroup2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2 AsEventStreamCloudEventGroupMemberDeletedObjectGroup2() =>
+        IsEventStreamCloudEventGroupMemberDeletedObjectGroup2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberDeletedObjectGroup2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberDeletedObjectGroup0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberDeletedObjectGroup0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberDeletedObjectGroup1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberDeletedObjectGroup1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberDeletedObjectGroup2(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberDeletedObjectGroup2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0,
+            T
+        > onEventStreamCloudEventGroupMemberDeletedObjectGroup0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1,
+            T
+        > onEventStreamCloudEventGroupMemberDeletedObjectGroup1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2,
+            T
+        > onEventStreamCloudEventGroupMemberDeletedObjectGroup2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupMemberDeletedObjectGroup0" =>
+                onEventStreamCloudEventGroupMemberDeletedObjectGroup0(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectGroup0()
+                ),
+            "eventStreamCloudEventGroupMemberDeletedObjectGroup1" =>
+                onEventStreamCloudEventGroupMemberDeletedObjectGroup1(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectGroup1()
+                ),
+            "eventStreamCloudEventGroupMemberDeletedObjectGroup2" =>
+                onEventStreamCloudEventGroupMemberDeletedObjectGroup2(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectGroup2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0> onEventStreamCloudEventGroupMemberDeletedObjectGroup0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1> onEventStreamCloudEventGroupMemberDeletedObjectGroup1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2> onEventStreamCloudEventGroupMemberDeletedObjectGroup2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupMemberDeletedObjectGroup0":
+                onEventStreamCloudEventGroupMemberDeletedObjectGroup0(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectGroup0()
+                );
+                break;
+            case "eventStreamCloudEventGroupMemberDeletedObjectGroup1":
+                onEventStreamCloudEventGroupMemberDeletedObjectGroup1(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectGroup1()
+                );
+                break;
+            case "eventStreamCloudEventGroupMemberDeletedObjectGroup2":
+                onEventStreamCloudEventGroupMemberDeletedObjectGroup2(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectGroup2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupMemberDeletedObjectGroup other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupMemberDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectGroup0", value);
+
+    public static implicit operator EventStreamCloudEventGroupMemberDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectGroup1", value);
+
+    public static implicit operator EventStreamCloudEventGroupMemberDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectGroup2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedObjectGroup>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupMemberDeletedObjectGroup0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupMemberDeletedObjectGroup1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup1)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupMemberDeletedObjectGroup2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectGroup2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupMemberDeletedObjectGroup result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupMemberDeletedObjectGroup"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupMemberDeletedObjectGroup result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup0.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a connection group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedObjectGroup0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum.EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup1.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to an organization group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedObjectGroup1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum.EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum Organization =
+        new(Values.Organization);
+
+    public EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup2.cs
@@ -1,0 +1,44 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a tenant group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedObjectGroup2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum Type { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum.cs
@@ -1,0 +1,127 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum.EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum Tenant = new(
+        Values.Tenant
+    );
+
+    public EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember.cs
@@ -1,0 +1,302 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The member that is a part of the group.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupMemberDeletedObjectMember.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupMemberDeletedObjectMember
+{
+    private EventStreamCloudEventGroupMemberDeletedObjectMember(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectMember FromEventStreamCloudEventGroupMemberDeletedObjectMember0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectMember0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectMember FromEventStreamCloudEventGroupMemberDeletedObjectMember1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectMember1", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberDeletedObjectMember0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberDeletedObjectMember0() =>
+        Type == "eventStreamCloudEventGroupMemberDeletedObjectMember0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupMemberDeletedObjectMember1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupMemberDeletedObjectMember1() =>
+        Type == "eventStreamCloudEventGroupMemberDeletedObjectMember1";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberDeletedObjectMember0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberDeletedObjectMember0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0 AsEventStreamCloudEventGroupMemberDeletedObjectMember0() =>
+        IsEventStreamCloudEventGroupMemberDeletedObjectMember0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberDeletedObjectMember0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupMemberDeletedObjectMember1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupMemberDeletedObjectMember1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1 AsEventStreamCloudEventGroupMemberDeletedObjectMember1() =>
+        IsEventStreamCloudEventGroupMemberDeletedObjectMember1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupMemberDeletedObjectMember1'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberDeletedObjectMember0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberDeletedObjectMember0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupMemberDeletedObjectMember1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupMemberDeletedObjectMember1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0,
+            T
+        > onEventStreamCloudEventGroupMemberDeletedObjectMember0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1,
+            T
+        > onEventStreamCloudEventGroupMemberDeletedObjectMember1
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupMemberDeletedObjectMember0" =>
+                onEventStreamCloudEventGroupMemberDeletedObjectMember0(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectMember0()
+                ),
+            "eventStreamCloudEventGroupMemberDeletedObjectMember1" =>
+                onEventStreamCloudEventGroupMemberDeletedObjectMember1(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectMember1()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0> onEventStreamCloudEventGroupMemberDeletedObjectMember0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1> onEventStreamCloudEventGroupMemberDeletedObjectMember1
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupMemberDeletedObjectMember0":
+                onEventStreamCloudEventGroupMemberDeletedObjectMember0(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectMember0()
+                );
+                break;
+            case "eventStreamCloudEventGroupMemberDeletedObjectMember1":
+                onEventStreamCloudEventGroupMemberDeletedObjectMember1(
+                    AsEventStreamCloudEventGroupMemberDeletedObjectMember1()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupMemberDeletedObjectMember other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupMemberDeletedObjectMember(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectMember0", value);
+
+    public static implicit operator EventStreamCloudEventGroupMemberDeletedObjectMember(
+        Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1 value
+    ) => new("eventStreamCloudEventGroupMemberDeletedObjectMember1", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedObjectMember>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedObjectMember? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupMemberDeletedObjectMember0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupMemberDeletedObjectMember1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeletedObjectMember1)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupMemberDeletedObjectMember result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupMemberDeletedObjectMember"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectMember value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedObjectMember ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupMemberDeletedObjectMember result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectMember value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember0.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// A group member of member_type user
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedObjectMember0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("member_type")]
+    public required EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum MemberType { get; set; }
+
+    /// <summary>
+    /// The user's unique identifier
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum.EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum User =
+        new(Values.User);
+
+    public EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectMember0MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string User = "user";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember1.cs
@@ -1,0 +1,49 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// A group member of member_type group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupMemberDeletedObjectMember1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("member_type")]
+    public required EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum MemberType { get; set; }
+
+    /// <summary>
+    /// The connection member's unique identifier
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The type of the connection
+    /// </summary>
+    [JsonPropertyName("type")]
+    public required string Type { get; set; }
+
+    /// <summary>
+    /// Connection ID associated with the member
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum.EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedObjectMember1MemberTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupMemberDeletedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupMemberDeletedTypeEnum.EventStreamCloudEventGroupMemberDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupMemberDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupMemberDeletedTypeEnum GroupMemberDeleted = new(
+        Values.GroupMemberDeleted
+    );
+
+    public EventStreamCloudEventGroupMemberDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupMemberDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupMemberDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupMemberDeletedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupMemberDeletedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventGroupMemberDeletedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupMemberDeletedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventGroupMemberDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupMemberDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventGroupMemberDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupMemberDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupMemberDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupMemberDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupMemberDeleted = "group.member.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssigned.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssigned.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for group.role.assigned.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssigned : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventGroupRoleAssignedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a role is assigned to a group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssignedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventGroupRoleAssignedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum.EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum GroupRoleAssigned =
+        new(Values.GroupRoleAssigned);
+
+    public EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupRoleAssigned = "group.role.assigned";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssignedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventGroupRoleAssignedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObject.cs
@@ -1,0 +1,40 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssignedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("group")]
+    public required EventStreamCloudEventGroupRoleAssignedObjectGroup Group { get; set; }
+
+    [JsonPropertyName("role")]
+    public required EventStreamCloudEventGroupRoleAssignedObjectRole Role { get; set; }
+
+    /// <summary>
+    /// The time at which the role was assigned to the group.
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup.cs
@@ -1,0 +1,363 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The group the role is assigned to.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupRoleAssignedObjectGroup.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupRoleAssignedObjectGroup
+{
+    private EventStreamCloudEventGroupRoleAssignedObjectGroup(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedObjectGroup FromEventStreamCloudEventGroupRoleAssignedObjectGroup0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupRoleAssignedObjectGroup0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedObjectGroup FromEventStreamCloudEventGroupRoleAssignedObjectGroup1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupRoleAssignedObjectGroup1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedObjectGroup FromEventStreamCloudEventGroupRoleAssignedObjectGroup2(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupRoleAssignedObjectGroup2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupRoleAssignedObjectGroup0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupRoleAssignedObjectGroup0() =>
+        Type == "eventStreamCloudEventGroupRoleAssignedObjectGroup0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupRoleAssignedObjectGroup1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupRoleAssignedObjectGroup1() =>
+        Type == "eventStreamCloudEventGroupRoleAssignedObjectGroup1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupRoleAssignedObjectGroup2"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupRoleAssignedObjectGroup2() =>
+        Type == "eventStreamCloudEventGroupRoleAssignedObjectGroup2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupRoleAssignedObjectGroup0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupRoleAssignedObjectGroup0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0 AsEventStreamCloudEventGroupRoleAssignedObjectGroup0() =>
+        IsEventStreamCloudEventGroupRoleAssignedObjectGroup0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupRoleAssignedObjectGroup0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupRoleAssignedObjectGroup1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupRoleAssignedObjectGroup1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1 AsEventStreamCloudEventGroupRoleAssignedObjectGroup1() =>
+        IsEventStreamCloudEventGroupRoleAssignedObjectGroup1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupRoleAssignedObjectGroup1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupRoleAssignedObjectGroup2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupRoleAssignedObjectGroup2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2 AsEventStreamCloudEventGroupRoleAssignedObjectGroup2() =>
+        IsEventStreamCloudEventGroupRoleAssignedObjectGroup2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupRoleAssignedObjectGroup2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupRoleAssignedObjectGroup0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupRoleAssignedObjectGroup0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupRoleAssignedObjectGroup1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupRoleAssignedObjectGroup1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupRoleAssignedObjectGroup2(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupRoleAssignedObjectGroup2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0,
+            T
+        > onEventStreamCloudEventGroupRoleAssignedObjectGroup0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1,
+            T
+        > onEventStreamCloudEventGroupRoleAssignedObjectGroup1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2,
+            T
+        > onEventStreamCloudEventGroupRoleAssignedObjectGroup2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupRoleAssignedObjectGroup0" =>
+                onEventStreamCloudEventGroupRoleAssignedObjectGroup0(
+                    AsEventStreamCloudEventGroupRoleAssignedObjectGroup0()
+                ),
+            "eventStreamCloudEventGroupRoleAssignedObjectGroup1" =>
+                onEventStreamCloudEventGroupRoleAssignedObjectGroup1(
+                    AsEventStreamCloudEventGroupRoleAssignedObjectGroup1()
+                ),
+            "eventStreamCloudEventGroupRoleAssignedObjectGroup2" =>
+                onEventStreamCloudEventGroupRoleAssignedObjectGroup2(
+                    AsEventStreamCloudEventGroupRoleAssignedObjectGroup2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0> onEventStreamCloudEventGroupRoleAssignedObjectGroup0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1> onEventStreamCloudEventGroupRoleAssignedObjectGroup1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2> onEventStreamCloudEventGroupRoleAssignedObjectGroup2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupRoleAssignedObjectGroup0":
+                onEventStreamCloudEventGroupRoleAssignedObjectGroup0(
+                    AsEventStreamCloudEventGroupRoleAssignedObjectGroup0()
+                );
+                break;
+            case "eventStreamCloudEventGroupRoleAssignedObjectGroup1":
+                onEventStreamCloudEventGroupRoleAssignedObjectGroup1(
+                    AsEventStreamCloudEventGroupRoleAssignedObjectGroup1()
+                );
+                break;
+            case "eventStreamCloudEventGroupRoleAssignedObjectGroup2":
+                onEventStreamCloudEventGroupRoleAssignedObjectGroup2(
+                    AsEventStreamCloudEventGroupRoleAssignedObjectGroup2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupRoleAssignedObjectGroup other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupRoleAssignedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupRoleAssignedObjectGroup0", value);
+
+    public static implicit operator EventStreamCloudEventGroupRoleAssignedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupRoleAssignedObjectGroup1", value);
+
+    public static implicit operator EventStreamCloudEventGroupRoleAssignedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupRoleAssignedObjectGroup2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventGroupRoleAssignedObjectGroup>
+    {
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupRoleAssignedObjectGroup0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupRoleAssignedObjectGroup1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup1)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupRoleAssignedObjectGroup2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssignedObjectGroup2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupRoleAssignedObjectGroup result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupRoleAssignedObjectGroup"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupRoleAssignedObjectGroup result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup0.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a connection group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssignedObjectGroup0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum.EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup1.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to an organization group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssignedObjectGroup1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum.EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum Organization =
+        new(Values.Organization);
+
+    public EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup2.cs
@@ -1,0 +1,44 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a tenant group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssignedObjectGroup2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum Type { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum.cs
@@ -1,0 +1,127 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum.EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum Tenant = new(
+        Values.Tenant
+    );
+
+    public EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectRole.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedObjectRole.cs
@@ -1,0 +1,40 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The role assigned to the group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleAssignedObjectRole : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the role.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleAssignedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleAssignedTypeEnum.EventStreamCloudEventGroupRoleAssignedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleAssignedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleAssignedTypeEnum GroupRoleAssigned = new(
+        Values.GroupRoleAssigned
+    );
+
+    public EventStreamCloudEventGroupRoleAssignedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleAssignedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupRoleAssignedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleAssignedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleAssignedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventGroupRoleAssignedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleAssignedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventGroupRoleAssignedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleAssignedTypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleAssignedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleAssignedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleAssignedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleAssignedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupRoleAssigned = "group.role.assigned";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for group.role.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventGroupRoleDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a role is removed from a group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventGroupRoleDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum.EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum GroupRoleDeleted =
+        new(Values.GroupRoleDeleted);
+
+    public EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupRoleDeleted = "group.role.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventGroupRoleDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObject.cs
@@ -1,0 +1,40 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeletedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("group")]
+    public required EventStreamCloudEventGroupRoleDeletedObjectGroup Group { get; set; }
+
+    [JsonPropertyName("role")]
+    public required EventStreamCloudEventGroupRoleDeletedObjectRole Role { get; set; }
+
+    /// <summary>
+    /// The time at which the role was removed from the group.
+    /// </summary>
+    [JsonPropertyName("deleted_at")]
+    public required DateTime DeletedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup.cs
@@ -1,0 +1,363 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The group the role is removed from.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupRoleDeletedObjectGroup.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupRoleDeletedObjectGroup
+{
+    private EventStreamCloudEventGroupRoleDeletedObjectGroup(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedObjectGroup FromEventStreamCloudEventGroupRoleDeletedObjectGroup0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupRoleDeletedObjectGroup0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedObjectGroup FromEventStreamCloudEventGroupRoleDeletedObjectGroup1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupRoleDeletedObjectGroup1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedObjectGroup FromEventStreamCloudEventGroupRoleDeletedObjectGroup2(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupRoleDeletedObjectGroup2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupRoleDeletedObjectGroup0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupRoleDeletedObjectGroup0() =>
+        Type == "eventStreamCloudEventGroupRoleDeletedObjectGroup0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupRoleDeletedObjectGroup1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupRoleDeletedObjectGroup1() =>
+        Type == "eventStreamCloudEventGroupRoleDeletedObjectGroup1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupRoleDeletedObjectGroup2"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupRoleDeletedObjectGroup2() =>
+        Type == "eventStreamCloudEventGroupRoleDeletedObjectGroup2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupRoleDeletedObjectGroup0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupRoleDeletedObjectGroup0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0 AsEventStreamCloudEventGroupRoleDeletedObjectGroup0() =>
+        IsEventStreamCloudEventGroupRoleDeletedObjectGroup0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupRoleDeletedObjectGroup0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupRoleDeletedObjectGroup1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupRoleDeletedObjectGroup1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1 AsEventStreamCloudEventGroupRoleDeletedObjectGroup1() =>
+        IsEventStreamCloudEventGroupRoleDeletedObjectGroup1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupRoleDeletedObjectGroup1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupRoleDeletedObjectGroup2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupRoleDeletedObjectGroup2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2 AsEventStreamCloudEventGroupRoleDeletedObjectGroup2() =>
+        IsEventStreamCloudEventGroupRoleDeletedObjectGroup2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupRoleDeletedObjectGroup2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupRoleDeletedObjectGroup0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupRoleDeletedObjectGroup0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupRoleDeletedObjectGroup1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupRoleDeletedObjectGroup1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupRoleDeletedObjectGroup2(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupRoleDeletedObjectGroup2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0,
+            T
+        > onEventStreamCloudEventGroupRoleDeletedObjectGroup0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1,
+            T
+        > onEventStreamCloudEventGroupRoleDeletedObjectGroup1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2,
+            T
+        > onEventStreamCloudEventGroupRoleDeletedObjectGroup2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupRoleDeletedObjectGroup0" =>
+                onEventStreamCloudEventGroupRoleDeletedObjectGroup0(
+                    AsEventStreamCloudEventGroupRoleDeletedObjectGroup0()
+                ),
+            "eventStreamCloudEventGroupRoleDeletedObjectGroup1" =>
+                onEventStreamCloudEventGroupRoleDeletedObjectGroup1(
+                    AsEventStreamCloudEventGroupRoleDeletedObjectGroup1()
+                ),
+            "eventStreamCloudEventGroupRoleDeletedObjectGroup2" =>
+                onEventStreamCloudEventGroupRoleDeletedObjectGroup2(
+                    AsEventStreamCloudEventGroupRoleDeletedObjectGroup2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0> onEventStreamCloudEventGroupRoleDeletedObjectGroup0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1> onEventStreamCloudEventGroupRoleDeletedObjectGroup1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2> onEventStreamCloudEventGroupRoleDeletedObjectGroup2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupRoleDeletedObjectGroup0":
+                onEventStreamCloudEventGroupRoleDeletedObjectGroup0(
+                    AsEventStreamCloudEventGroupRoleDeletedObjectGroup0()
+                );
+                break;
+            case "eventStreamCloudEventGroupRoleDeletedObjectGroup1":
+                onEventStreamCloudEventGroupRoleDeletedObjectGroup1(
+                    AsEventStreamCloudEventGroupRoleDeletedObjectGroup1()
+                );
+                break;
+            case "eventStreamCloudEventGroupRoleDeletedObjectGroup2":
+                onEventStreamCloudEventGroupRoleDeletedObjectGroup2(
+                    AsEventStreamCloudEventGroupRoleDeletedObjectGroup2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupRoleDeletedObjectGroup other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupRoleDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0 value
+    ) => new("eventStreamCloudEventGroupRoleDeletedObjectGroup0", value);
+
+    public static implicit operator EventStreamCloudEventGroupRoleDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1 value
+    ) => new("eventStreamCloudEventGroupRoleDeletedObjectGroup1", value);
+
+    public static implicit operator EventStreamCloudEventGroupRoleDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2 value
+    ) => new("eventStreamCloudEventGroupRoleDeletedObjectGroup2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventGroupRoleDeletedObjectGroup>
+    {
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupRoleDeletedObjectGroup0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupRoleDeletedObjectGroup1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup1)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupRoleDeletedObjectGroup2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeletedObjectGroup2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupRoleDeletedObjectGroup result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupRoleDeletedObjectGroup"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupRoleDeletedObjectGroup result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup0.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a connection group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeletedObjectGroup0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum.EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup1.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to an organization group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeletedObjectGroup1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum.EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum Organization =
+        new(Values.Organization);
+
+    public EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup2.cs
@@ -1,0 +1,44 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a tenant group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeletedObjectGroup2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum Type { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum.cs
@@ -1,0 +1,125 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum.EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum Tenant = new(
+        Values.Tenant
+    );
+
+    public EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectRole.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedObjectRole.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The role removed from the group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupRoleDeletedObjectRole : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupRoleDeletedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupRoleDeletedTypeEnum.EventStreamCloudEventGroupRoleDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupRoleDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupRoleDeletedTypeEnum GroupRoleDeleted = new(
+        Values.GroupRoleDeleted
+    );
+
+    public EventStreamCloudEventGroupRoleDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupRoleDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupRoleDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupRoleDeletedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupRoleDeletedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventGroupRoleDeletedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupRoleDeletedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventGroupRoleDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupRoleDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventGroupRoleDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupRoleDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupRoleDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupRoleDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupRoleDeleted = "group.role.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdated.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdated.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for group.updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupUpdated : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventGroupUpdatedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a group is updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupUpdatedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupUpdatedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventGroupUpdatedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupUpdatedCloudEventTypeEnum.EventStreamCloudEventGroupUpdatedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupUpdatedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupUpdatedCloudEventTypeEnum GroupUpdated = new(
+        Values.GroupUpdated
+    );
+
+    public EventStreamCloudEventGroupUpdatedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupUpdatedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupUpdatedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupUpdatedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupUpdatedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupUpdatedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventGroupUpdatedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupUpdatedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupUpdated = "group.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupUpdatedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventGroupUpdatedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject.cs
@@ -1,0 +1,359 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventGroupUpdatedObject.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventGroupUpdatedObject
+{
+    private EventStreamCloudEventGroupUpdatedObject(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedObject FromEventStreamCloudEventGroupUpdatedObject0(
+        Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0 value
+    ) => new("eventStreamCloudEventGroupUpdatedObject0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedObject FromEventStreamCloudEventGroupUpdatedObject1(
+        Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1 value
+    ) => new("eventStreamCloudEventGroupUpdatedObject1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2 value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedObject FromEventStreamCloudEventGroupUpdatedObject2(
+        Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2 value
+    ) => new("eventStreamCloudEventGroupUpdatedObject2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupUpdatedObject0"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupUpdatedObject0() =>
+        Type == "eventStreamCloudEventGroupUpdatedObject0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupUpdatedObject1"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupUpdatedObject1() =>
+        Type == "eventStreamCloudEventGroupUpdatedObject1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventGroupUpdatedObject2"
+    /// </summary>
+    public bool IsEventStreamCloudEventGroupUpdatedObject2() =>
+        Type == "eventStreamCloudEventGroupUpdatedObject2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupUpdatedObject0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupUpdatedObject0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0 AsEventStreamCloudEventGroupUpdatedObject0() =>
+        IsEventStreamCloudEventGroupUpdatedObject0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupUpdatedObject0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupUpdatedObject1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupUpdatedObject1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1 AsEventStreamCloudEventGroupUpdatedObject1() =>
+        IsEventStreamCloudEventGroupUpdatedObject1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupUpdatedObject1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2"/> if <see cref="Type"/> is 'eventStreamCloudEventGroupUpdatedObject2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventGroupUpdatedObject2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2 AsEventStreamCloudEventGroupUpdatedObject2() =>
+        IsEventStreamCloudEventGroupUpdatedObject2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventGroupUpdatedObject2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupUpdatedObject0(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupUpdatedObject0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupUpdatedObject1(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupUpdatedObject1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventGroupUpdatedObject2(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventGroupUpdatedObject2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0,
+            T
+        > onEventStreamCloudEventGroupUpdatedObject0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1,
+            T
+        > onEventStreamCloudEventGroupUpdatedObject1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2,
+            T
+        > onEventStreamCloudEventGroupUpdatedObject2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventGroupUpdatedObject0" =>
+                onEventStreamCloudEventGroupUpdatedObject0(
+                    AsEventStreamCloudEventGroupUpdatedObject0()
+                ),
+            "eventStreamCloudEventGroupUpdatedObject1" =>
+                onEventStreamCloudEventGroupUpdatedObject1(
+                    AsEventStreamCloudEventGroupUpdatedObject1()
+                ),
+            "eventStreamCloudEventGroupUpdatedObject2" =>
+                onEventStreamCloudEventGroupUpdatedObject2(
+                    AsEventStreamCloudEventGroupUpdatedObject2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0> onEventStreamCloudEventGroupUpdatedObject0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1> onEventStreamCloudEventGroupUpdatedObject1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2> onEventStreamCloudEventGroupUpdatedObject2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventGroupUpdatedObject0":
+                onEventStreamCloudEventGroupUpdatedObject0(
+                    AsEventStreamCloudEventGroupUpdatedObject0()
+                );
+                break;
+            case "eventStreamCloudEventGroupUpdatedObject1":
+                onEventStreamCloudEventGroupUpdatedObject1(
+                    AsEventStreamCloudEventGroupUpdatedObject1()
+                );
+                break;
+            case "eventStreamCloudEventGroupUpdatedObject2":
+                onEventStreamCloudEventGroupUpdatedObject2(
+                    AsEventStreamCloudEventGroupUpdatedObject2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventGroupUpdatedObject other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventGroupUpdatedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0 value
+    ) => new("eventStreamCloudEventGroupUpdatedObject0", value);
+
+    public static implicit operator EventStreamCloudEventGroupUpdatedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1 value
+    ) => new("eventStreamCloudEventGroupUpdatedObject1", value);
+
+    public static implicit operator EventStreamCloudEventGroupUpdatedObject(
+        Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2 value
+    ) => new("eventStreamCloudEventGroupUpdatedObject2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter : JsonConverter<EventStreamCloudEventGroupUpdatedObject>
+    {
+        public override EventStreamCloudEventGroupUpdatedObject? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventGroupUpdatedObject0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject0)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupUpdatedObject1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject1)
+                    ),
+                    (
+                        "eventStreamCloudEventGroupUpdatedObject2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventGroupUpdatedObject2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventGroupUpdatedObject result = new(key, value);
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventGroupUpdatedObject"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventGroupUpdatedObject ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventGroupUpdatedObject result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject0.cs
@@ -1,0 +1,68 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Connection group with updated_at timestamp
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupUpdatedObject0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupUpdatedObject0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject0TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupUpdatedObject0TypeEnum.EventStreamCloudEventGroupUpdatedObject0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupUpdatedObject0TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupUpdatedObject0TypeEnum Connection = new(
+        Values.Connection
+    );
+
+    public EventStreamCloudEventGroupUpdatedObject0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedObject0TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupUpdatedObject0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupUpdatedObject0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupUpdatedObject0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupUpdatedObject0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupUpdatedObject0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupUpdatedObject0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupUpdatedObject0TypeEnum>
+    {
+        public override EventStreamCloudEventGroupUpdatedObject0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedObject0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupUpdatedObject0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedObject0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject1.cs
@@ -1,0 +1,68 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Organization group with updated_at timestamp
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupUpdatedObject1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupUpdatedObject1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject1TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupUpdatedObject1TypeEnum.EventStreamCloudEventGroupUpdatedObject1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupUpdatedObject1TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupUpdatedObject1TypeEnum Organization = new(
+        Values.Organization
+    );
+
+    public EventStreamCloudEventGroupUpdatedObject1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedObject1TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupUpdatedObject1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupUpdatedObject1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupUpdatedObject1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupUpdatedObject1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupUpdatedObject1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupUpdatedObject1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupUpdatedObject1TypeEnum>
+    {
+        public override EventStreamCloudEventGroupUpdatedObject1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedObject1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupUpdatedObject1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedObject1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject2.cs
@@ -1,0 +1,62 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Tenant group with updated_at timestamp
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventGroupUpdatedObject2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the group.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventGroupUpdatedObject2TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedObject2TypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupUpdatedObject2TypeEnum.EventStreamCloudEventGroupUpdatedObject2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupUpdatedObject2TypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupUpdatedObject2TypeEnum Tenant = new(
+        Values.Tenant
+    );
+
+    public EventStreamCloudEventGroupUpdatedObject2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedObject2TypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupUpdatedObject2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupUpdatedObject2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupUpdatedObject2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventGroupUpdatedObject2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupUpdatedObject2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventGroupUpdatedObject2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupUpdatedObject2TypeEnum>
+    {
+        public override EventStreamCloudEventGroupUpdatedObject2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedObject2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupUpdatedObject2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedObject2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedObject2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventGroupUpdatedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventGroupUpdatedTypeEnum.EventStreamCloudEventGroupUpdatedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventGroupUpdatedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventGroupUpdatedTypeEnum GroupUpdated = new(
+        Values.GroupUpdated
+    );
+
+    public EventStreamCloudEventGroupUpdatedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventGroupUpdatedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventGroupUpdatedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventGroupUpdatedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventGroupUpdatedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventGroupUpdatedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventGroupUpdatedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventGroupUpdatedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventGroupUpdatedTypeEnum>
+    {
+        public override EventStreamCloudEventGroupUpdatedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventGroupUpdatedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventGroupUpdatedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventGroupUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupUpdated = "group.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOffsetOnlyMessage.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOffsetOnlyMessage.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// An offset-only heartbeat message. Advances the cursor without delivering an event.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOffsetOnlyMessage : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing the latest position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOffsetOnlyMessageTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOffsetOnlyMessageTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOffsetOnlyMessageTypeEnum.EventStreamCloudEventOffsetOnlyMessageTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOffsetOnlyMessageTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOffsetOnlyMessageTypeEnum OffsetOnly = new(
+        Values.OffsetOnly
+    );
+
+    public EventStreamCloudEventOffsetOnlyMessageTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOffsetOnlyMessageTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOffsetOnlyMessageTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOffsetOnlyMessageTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOffsetOnlyMessageTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventOffsetOnlyMessageTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventOffsetOnlyMessageTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventOffsetOnlyMessageTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOffsetOnlyMessageTypeEnum>
+    {
+        public override EventStreamCloudEventOffsetOnlyMessageTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOffsetOnlyMessageTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOffsetOnlyMessageTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOffsetOnlyMessageTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOffsetOnlyMessageTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOffsetOnlyMessageTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OffsetOnly = "offset-only";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAdded.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAdded.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.connection.added.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionAdded : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgConnectionAddedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a connection is added to an organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionAddedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgConnectionAddedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum.EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum OrganizationConnectionAdded =
+        new(Values.OrganizationConnectionAdded);
+
+    public EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionAddedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationConnectionAdded = "organization.connection.added";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionAddedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgConnectionAddedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedObject.cs
@@ -1,0 +1,59 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionAddedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgConnectionAddedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("connection")]
+    public required EventStreamCloudEventOrgConnectionAddedObjectConnection Connection { get; set; }
+
+    /// <summary>
+    /// When true, all users that log in with this connection will be automatically granted membership
+    /// in the organization. When false, users must be granted membership in the organization before
+    /// logging in with this connection.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("assign_membership_on_login")]
+    public bool? AssignMembershipOnLogin { get; set; }
+
+    /// <summary>
+    /// Determines whether a connection should be displayed on this organization’s login prompt.
+    /// Only applicable for enterprise connections.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("show_as_button")]
+    public bool? ShowAsButton { get; set; }
+
+    /// <summary>
+    /// Determines whether organization signup should be enabled for this organization connection.
+    /// Only applicable for database connections.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("is_signup_enabled")]
+    public bool? IsSignupEnabled { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedObjectConnection.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedObjectConnection.cs
@@ -1,0 +1,31 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[Serializable]
+public record EventStreamCloudEventOrgConnectionAddedObjectConnection : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the connection.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedObjectOrganization.cs
@@ -1,0 +1,41 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Information about an Auth0 Organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionAddedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionAddedTypeEnum.cs
@@ -1,0 +1,121 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgConnectionAddedTypeEnum.EventStreamCloudEventOrgConnectionAddedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgConnectionAddedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgConnectionAddedTypeEnum OrganizationConnectionAdded =
+        new(Values.OrganizationConnectionAdded);
+
+    public EventStreamCloudEventOrgConnectionAddedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgConnectionAddedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgConnectionAddedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgConnectionAddedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgConnectionAddedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventOrgConnectionAddedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgConnectionAddedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventOrgConnectionAddedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgConnectionAddedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgConnectionAddedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionAddedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionAddedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgConnectionAddedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionAddedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionAddedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationConnectionAdded = "organization.connection.added";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemoved.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemoved.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.connection.removed.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionRemoved : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgConnectionRemovedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a connection is removed from an organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionRemovedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgConnectionRemovedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum.EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum OrganizationConnectionRemoved =
+        new(Values.OrganizationConnectionRemoved);
+
+    public EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionRemovedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionRemovedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgConnectionRemovedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedObject.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionRemovedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgConnectionRemovedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("connection")]
+    public required EventStreamCloudEventOrgConnectionRemovedObjectConnection Connection { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedObjectConnection.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedObjectConnection.cs
@@ -1,0 +1,31 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[Serializable]
+public record EventStreamCloudEventOrgConnectionRemovedObjectConnection : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the connection.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedObjectOrganization.cs
@@ -1,0 +1,41 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Information about an Auth0 Organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionRemovedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionRemovedTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgConnectionRemovedTypeEnum.EventStreamCloudEventOrgConnectionRemovedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgConnectionRemovedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgConnectionRemovedTypeEnum OrganizationConnectionRemoved =
+        new(Values.OrganizationConnectionRemoved);
+
+    public EventStreamCloudEventOrgConnectionRemovedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgConnectionRemovedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgConnectionRemovedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgConnectionRemovedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgConnectionRemovedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgConnectionRemovedTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgConnectionRemovedTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgConnectionRemovedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgConnectionRemovedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgConnectionRemovedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionRemovedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionRemovedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgConnectionRemovedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionRemovedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionRemovedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdated.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdated.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.connection.updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionUpdated : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgConnectionUpdatedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a organization connection is updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionUpdatedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgConnectionUpdatedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum.EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum OrganizationConnectionUpdated =
+        new(Values.OrganizationConnectionUpdated);
+
+    public EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationConnectionUpdated = "organization.connection.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionUpdatedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgConnectionUpdatedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedObject.cs
@@ -1,0 +1,59 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionUpdatedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgConnectionUpdatedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("connection")]
+    public required EventStreamCloudEventOrgConnectionUpdatedObjectConnection Connection { get; set; }
+
+    /// <summary>
+    /// When true, all users that log in with this connection will be automatically granted membership
+    /// in the organization. When false, users must be granted membership in the organization before
+    /// logging in with this connection.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("assign_membership_on_login")]
+    public bool? AssignMembershipOnLogin { get; set; }
+
+    /// <summary>
+    /// Determines whether a connection should be displayed on this organization’s login prompt.
+    /// Only applicable for enterprise connections.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("show_as_button")]
+    public bool? ShowAsButton { get; set; }
+
+    /// <summary>
+    /// Determines whether organization signup should be enabled for this organization connection.
+    /// Only applicable for database connections.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("is_signup_enabled")]
+    public bool? IsSignupEnabled { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedObjectConnection.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedObjectConnection.cs
@@ -1,0 +1,31 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[Serializable]
+public record EventStreamCloudEventOrgConnectionUpdatedObjectConnection : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the connection.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedObjectOrganization.cs
@@ -1,0 +1,41 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Information about an Auth0 Organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgConnectionUpdatedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgConnectionUpdatedTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgConnectionUpdatedTypeEnum.EventStreamCloudEventOrgConnectionUpdatedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgConnectionUpdatedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgConnectionUpdatedTypeEnum OrganizationConnectionUpdated =
+        new(Values.OrganizationConnectionUpdated);
+
+    public EventStreamCloudEventOrgConnectionUpdatedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgConnectionUpdatedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgConnectionUpdatedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgConnectionUpdatedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgConnectionUpdatedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgConnectionUpdatedTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgConnectionUpdatedTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgConnectionUpdatedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgConnectionUpdatedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgConnectionUpdatedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionUpdatedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgConnectionUpdatedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgConnectionUpdatedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgConnectionUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationConnectionUpdated = "organization.connection.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreated.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreated.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.created.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgCreated : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgCreatedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when an organization is created.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgCreatedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgCreatedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgCreatedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgCreatedCloudEventTypeEnum.EventStreamCloudEventOrgCreatedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgCreatedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgCreatedCloudEventTypeEnum OrganizationCreated =
+        new(Values.OrganizationCreated);
+
+    public EventStreamCloudEventOrgCreatedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgCreatedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgCreatedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgCreatedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgCreatedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgCreatedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgCreatedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgCreatedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgCreatedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgCreatedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgCreatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgCreatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgCreatedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgCreatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgCreatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationCreated = "organization.created";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgCreatedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgCreatedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedObject.cs
@@ -1,0 +1,56 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgCreatedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// If set, the name that will be displayed to end-users for this organization in any interaction with them.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("display_name")]
+    public string? DisplayName { get; set; }
+
+    [Optional]
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object?>? Metadata { get; set; }
+
+    [Optional]
+    [JsonPropertyName("branding")]
+    public EventStreamCloudEventOrgCreatedObjectBranding? Branding { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedObjectBranding.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedObjectBranding.cs
@@ -1,0 +1,39 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The branding associated with the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgCreatedObjectBranding : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// URL of logo to display on login page.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("logo_url")]
+    public string? LogoUrl { get; set; }
+
+    [Optional]
+    [JsonPropertyName("colors")]
+    public EventStreamCloudEventOrgCreatedObjectBrandingColors? Colors { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedObjectBrandingColors.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedObjectBrandingColors.cs
@@ -1,0 +1,42 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Color scheme used to customize the login pages.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgCreatedObjectBrandingColors : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// HEX Color for primary elements.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("primary")]
+    public string? Primary { get; set; }
+
+    /// <summary>
+    /// HEX Color for background.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("page_background")]
+    public string? PageBackground { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgCreatedTypeEnum.cs
@@ -1,0 +1,118 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgCreatedTypeEnum.EventStreamCloudEventOrgCreatedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgCreatedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgCreatedTypeEnum OrganizationCreated = new(
+        Values.OrganizationCreated
+    );
+
+    public EventStreamCloudEventOrgCreatedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgCreatedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgCreatedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(EventStreamCloudEventOrgCreatedTypeEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(EventStreamCloudEventOrgCreatedTypeEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventOrgCreatedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgCreatedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventOrgCreatedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgCreatedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgCreatedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgCreatedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgCreatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgCreatedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgCreatedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgCreatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationCreated = "organization.created";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when an organization is deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgDeletedCloudEventTypeEnum.EventStreamCloudEventOrgDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgDeletedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgDeletedCloudEventTypeEnum OrganizationDeleted =
+        new(Values.OrganizationDeleted);
+
+    public EventStreamCloudEventOrgDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgDeletedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationDeleted = "organization.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedObject.cs
@@ -1,0 +1,52 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgDeletedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// If set, the name that will be displayed to end-users for this organization in any interaction with them.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("display_name")]
+    public string? DisplayName { get; set; }
+
+    [Optional]
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object?>? Metadata { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgDeletedTypeEnum.cs
@@ -1,0 +1,118 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgDeletedTypeEnum.EventStreamCloudEventOrgDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgDeletedTypeEnum OrganizationDeleted = new(
+        Values.OrganizationDeleted
+    );
+
+    public EventStreamCloudEventOrgDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(EventStreamCloudEventOrgDeletedTypeEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(EventStreamCloudEventOrgDeletedTypeEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventOrgDeletedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgDeletedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventOrgDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationDeleted = "organization.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssigned.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssigned.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.group.role.assigned.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssigned : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a role is assigned to an organization group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum.EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum OrganizationGroupRoleAssigned =
+        new(Values.OrganizationGroupRoleAssigned);
+
+    public EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationGroupRoleAssigned = "organization.group.role.assigned";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObject.cs
@@ -1,0 +1,43 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("role")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedObjectRole Role { get; set; }
+
+    [JsonPropertyName("group")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedObjectGroup Group { get; set; }
+
+    /// <summary>
+    /// The time at which the role was assigned to the group in the organization.
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup.cs
@@ -1,0 +1,369 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The group the role is assigned to.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventOrgGroupRoleAssignedObjectGroup.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventOrgGroupRoleAssignedObjectGroup
+{
+    private EventStreamCloudEventOrgGroupRoleAssignedObjectGroup(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0 value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedObjectGroup FromEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0 value
+    ) => new("eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1 value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedObjectGroup FromEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1 value
+    ) => new("eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2 value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedObjectGroup FromEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2 value
+    ) => new("eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0"
+    /// </summary>
+    public bool IsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0() =>
+        Type == "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1"
+    /// </summary>
+    public bool IsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1() =>
+        Type == "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2"
+    /// </summary>
+    public bool IsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2() =>
+        Type == "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0"/> if <see cref="Type"/> is 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0 AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0() =>
+        IsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1"/> if <see cref="Type"/> is 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1 AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1() =>
+        IsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2"/> if <see cref="Type"/> is 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2 AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2() =>
+        IsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0,
+            T
+        > onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1,
+            T
+        > onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2,
+            T
+        > onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0" =>
+                onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0(
+                    AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0()
+                ),
+            "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1" =>
+                onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1(
+                    AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1()
+                ),
+            "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2" =>
+                onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2(
+                    AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0> onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1> onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2> onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0":
+                onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0(
+                    AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup0()
+                );
+                break;
+            case "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1":
+                onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1(
+                    AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup1()
+                );
+                break;
+            case "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2":
+                onEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2(
+                    AsEventStreamCloudEventOrgGroupRoleAssignedObjectGroup2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventOrgGroupRoleAssignedObjectGroup other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventOrgGroupRoleAssignedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0 value
+    ) => new("eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0", value);
+
+    public static implicit operator EventStreamCloudEventOrgGroupRoleAssignedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1 value
+    ) => new("eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1", value);
+
+    public static implicit operator EventStreamCloudEventOrgGroupRoleAssignedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2 value
+    ) => new("eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleAssignedObjectGroup>
+    {
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0)
+                    ),
+                    (
+                        "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1)
+                    ),
+                    (
+                        "eventStreamCloudEventOrgGroupRoleAssignedObjectGroup2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventOrgGroupRoleAssignedObjectGroup"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a connection group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to an organization group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum Organization =
+        new(Values.Organization);
+
+    public EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2.cs
@@ -1,0 +1,44 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a tenant group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum Type { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum.EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum Tenant =
+        new(Values.Tenant);
+
+    public EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectOrganization.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The organization the group role is assigned in.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectRole.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedObjectRole.cs
@@ -1,0 +1,40 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The role assigned to the group in the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleAssignedObjectRole : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the role.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleAssignedTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleAssignedTypeEnum.EventStreamCloudEventOrgGroupRoleAssignedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleAssignedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleAssignedTypeEnum OrganizationGroupRoleAssigned =
+        new(Values.OrganizationGroupRoleAssigned);
+
+    public EventStreamCloudEventOrgGroupRoleAssignedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleAssignedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgGroupRoleAssignedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleAssignedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleAssignedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleAssignedTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleAssignedTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleAssignedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleAssignedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleAssignedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleAssignedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleAssignedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleAssignedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationGroupRoleAssigned = "organization.group.role.assigned";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.group.role.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a role is removed from an organization group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum.EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum OrganizationGroupRoleDeleted =
+        new(Values.OrganizationGroupRoleDeleted);
+
+    public EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationGroupRoleDeleted = "organization.group.role.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObject.cs
@@ -1,0 +1,43 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("role")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedObjectRole Role { get; set; }
+
+    [JsonPropertyName("group")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedObjectGroup Group { get; set; }
+
+    /// <summary>
+    /// The time at which the role was removed from the group in the organization.
+    /// </summary>
+    [JsonPropertyName("deleted_at")]
+    public required DateTime DeletedAt { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup.cs
@@ -1,0 +1,366 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The group the role is removed from.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventOrgGroupRoleDeletedObjectGroup.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventOrgGroupRoleDeletedObjectGroup
+{
+    private EventStreamCloudEventOrgGroupRoleDeletedObjectGroup(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0 value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedObjectGroup FromEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0 value
+    ) => new("eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1 value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedObjectGroup FromEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1 value
+    ) => new("eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2 value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedObjectGroup FromEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2 value
+    ) => new("eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0"
+    /// </summary>
+    public bool IsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0() =>
+        Type == "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1"
+    /// </summary>
+    public bool IsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1() =>
+        Type == "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2"
+    /// </summary>
+    public bool IsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2() =>
+        Type == "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0"/> if <see cref="Type"/> is 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0 AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0() =>
+        IsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0()
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1"/> if <see cref="Type"/> is 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1 AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1() =>
+        IsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1()
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2"/> if <see cref="Type"/> is 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2 AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2() =>
+        IsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2()
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0? value
+    )
+    {
+        if (Type == "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1? value
+    )
+    {
+        if (Type == "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2? value
+    )
+    {
+        if (Type == "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0,
+            T
+        > onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1,
+            T
+        > onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2,
+            T
+        > onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0" =>
+                onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0(
+                    AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0()
+                ),
+            "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1" =>
+                onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1(
+                    AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1()
+                ),
+            "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2" =>
+                onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2(
+                    AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0> onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1> onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2> onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0":
+                onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0(
+                    AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup0()
+                );
+                break;
+            case "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1":
+                onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1(
+                    AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup1()
+                );
+                break;
+            case "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2":
+                onEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2(
+                    AsEventStreamCloudEventOrgGroupRoleDeletedObjectGroup2()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventOrgGroupRoleDeletedObjectGroup other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventOrgGroupRoleDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0 value
+    ) => new("eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0", value);
+
+    public static implicit operator EventStreamCloudEventOrgGroupRoleDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1 value
+    ) => new("eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1", value);
+
+    public static implicit operator EventStreamCloudEventOrgGroupRoleDeletedObjectGroup(
+        Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2 value
+    ) => new("eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleDeletedObjectGroup>
+    {
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup0",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0)
+                    ),
+                    (
+                        "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup1",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1)
+                    ),
+                    (
+                        "eventStreamCloudEventOrgGroupRoleDeletedObjectGroup2",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventOrgGroupRoleDeletedObjectGroup"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a connection group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The connection ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("connection_id")]
+    public required string ConnectionId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum Connection =
+        new(Values.Connection);
+
+    public EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup0TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Connection = "connection";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1.cs
@@ -1,0 +1,50 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to an organization group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The organization ID associated with the group.
+    /// </summary>
+    [JsonPropertyName("organization_id")]
+    public required string OrganizationId { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum Organization =
+        new(Values.Organization);
+
+    public EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup1TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Organization = "organization";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2.cs
@@ -1,0 +1,44 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Reference to a tenant group
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2 : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The unique identifier for the group.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The external identifier for the group.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("external_id")]
+    public string? ExternalId { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum Type { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum.EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum Tenant =
+        new(Values.Tenant);
+
+    public EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedObjectGroup2TypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Tenant = "tenant";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectOrganization.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The organization the group role is removed from.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectRole.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedObjectRole.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The role removed from the group.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgGroupRoleDeletedObjectRole : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgGroupRoleDeletedTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgGroupRoleDeletedTypeEnum.EventStreamCloudEventOrgGroupRoleDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgGroupRoleDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgGroupRoleDeletedTypeEnum OrganizationGroupRoleDeleted =
+        new(Values.OrganizationGroupRoleDeleted);
+
+    public EventStreamCloudEventOrgGroupRoleDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgGroupRoleDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgGroupRoleDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgGroupRoleDeletedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgGroupRoleDeletedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgGroupRoleDeletedTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgGroupRoleDeletedTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgGroupRoleDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgGroupRoleDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgGroupRoleDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgGroupRoleDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgGroupRoleDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgGroupRoleDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationGroupRoleDeleted = "organization.group.role.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAdded.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAdded.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.member.added.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberAdded : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgMemberAddedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a member is added to an organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberAddedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgMemberAddedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum.EventStreamCloudEventOrgMemberAddedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum OrganizationMemberAdded =
+        new(Values.OrganizationMemberAdded);
+
+    public EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgMemberAddedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberAddedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberAdded = "organization.member.added";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberAddedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgMemberAddedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedObject.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberAddedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgMemberAddedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("user")]
+    public required EventStreamCloudEventOrgMemberAddedObjectUser User { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedObjectOrganization.cs
@@ -1,0 +1,41 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The organization the member belongs to.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberAddedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedObjectUser.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedObjectUser.cs
@@ -1,0 +1,38 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The user that is a member of the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberAddedObjectUser
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// ID of the user which can be used when interacting with other APIs.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberAddedTypeEnum.cs
@@ -1,0 +1,121 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberAddedTypeEnum.EventStreamCloudEventOrgMemberAddedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberAddedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberAddedTypeEnum OrganizationMemberAdded =
+        new(Values.OrganizationMemberAdded);
+
+    public EventStreamCloudEventOrgMemberAddedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberAddedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgMemberAddedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberAddedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberAddedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventOrgMemberAddedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberAddedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventOrgMemberAddedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberAddedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberAddedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberAddedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberAddedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberAddedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberAddedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberAddedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberAdded = "organization.member.added";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.member.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgMemberDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a member is removed from an organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgMemberDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum.EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum OrganizationMemberDeleted =
+        new(Values.OrganizationMemberDeleted);
+
+    public EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberDeleted = "organization.member.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgMemberDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedObject.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberDeletedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgMemberDeletedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("user")]
+    public required EventStreamCloudEventOrgMemberDeletedObjectUser User { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedObjectOrganization.cs
@@ -1,0 +1,41 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The organization the member belongs to.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberDeletedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedObjectUser.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedObjectUser.cs
@@ -1,0 +1,38 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The user that is a member of the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberDeletedObjectUser
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// ID of the user which can be used when interacting with other APIs.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberDeletedTypeEnum.cs
@@ -1,0 +1,121 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberDeletedTypeEnum.EventStreamCloudEventOrgMemberDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberDeletedTypeEnum OrganizationMemberDeleted =
+        new(Values.OrganizationMemberDeleted);
+
+    public EventStreamCloudEventOrgMemberDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgMemberDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberDeletedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberDeletedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventOrgMemberDeletedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberDeletedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventOrgMemberDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberDeleted = "organization.member.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssigned.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssigned.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.member.role.assigned.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleAssigned : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgMemberRoleAssignedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a member is added to an organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleAssignedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgMemberRoleAssignedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum.EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum OrganizationMemberRoleAssigned =
+        new(Values.OrganizationMemberRoleAssigned);
+
+    public EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleAssignedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberRoleAssigned = "organization.member.role.assigned";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleAssignedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgMemberRoleAssignedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObject.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleAssignedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgMemberRoleAssignedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("user")]
+    public required EventStreamCloudEventOrgMemberRoleAssignedObjectUser User { get; set; }
+
+    [JsonPropertyName("role")]
+    public required EventStreamCloudEventOrgMemberRoleAssignedObjectRole Role { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObjectOrganization.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The organization the member belongs to.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleAssignedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObjectRole.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObjectRole.cs
@@ -1,0 +1,40 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The role assigned to the user in the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleAssignedObjectRole : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the role.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObjectUser.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedObjectUser.cs
@@ -1,0 +1,38 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The user that is a member of the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleAssignedObjectUser
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// ID of the user which can be used when interacting with other APIs.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleAssignedTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberRoleAssignedTypeEnum.EventStreamCloudEventOrgMemberRoleAssignedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberRoleAssignedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberRoleAssignedTypeEnum OrganizationMemberRoleAssigned =
+        new(Values.OrganizationMemberRoleAssigned);
+
+    public EventStreamCloudEventOrgMemberRoleAssignedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberRoleAssignedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgMemberRoleAssignedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberRoleAssignedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberRoleAssignedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgMemberRoleAssignedTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberRoleAssignedTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgMemberRoleAssignedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberRoleAssignedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberRoleAssignedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleAssignedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleAssignedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberRoleAssignedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleAssignedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleAssignedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberRoleAssigned = "organization.member.role.assigned";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.member.role.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgMemberRoleDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a member is removed from an organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgMemberRoleDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,126 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum.EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum OrganizationMemberRoleDeleted =
+        new(Values.OrganizationMemberRoleDeleted);
+
+    public EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberRoleDeleted = "organization.member.role.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgMemberRoleDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObject.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleDeletedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("organization")]
+    public required EventStreamCloudEventOrgMemberRoleDeletedObjectOrganization Organization { get; set; }
+
+    [JsonPropertyName("user")]
+    public required EventStreamCloudEventOrgMemberRoleDeletedObjectUser User { get; set; }
+
+    [JsonPropertyName("role")]
+    public required EventStreamCloudEventOrgMemberRoleDeletedObjectRole Role { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObjectOrganization.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObjectOrganization.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The organization the member belongs to.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleDeletedObjectOrganization : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObjectRole.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObjectRole.cs
@@ -1,0 +1,40 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The role assigned to the user in the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleDeletedObjectRole : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The ID of the role.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// The name of the role.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObjectUser.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedObjectUser.cs
@@ -1,0 +1,38 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The user that is a member of the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgMemberRoleDeletedObjectUser
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// ID of the user which can be used when interacting with other APIs.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgMemberRoleDeletedTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgMemberRoleDeletedTypeEnum.EventStreamCloudEventOrgMemberRoleDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgMemberRoleDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgMemberRoleDeletedTypeEnum OrganizationMemberRoleDeleted =
+        new(Values.OrganizationMemberRoleDeleted);
+
+    public EventStreamCloudEventOrgMemberRoleDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgMemberRoleDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgMemberRoleDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgMemberRoleDeletedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgMemberRoleDeletedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgMemberRoleDeletedTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgMemberRoleDeletedTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgMemberRoleDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgMemberRoleDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgMemberRoleDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgMemberRoleDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgMemberRoleDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgMemberRoleDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationMemberRoleDeleted = "organization.member.role.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdated.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdated.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for organization.updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgUpdated : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventOrgUpdatedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when an organization is updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgUpdatedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventOrgUpdatedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventOrgUpdatedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedCloudEventTypeEnum.cs
@@ -1,0 +1,123 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgUpdatedCloudEventTypeEnum.EventStreamCloudEventOrgUpdatedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgUpdatedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgUpdatedCloudEventTypeEnum OrganizationUpdated =
+        new(Values.OrganizationUpdated);
+
+    public EventStreamCloudEventOrgUpdatedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgUpdatedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgUpdatedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventOrgUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventOrgUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventOrgUpdatedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgUpdatedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventOrgUpdatedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgUpdatedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventOrgUpdatedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgUpdatedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationUpdated = "organization.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgUpdatedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventOrgUpdatedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedObject.cs
@@ -1,0 +1,56 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgUpdatedObject : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The human-readable identifier for the organization that will be used by end-users to direct them to their organization in your application..
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// ID of the organization.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// If set, the name that will be displayed to end-users for this organization in any interaction with them.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("display_name")]
+    public string? DisplayName { get; set; }
+
+    [Optional]
+    [JsonPropertyName("metadata")]
+    public Dictionary<string, object?>? Metadata { get; set; }
+
+    [Optional]
+    [JsonPropertyName("branding")]
+    public EventStreamCloudEventOrgUpdatedObjectBranding? Branding { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedObjectBranding.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedObjectBranding.cs
@@ -1,0 +1,39 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The branding associated with the organization.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgUpdatedObjectBranding : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// URL of logo to display on login page.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("logo_url")]
+    public string? LogoUrl { get; set; }
+
+    [Optional]
+    [JsonPropertyName("colors")]
+    public EventStreamCloudEventOrgUpdatedObjectBrandingColors? Colors { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedObjectBrandingColors.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedObjectBrandingColors.cs
@@ -1,0 +1,42 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Color scheme used to customize the login pages.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventOrgUpdatedObjectBrandingColors : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// HEX Color for primary elements.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("primary")]
+    public string? Primary { get; set; }
+
+    /// <summary>
+    /// HEX Color for background.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("page_background")]
+    public string? PageBackground { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventOrgUpdatedTypeEnum.cs
@@ -1,0 +1,118 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventOrgUpdatedTypeEnum.EventStreamCloudEventOrgUpdatedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventOrgUpdatedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventOrgUpdatedTypeEnum OrganizationUpdated = new(
+        Values.OrganizationUpdated
+    );
+
+    public EventStreamCloudEventOrgUpdatedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventOrgUpdatedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventOrgUpdatedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(EventStreamCloudEventOrgUpdatedTypeEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(EventStreamCloudEventOrgUpdatedTypeEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventOrgUpdatedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventOrgUpdatedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventOrgUpdatedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventOrgUpdatedTypeEnum>
+    {
+        public override EventStreamCloudEventOrgUpdatedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgUpdatedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventOrgUpdatedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventOrgUpdatedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventOrgUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string OrganizationUpdated = "organization.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreated.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreated.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for user.created.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreated : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventUserCreatedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a user is created.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventUserCreatedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventUserCreatedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedCloudEventTypeEnum.EventStreamCloudEventUserCreatedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserCreatedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserCreatedCloudEventTypeEnum UserCreated = new(
+        Values.UserCreated
+    );
+
+    public EventStreamCloudEventUserCreatedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventUserCreatedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserCreatedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserCreatedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserCreatedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserCreatedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserCreatedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserCreatedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventUserCreatedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserCreatedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string UserCreated = "user.created";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventUserCreatedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObject.cs
@@ -1,0 +1,168 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObject : IJsonOnDeserialized, IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// ID of the user which can be used when interacting with other APIs.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Array of user identity objects when accounts are linked.
+    /// </summary>
+    [JsonPropertyName("identities")]
+    public IEnumerable<EventStreamCloudEventUserCreatedObjectIdentitiesItem> Identities { get; set; } =
+        new List<EventStreamCloudEventUserCreatedObjectIdentitiesItem>();
+
+    [Optional]
+    [JsonPropertyName("app_metadata")]
+    public Dictionary<string, object?>? AppMetadata { get; set; }
+
+    [Optional]
+    [JsonPropertyName("user_metadata")]
+    public Dictionary<string, object?>? UserMetadata { get; set; }
+
+    /// <summary>
+    /// URL to picture, photo, or avatar of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("picture")]
+    public string? Picture { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Preferred nickname or alias of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("nickname")]
+    public string? Nickname { get; set; }
+
+    /// <summary>
+    /// List of multi-factor authentication providers with which this user has enrolled.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("multifactor")]
+    public IEnumerable<string>? Multifactor { get; set; }
+
+    /// <summary>
+    /// Last IP address from which this user logged in.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("last_ip")]
+    public string? LastIp { get; set; }
+
+    /// <summary>
+    /// Last date and time this user logged in (ISO_8601 format).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("last_login")]
+    public DateTime? LastLogin { get; set; }
+
+    /// <summary>
+    /// Total number of logins this user has performed.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("logins_count")]
+    public int? LoginsCount { get; set; }
+
+    /// <summary>
+    /// Whether this user was blocked by an administrator (true) or is not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("blocked")]
+    public bool? Blocked { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItem.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItem.cs
@@ -1,0 +1,503 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Identity object when accounts are linked.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItem.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventUserCreatedObjectIdentitiesItem
+{
+    private EventStreamCloudEventUserCreatedObjectIdentitiesItem(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItem FromEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItem FromEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItem FromEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItem FromEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItem FromEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom() =>
+        Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase() =>
+        Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise() =>
+        Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless() =>
+        Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial() =>
+        Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom"/> if <see cref="Type"/> is 'eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom AsEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom() =>
+        IsEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase"/> if <see cref="Type"/> is 'eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase AsEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase() =>
+        IsEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise"/> if <see cref="Type"/> is 'eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise AsEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise() =>
+        IsEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless"/> if <see cref="Type"/> is 'eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless AsEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless() =>
+        IsEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial"/> if <see cref="Type"/> is 'eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial AsEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial() =>
+        IsEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom(
+        out Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase(
+        out Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise(
+        out Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless(
+        out Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial(
+        out Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom,
+            T
+        > onEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase,
+            T
+        > onEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise,
+            T
+        > onEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless,
+            T
+        > onEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial,
+            T
+        > onEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom" =>
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom()
+                ),
+            "eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase" =>
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase()
+                ),
+            "eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise" =>
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise()
+                ),
+            "eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless" =>
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless()
+                ),
+            "eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial" =>
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom> onEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase> onEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise> onEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless> onEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial> onEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom":
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemCustom()
+                );
+                break;
+            case "eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase":
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase()
+                );
+                break;
+            case "eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise":
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise()
+                );
+                break;
+            case "eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless":
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless()
+                );
+                break;
+            case "eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial":
+                onEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial(
+                    AsEventStreamCloudEventUserCreatedObjectIdentitiesItemSocial()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserCreatedObjectIdentitiesItem other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial value
+    ) => new("eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItem>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItem? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventUserCreatedObjectIdentitiesItemCustom",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom)
+                    ),
+                    (
+                        "eventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase)
+                    ),
+                    (
+                        "eventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise)
+                    ),
+                    (
+                        "eventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless)
+                    ),
+                    (
+                        "eventStreamCloudEventUserCreatedObjectIdentitiesItemSocial",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventUserCreatedObjectIdentitiesItem result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserCreatedObjectIdentitiesItem"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItem value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItem ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserCreatedObjectIdentitiesItem result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItem value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for custom identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemCustom : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum.EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum Custom =
+        new(Values.Custom);
+
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Custom = "custom";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId.cs
@@ -1,0 +1,260 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId
+{
+    private EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId stringResult = new(
+                    "string",
+                    stringValue
+                );
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemCustomUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for database identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabase : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum.EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum Auth0 =
+        new(Values.Auth0);
+
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Auth0 = "auth0";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId
+{
+    private EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemDatabaseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for enterprise identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterprise : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum.cs
@@ -1,0 +1,182 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum.EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Ad =
+        new(Values.Ad);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Adfs =
+        new(Values.Adfs);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum GoogleApps =
+        new(Values.GoogleApps);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Ip =
+        new(Values.Ip);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Office365 =
+        new(Values.Office365);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Oidc =
+        new(Values.Oidc);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Okta =
+        new(Values.Okta);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Pingfederate =
+        new(Values.Pingfederate);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Samlp =
+        new(Values.Samlp);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Sharepoint =
+        new(Values.Sharepoint);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Waad =
+        new(Values.Waad);
+
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum(
+            value
+        );
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Ad = "ad";
+
+        public const string Adfs = "adfs";
+
+        public const string GoogleApps = "google-apps";
+
+        public const string Ip = "ip";
+
+        public const string Office365 = "office365";
+
+        public const string Oidc = "oidc";
+
+        public const string Okta = "okta";
+
+        public const string Pingfederate = "pingfederate";
+
+        public const string Samlp = "samlp";
+
+        public const string Sharepoint = "sharepoint";
+
+        public const string Waad = "waad";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId
+{
+    private EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemEnterpriseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for passwordless identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordless : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum.cs
@@ -1,0 +1,139 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum.EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum Email =
+        new(Values.Email);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum Sms =
+        new(Values.Sms);
+
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum(
+        string value
+    )
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum(
+            value
+        );
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Email = "email";
+
+        public const string Sms = "sms";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId
+{
+    private EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemPasswordlessUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for social identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemSocial : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum.cs
@@ -1,0 +1,320 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum.EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Amazon =
+        new(Values.Amazon);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Apple =
+        new(Values.Apple);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Dropbox =
+        new(Values.Dropbox);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Bitbucket =
+        new(Values.Bitbucket);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Auth0Oidc =
+        new(Values.Auth0Oidc);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Baidu =
+        new(Values.Baidu);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Bitly =
+        new(Values.Bitly);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Box =
+        new(Values.Box);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Daccount =
+        new(Values.Daccount);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Dwolla =
+        new(Values.Dwolla);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum EvernoteSandbox =
+        new(Values.EvernoteSandbox);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Evernote =
+        new(Values.Evernote);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Exact =
+        new(Values.Exact);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Facebook =
+        new(Values.Facebook);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Fitbit =
+        new(Values.Fitbit);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Github =
+        new(Values.Github);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum GoogleOauth2 =
+        new(Values.GoogleOauth2);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Instagram =
+        new(Values.Instagram);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Line =
+        new(Values.Line);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Linkedin =
+        new(Values.Linkedin);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Oauth1 =
+        new(Values.Oauth1);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Oauth2 =
+        new(Values.Oauth2);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Paypal =
+        new(Values.Paypal);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum PaypalSandbox =
+        new(Values.PaypalSandbox);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Planningcenter =
+        new(Values.Planningcenter);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum SalesforceCommunity =
+        new(Values.SalesforceCommunity);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum SalesforceSandbox =
+        new(Values.SalesforceSandbox);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Salesforce =
+        new(Values.Salesforce);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Shopify =
+        new(Values.Shopify);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Soundcloud =
+        new(Values.Soundcloud);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Thirtysevensignals =
+        new(Values.Thirtysevensignals);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Twitter =
+        new(Values.Twitter);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Untapped =
+        new(Values.Untapped);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Vkontakte =
+        new(Values.Vkontakte);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Weibo =
+        new(Values.Weibo);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Windowslive =
+        new(Values.Windowslive);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Wordpress =
+        new(Values.Wordpress);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Yahoo =
+        new(Values.Yahoo);
+
+    public static readonly EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Yandex =
+        new(Values.Yandex);
+
+    public EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Amazon = "amazon";
+
+        public const string Apple = "apple";
+
+        public const string Dropbox = "dropbox";
+
+        public const string Bitbucket = "bitbucket";
+
+        public const string Auth0Oidc = "auth0-oidc";
+
+        public const string Baidu = "baidu";
+
+        public const string Bitly = "bitly";
+
+        public const string Box = "box";
+
+        public const string Daccount = "daccount";
+
+        public const string Dwolla = "dwolla";
+
+        public const string EvernoteSandbox = "evernote-sandbox";
+
+        public const string Evernote = "evernote";
+
+        public const string Exact = "exact";
+
+        public const string Facebook = "facebook";
+
+        public const string Fitbit = "fitbit";
+
+        public const string Github = "github";
+
+        public const string GoogleOauth2 = "google-oauth2";
+
+        public const string Instagram = "instagram";
+
+        public const string Line = "line";
+
+        public const string Linkedin = "linkedin";
+
+        public const string Oauth1 = "oauth1";
+
+        public const string Oauth2 = "oauth2";
+
+        public const string Paypal = "paypal";
+
+        public const string PaypalSandbox = "paypal-sandbox";
+
+        public const string Planningcenter = "planningcenter";
+
+        public const string SalesforceCommunity = "salesforce-community";
+
+        public const string SalesforceSandbox = "salesforce-sandbox";
+
+        public const string Salesforce = "salesforce";
+
+        public const string Shopify = "shopify";
+
+        public const string Soundcloud = "soundcloud";
+
+        public const string Thirtysevensignals = "thirtysevensignals";
+
+        public const string Twitter = "twitter";
+
+        public const string Untapped = "untapped";
+
+        public const string Vkontakte = "vkontakte";
+
+        public const string Weibo = "weibo";
+
+        public const string Windowslive = "windowslive";
+
+        public const string Wordpress = "wordpress";
+
+        public const string Yahoo = "yahoo";
+
+        public const string Yandex = "yandex";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId.cs
@@ -1,0 +1,260 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId
+{
+    private EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId>
+    {
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId stringResult = new(
+                    "string",
+                    stringValue
+                );
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedObjectIdentitiesItemSocialUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserCreatedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserCreatedTypeEnum.EventStreamCloudEventUserCreatedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserCreatedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserCreatedTypeEnum UserCreated = new(
+        Values.UserCreated
+    );
+
+    public EventStreamCloudEventUserCreatedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserCreatedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventUserCreatedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserCreatedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserCreatedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventUserCreatedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventUserCreatedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventUserCreatedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserCreatedTypeEnum>
+    {
+        public override EventStreamCloudEventUserCreatedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserCreatedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserCreatedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserCreatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string UserCreated = "user.created";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeleted.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeleted.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for user.deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeleted : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventUserDeletedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a user is deleted.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventUserDeletedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventUserDeletedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedCloudEventTypeEnum.EventStreamCloudEventUserDeletedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserDeletedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserDeletedCloudEventTypeEnum UserDeleted = new(
+        Values.UserDeleted
+    );
+
+    public EventStreamCloudEventUserDeletedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventUserDeletedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserDeletedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserDeletedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserDeletedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserDeletedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserDeletedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventUserDeletedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserDeletedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string UserDeleted = "user.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventUserDeletedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObject.cs
@@ -1,0 +1,174 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObject : IJsonOnDeserialized, IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// ID of the user which can be used when interacting with other APIs.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Array of user identity objects when accounts are linked.
+    /// </summary>
+    [JsonPropertyName("identities")]
+    public IEnumerable<EventStreamCloudEventUserDeletedObjectIdentitiesItem> Identities { get; set; } =
+        new List<EventStreamCloudEventUserDeletedObjectIdentitiesItem>();
+
+    [Optional]
+    [JsonPropertyName("app_metadata")]
+    public Dictionary<string, object?>? AppMetadata { get; set; }
+
+    [Optional]
+    [JsonPropertyName("user_metadata")]
+    public Dictionary<string, object?>? UserMetadata { get; set; }
+
+    /// <summary>
+    /// URL to picture, photo, or avatar of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("picture")]
+    public string? Picture { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Preferred nickname or alias of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("nickname")]
+    public string? Nickname { get; set; }
+
+    /// <summary>
+    /// List of multi-factor authentication providers with which this user has enrolled.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("multifactor")]
+    public IEnumerable<string>? Multifactor { get; set; }
+
+    /// <summary>
+    /// Last IP address from which this user logged in.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("last_ip")]
+    public string? LastIp { get; set; }
+
+    /// <summary>
+    /// Last date and time this user logged in (ISO_8601 format).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("last_login")]
+    public DateTime? LastLogin { get; set; }
+
+    /// <summary>
+    /// Total number of logins this user has performed.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("logins_count")]
+    public int? LoginsCount { get; set; }
+
+    /// <summary>
+    /// Whether this user was blocked by an administrator (true) or is not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("blocked")]
+    public bool? Blocked { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was deleted (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("deleted_at")]
+    public required DateTime DeletedAt { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItem.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItem.cs
@@ -1,0 +1,503 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Identity object when accounts are linked.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItem.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventUserDeletedObjectIdentitiesItem
+{
+    private EventStreamCloudEventUserDeletedObjectIdentitiesItem(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItem FromEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItem FromEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItem FromEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItem FromEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItem FromEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom() =>
+        Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase() =>
+        Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise() =>
+        Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless() =>
+        Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial() =>
+        Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom"/> if <see cref="Type"/> is 'eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom AsEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom() =>
+        IsEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase"/> if <see cref="Type"/> is 'eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase AsEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase() =>
+        IsEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise"/> if <see cref="Type"/> is 'eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise AsEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise() =>
+        IsEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless"/> if <see cref="Type"/> is 'eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless AsEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless() =>
+        IsEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial"/> if <see cref="Type"/> is 'eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial AsEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial() =>
+        IsEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom(
+        out Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase(
+        out Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise(
+        out Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless(
+        out Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial(
+        out Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom,
+            T
+        > onEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase,
+            T
+        > onEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise,
+            T
+        > onEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless,
+            T
+        > onEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial,
+            T
+        > onEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom" =>
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom()
+                ),
+            "eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase" =>
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase()
+                ),
+            "eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise" =>
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise()
+                ),
+            "eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless" =>
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless()
+                ),
+            "eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial" =>
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom> onEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase> onEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise> onEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless> onEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial> onEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom":
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemCustom()
+                );
+                break;
+            case "eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase":
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase()
+                );
+                break;
+            case "eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise":
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise()
+                );
+                break;
+            case "eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless":
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless()
+                );
+                break;
+            case "eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial":
+                onEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial(
+                    AsEventStreamCloudEventUserDeletedObjectIdentitiesItemSocial()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserDeletedObjectIdentitiesItem other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial value
+    ) => new("eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItem>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItem? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventUserDeletedObjectIdentitiesItemCustom",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom)
+                    ),
+                    (
+                        "eventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase)
+                    ),
+                    (
+                        "eventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise)
+                    ),
+                    (
+                        "eventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless)
+                    ),
+                    (
+                        "eventStreamCloudEventUserDeletedObjectIdentitiesItemSocial",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventUserDeletedObjectIdentitiesItem result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserDeletedObjectIdentitiesItem"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItem value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItem ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserDeletedObjectIdentitiesItem result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItem value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for custom identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemCustom : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum.EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum Custom =
+        new(Values.Custom);
+
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Custom = "custom";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId.cs
@@ -1,0 +1,260 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId
+{
+    private EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId stringResult = new(
+                    "string",
+                    stringValue
+                );
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemCustomUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for database identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabase : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum.EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum Auth0 =
+        new(Values.Auth0);
+
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Auth0 = "auth0";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId
+{
+    private EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemDatabaseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for enterprise identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterprise : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum.cs
@@ -1,0 +1,182 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum.EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Ad =
+        new(Values.Ad);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Adfs =
+        new(Values.Adfs);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum GoogleApps =
+        new(Values.GoogleApps);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Ip =
+        new(Values.Ip);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Office365 =
+        new(Values.Office365);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Oidc =
+        new(Values.Oidc);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Okta =
+        new(Values.Okta);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Pingfederate =
+        new(Values.Pingfederate);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Samlp =
+        new(Values.Samlp);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Sharepoint =
+        new(Values.Sharepoint);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Waad =
+        new(Values.Waad);
+
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum(
+            value
+        );
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Ad = "ad";
+
+        public const string Adfs = "adfs";
+
+        public const string GoogleApps = "google-apps";
+
+        public const string Ip = "ip";
+
+        public const string Office365 = "office365";
+
+        public const string Oidc = "oidc";
+
+        public const string Okta = "okta";
+
+        public const string Pingfederate = "pingfederate";
+
+        public const string Samlp = "samlp";
+
+        public const string Sharepoint = "sharepoint";
+
+        public const string Waad = "waad";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId
+{
+    private EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemEnterpriseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for passwordless identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordless : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum.cs
@@ -1,0 +1,139 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum.EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum Email =
+        new(Values.Email);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum Sms =
+        new(Values.Sms);
+
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum(
+        string value
+    )
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum(
+            value
+        );
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Email = "email";
+
+        public const string Sms = "sms";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId
+{
+    private EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemPasswordlessUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for social identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemSocial : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum.cs
@@ -1,0 +1,320 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum.EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Amazon =
+        new(Values.Amazon);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Apple =
+        new(Values.Apple);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Dropbox =
+        new(Values.Dropbox);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Bitbucket =
+        new(Values.Bitbucket);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Auth0Oidc =
+        new(Values.Auth0Oidc);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Baidu =
+        new(Values.Baidu);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Bitly =
+        new(Values.Bitly);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Box =
+        new(Values.Box);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Daccount =
+        new(Values.Daccount);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Dwolla =
+        new(Values.Dwolla);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum EvernoteSandbox =
+        new(Values.EvernoteSandbox);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Evernote =
+        new(Values.Evernote);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Exact =
+        new(Values.Exact);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Facebook =
+        new(Values.Facebook);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Fitbit =
+        new(Values.Fitbit);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Github =
+        new(Values.Github);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum GoogleOauth2 =
+        new(Values.GoogleOauth2);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Instagram =
+        new(Values.Instagram);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Line =
+        new(Values.Line);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Linkedin =
+        new(Values.Linkedin);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Oauth1 =
+        new(Values.Oauth1);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Oauth2 =
+        new(Values.Oauth2);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Paypal =
+        new(Values.Paypal);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum PaypalSandbox =
+        new(Values.PaypalSandbox);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Planningcenter =
+        new(Values.Planningcenter);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum SalesforceCommunity =
+        new(Values.SalesforceCommunity);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum SalesforceSandbox =
+        new(Values.SalesforceSandbox);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Salesforce =
+        new(Values.Salesforce);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Shopify =
+        new(Values.Shopify);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Soundcloud =
+        new(Values.Soundcloud);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Thirtysevensignals =
+        new(Values.Thirtysevensignals);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Twitter =
+        new(Values.Twitter);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Untapped =
+        new(Values.Untapped);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Vkontakte =
+        new(Values.Vkontakte);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Weibo =
+        new(Values.Weibo);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Windowslive =
+        new(Values.Windowslive);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Wordpress =
+        new(Values.Wordpress);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Yahoo =
+        new(Values.Yahoo);
+
+    public static readonly EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Yandex =
+        new(Values.Yandex);
+
+    public EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Amazon = "amazon";
+
+        public const string Apple = "apple";
+
+        public const string Dropbox = "dropbox";
+
+        public const string Bitbucket = "bitbucket";
+
+        public const string Auth0Oidc = "auth0-oidc";
+
+        public const string Baidu = "baidu";
+
+        public const string Bitly = "bitly";
+
+        public const string Box = "box";
+
+        public const string Daccount = "daccount";
+
+        public const string Dwolla = "dwolla";
+
+        public const string EvernoteSandbox = "evernote-sandbox";
+
+        public const string Evernote = "evernote";
+
+        public const string Exact = "exact";
+
+        public const string Facebook = "facebook";
+
+        public const string Fitbit = "fitbit";
+
+        public const string Github = "github";
+
+        public const string GoogleOauth2 = "google-oauth2";
+
+        public const string Instagram = "instagram";
+
+        public const string Line = "line";
+
+        public const string Linkedin = "linkedin";
+
+        public const string Oauth1 = "oauth1";
+
+        public const string Oauth2 = "oauth2";
+
+        public const string Paypal = "paypal";
+
+        public const string PaypalSandbox = "paypal-sandbox";
+
+        public const string Planningcenter = "planningcenter";
+
+        public const string SalesforceCommunity = "salesforce-community";
+
+        public const string SalesforceSandbox = "salesforce-sandbox";
+
+        public const string Salesforce = "salesforce";
+
+        public const string Shopify = "shopify";
+
+        public const string Soundcloud = "soundcloud";
+
+        public const string Thirtysevensignals = "thirtysevensignals";
+
+        public const string Twitter = "twitter";
+
+        public const string Untapped = "untapped";
+
+        public const string Vkontakte = "vkontakte";
+
+        public const string Weibo = "weibo";
+
+        public const string Windowslive = "windowslive";
+
+        public const string Wordpress = "wordpress";
+
+        public const string Yahoo = "yahoo";
+
+        public const string Yandex = "yandex";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId.cs
@@ -1,0 +1,260 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId
+{
+    private EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId>
+    {
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId stringResult = new(
+                    "string",
+                    stringValue
+                );
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedObjectIdentitiesItemSocialUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserDeletedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserDeletedTypeEnum.EventStreamCloudEventUserDeletedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserDeletedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserDeletedTypeEnum UserDeleted = new(
+        Values.UserDeleted
+    );
+
+    public EventStreamCloudEventUserDeletedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserDeletedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventUserDeletedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserDeletedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserDeletedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventUserDeletedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventUserDeletedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventUserDeletedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserDeletedTypeEnum>
+    {
+        public override EventStreamCloudEventUserDeletedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserDeletedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserDeletedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserDeletedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string UserDeleted = "user.deleted";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdated.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdated.cs
@@ -1,0 +1,37 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// SSE message for user.updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdated : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Opaque cursor representing position in the stream. Pass as the `from` query parameter to resume.
+    /// </summary>
+    [JsonPropertyName("offset")]
+    public required string Offset { get; set; }
+
+    [JsonPropertyName("event")]
+    public required EventStreamCloudEventUserUpdatedCloudEvent Event { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedCloudEvent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedCloudEvent.cs
@@ -1,0 +1,74 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Represents an event that occurs when a user is updated.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedCloudEvent : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// The version of the CloudEvents specification which the event uses.
+    /// </summary>
+    [JsonPropertyName("specversion")]
+    public required string Specversion { get; set; }
+
+    [JsonPropertyName("type")]
+    public required EventStreamCloudEventUserUpdatedCloudEventTypeEnum Type { get; set; }
+
+    /// <summary>
+    /// The source of the event. This will take the form 'urn:auth0:&lt;tenant&gt;.&lt;domain&gt;'.
+    /// </summary>
+    [JsonPropertyName("source")]
+    public required string Source { get; set; }
+
+    /// <summary>
+    /// A unique identifier for the event.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; set; }
+
+    /// <summary>
+    /// An ISO-8601 timestamp indicating when the event physically occurred.
+    /// </summary>
+    [JsonPropertyName("time")]
+    public required DateTime Time { get; set; }
+
+    [JsonPropertyName("data")]
+    public required EventStreamCloudEventUserUpdatedData Data { get; set; }
+
+    /// <summary>
+    /// The auth0 tenant ID to which the event is associated.
+    /// </summary>
+    [JsonPropertyName("a0tenant")]
+    public required string A0Tenant { get; set; }
+
+    /// <summary>
+    /// The auth0 event stream ID of the stream the event was delivered on.
+    /// </summary>
+    [JsonPropertyName("a0stream")]
+    public required string A0Stream { get; set; }
+
+    [Optional]
+    [JsonPropertyName("a0purpose")]
+    public EventStreamCloudEventA0PurposeEnum? A0Purpose { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedCloudEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedCloudEventTypeEnum.cs
@@ -1,0 +1,124 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedCloudEventTypeEnum.EventStreamCloudEventUserUpdatedCloudEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserUpdatedCloudEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserUpdatedCloudEventTypeEnum UserUpdated = new(
+        Values.UserUpdated
+    );
+
+    public EventStreamCloudEventUserUpdatedCloudEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedCloudEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventUserUpdatedCloudEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserUpdatedCloudEventTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserUpdatedCloudEventTypeEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserUpdatedCloudEventTypeEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserUpdatedCloudEventTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserUpdatedCloudEventTypeEnum>
+    {
+        public override EventStreamCloudEventUserUpdatedCloudEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserUpdatedCloudEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedCloudEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedCloudEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string UserUpdated = "user.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedData.cs
@@ -1,0 +1,35 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event payload.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedData : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("object")]
+    public required EventStreamCloudEventUserUpdatedObject Object { get; set; }
+
+    [Optional]
+    [JsonPropertyName("context")]
+    public EventStreamCloudEventContext? Context { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObject.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObject.cs
@@ -1,0 +1,168 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The event content.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObject : IJsonOnDeserialized, IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// ID of the user which can be used when interacting with other APIs.
+    /// </summary>
+    [JsonPropertyName("user_id")]
+    public required string UserId { get; set; }
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was created (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("created_at")]
+    public required DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Date and time when this entity was last updated/modified (ISO_8601 format).
+    /// </summary>
+    [JsonPropertyName("updated_at")]
+    public required DateTime UpdatedAt { get; set; }
+
+    /// <summary>
+    /// Array of user identity objects when accounts are linked.
+    /// </summary>
+    [JsonPropertyName("identities")]
+    public IEnumerable<EventStreamCloudEventUserUpdatedObjectIdentitiesItem> Identities { get; set; } =
+        new List<EventStreamCloudEventUserUpdatedObjectIdentitiesItem>();
+
+    [Optional]
+    [JsonPropertyName("app_metadata")]
+    public Dictionary<string, object?>? AppMetadata { get; set; }
+
+    [Optional]
+    [JsonPropertyName("user_metadata")]
+    public Dictionary<string, object?>? UserMetadata { get; set; }
+
+    /// <summary>
+    /// URL to picture, photo, or avatar of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("picture")]
+    public string? Picture { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Preferred nickname or alias of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("nickname")]
+    public string? Nickname { get; set; }
+
+    /// <summary>
+    /// List of multi-factor authentication providers with which this user has enrolled.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("multifactor")]
+    public IEnumerable<string>? Multifactor { get; set; }
+
+    /// <summary>
+    /// Last IP address from which this user logged in.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("last_ip")]
+    public string? LastIp { get; set; }
+
+    /// <summary>
+    /// Last date and time this user logged in (ISO_8601 format).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("last_login")]
+    public DateTime? LastLogin { get; set; }
+
+    /// <summary>
+    /// Total number of logins this user has performed.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("logins_count")]
+    public int? LoginsCount { get; set; }
+
+    /// <summary>
+    /// Whether this user was blocked by an administrator (true) or is not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("blocked")]
+    public bool? Blocked { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItem.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItem.cs
@@ -1,0 +1,503 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Identity object when accounts are linked.
+/// </summary>
+[JsonConverter(typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItem.JsonConverter))]
+[Serializable]
+public class EventStreamCloudEventUserUpdatedObjectIdentitiesItem
+{
+    private EventStreamCloudEventUserUpdatedObjectIdentitiesItem(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItem FromEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItem FromEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItem FromEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItem FromEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless", value);
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItem FromEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom() =>
+        Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase() =>
+        Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise() =>
+        Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless() =>
+        Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial"
+    /// </summary>
+    public bool IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial() =>
+        Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom"/> if <see cref="Type"/> is 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom() =>
+        IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase"/> if <see cref="Type"/> is 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase() =>
+        IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise"/> if <see cref="Type"/> is 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise() =>
+        IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless"/> if <see cref="Type"/> is 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless() =>
+        IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless)
+                Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial"/> if <see cref="Type"/> is 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial() =>
+        IsEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial()
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial'"
+            );
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom(
+        out Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase(
+        out Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise(
+        out Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless(
+        out Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless")
+        {
+            value =
+                (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless)
+                    Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial(
+        out Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial? value
+    )
+    {
+        if (Type == "eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial)
+                Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom,
+            T
+        > onEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase,
+            T
+        > onEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise,
+            T
+        > onEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless,
+            T
+        > onEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial,
+            T
+        > onEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial
+    )
+    {
+        return Type switch
+        {
+            "eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom" =>
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom()
+                ),
+            "eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase" =>
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase()
+                ),
+            "eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise" =>
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise()
+                ),
+            "eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless" =>
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless()
+                ),
+            "eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial" =>
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial()
+                ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom> onEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase> onEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise> onEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless> onEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial> onEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom":
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom()
+                );
+                break;
+            case "eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase":
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase()
+                );
+                break;
+            case "eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise":
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise()
+                );
+                break;
+            case "eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless":
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless()
+                );
+                break;
+            case "eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial":
+                onEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial(
+                    AsEventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserUpdatedObjectIdentitiesItem other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItem(
+        Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial value
+    ) => new("eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItem>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItem? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom)
+                    ),
+                    (
+                        "eventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase)
+                    ),
+                    (
+                        "eventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise)
+                    ),
+                    (
+                        "eventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless)
+                    ),
+                    (
+                        "eventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial",
+                        typeof(Auth0.ManagementApi.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamCloudEventUserUpdatedObjectIdentitiesItem result = new(
+                                key,
+                                value
+                            );
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserUpdatedObjectIdentitiesItem"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItem value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItem ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItem result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItem value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for custom identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustom : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum.EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum Custom =
+        new(Values.Custom);
+
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Custom = "custom";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId.cs
@@ -1,0 +1,260 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId
+{
+    private EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId stringResult = new(
+                    "string",
+                    stringValue
+                );
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemCustomUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for database identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabase : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum.cs
@@ -1,0 +1,130 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum.EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum Auth0 =
+        new(Values.Auth0);
+
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Auth0 = "auth0";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId
+{
+    private EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemDatabaseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for enterprise identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterprise : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum.cs
@@ -1,0 +1,182 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum.EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Ad =
+        new(Values.Ad);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Adfs =
+        new(Values.Adfs);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum GoogleApps =
+        new(Values.GoogleApps);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Ip =
+        new(Values.Ip);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Office365 =
+        new(Values.Office365);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Oidc =
+        new(Values.Oidc);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Okta =
+        new(Values.Okta);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Pingfederate =
+        new(Values.Pingfederate);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Samlp =
+        new(Values.Samlp);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Sharepoint =
+        new(Values.Sharepoint);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Waad =
+        new(Values.Waad);
+
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum(
+            value
+        );
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Ad = "ad";
+
+        public const string Adfs = "adfs";
+
+        public const string GoogleApps = "google-apps";
+
+        public const string Ip = "ip";
+
+        public const string Office365 = "office365";
+
+        public const string Oidc = "oidc";
+
+        public const string Okta = "okta";
+
+        public const string Pingfederate = "pingfederate";
+
+        public const string Samlp = "samlp";
+
+        public const string Sharepoint = "sharepoint";
+
+        public const string Waad = "waad";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId
+{
+    private EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemEnterpriseUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for passwordless identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordless : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum.cs
@@ -1,0 +1,139 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum.EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum Email =
+        new(Values.Email);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum Sms =
+        new(Values.Sms);
+
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum(
+        string value
+    )
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum(
+            value
+        );
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Email = "email";
+
+        public const string Sms = "sms";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId.cs
@@ -1,0 +1,258 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId
+{
+    private EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId stringResult =
+                    new("string", stringValue);
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemPasswordlessUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial.cs
@@ -1,0 +1,47 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The identity object for social identity providers.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocial : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    /// <summary>
+    /// Name of the connection containing this identity.
+    /// </summary>
+    [JsonPropertyName("connection")]
+    public required string Connection { get; set; }
+
+    [JsonPropertyName("user_id")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId UserId { get; set; }
+
+    [Optional]
+    [JsonPropertyName("profileData")]
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProfileData? ProfileData { get; set; }
+
+    [JsonPropertyName("provider")]
+    public required EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Provider { get; set; }
+
+    [JsonPropertyName("isSocial")]
+    public required bool IsSocial { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProfileData.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProfileData.cs
@@ -1,0 +1,88 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Profile data for the user.
+/// </summary>
+[Serializable]
+public record EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProfileData
+    : IJsonOnDeserialized,
+        IJsonOnSerializing
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, object?> _extensionData =
+        new Dictionary<string, object?>();
+
+    /// <summary>
+    /// Email address of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email")]
+    public string? Email { get; set; }
+
+    /// <summary>
+    /// Whether this email address is verified (true) or unverified (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("email_verified")]
+    public bool? EmailVerified { get; set; }
+
+    /// <summary>
+    /// Name of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("name")]
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// Username of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("username")]
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// Given name/first name/forename of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("given_name")]
+    public string? GivenName { get; set; }
+
+    /// <summary>
+    /// Family name/last name/surname of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("family_name")]
+    public string? FamilyName { get; set; }
+
+    /// <summary>
+    /// Phone number of this user.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_number")]
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// Whether this phone number has been verified (true) or not (false).
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("phone_verified")]
+    public bool? PhoneVerified { get; set; }
+
+    [JsonIgnore]
+    public AdditionalProperties AdditionalProperties { get; set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    void IJsonOnSerializing.OnSerializing() =>
+        AdditionalProperties.CopyToExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum.cs
@@ -1,0 +1,320 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum.EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum
+    : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Amazon =
+        new(Values.Amazon);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Apple =
+        new(Values.Apple);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Dropbox =
+        new(Values.Dropbox);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Bitbucket =
+        new(Values.Bitbucket);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Auth0Oidc =
+        new(Values.Auth0Oidc);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Baidu =
+        new(Values.Baidu);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Bitly =
+        new(Values.Bitly);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Box =
+        new(Values.Box);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Daccount =
+        new(Values.Daccount);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Dwolla =
+        new(Values.Dwolla);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum EvernoteSandbox =
+        new(Values.EvernoteSandbox);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Evernote =
+        new(Values.Evernote);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Exact =
+        new(Values.Exact);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Facebook =
+        new(Values.Facebook);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Fitbit =
+        new(Values.Fitbit);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Github =
+        new(Values.Github);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum GoogleOauth2 =
+        new(Values.GoogleOauth2);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Instagram =
+        new(Values.Instagram);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Line =
+        new(Values.Line);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Linkedin =
+        new(Values.Linkedin);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Oauth1 =
+        new(Values.Oauth1);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Oauth2 =
+        new(Values.Oauth2);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Paypal =
+        new(Values.Paypal);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum PaypalSandbox =
+        new(Values.PaypalSandbox);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Planningcenter =
+        new(Values.Planningcenter);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum SalesforceCommunity =
+        new(Values.SalesforceCommunity);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum SalesforceSandbox =
+        new(Values.SalesforceSandbox);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Salesforce =
+        new(Values.Salesforce);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Shopify =
+        new(Values.Shopify);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Soundcloud =
+        new(Values.Soundcloud);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Thirtysevensignals =
+        new(Values.Thirtysevensignals);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Twitter =
+        new(Values.Twitter);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Untapped =
+        new(Values.Untapped);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Vkontakte =
+        new(Values.Vkontakte);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Weibo =
+        new(Values.Weibo);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Windowslive =
+        new(Values.Windowslive);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Wordpress =
+        new(Values.Wordpress);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Yahoo =
+        new(Values.Yahoo);
+
+    public static readonly EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Yandex =
+        new(Values.Yandex);
+
+    public EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum FromCustom(
+        string value
+    )
+    {
+        return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(
+        EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum value
+    ) => value.Value;
+
+    public static explicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum(
+        string value
+    ) => new(value);
+
+    internal class EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum(
+                stringValue
+            );
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialProviderEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Amazon = "amazon";
+
+        public const string Apple = "apple";
+
+        public const string Dropbox = "dropbox";
+
+        public const string Bitbucket = "bitbucket";
+
+        public const string Auth0Oidc = "auth0-oidc";
+
+        public const string Baidu = "baidu";
+
+        public const string Bitly = "bitly";
+
+        public const string Box = "box";
+
+        public const string Daccount = "daccount";
+
+        public const string Dwolla = "dwolla";
+
+        public const string EvernoteSandbox = "evernote-sandbox";
+
+        public const string Evernote = "evernote";
+
+        public const string Exact = "exact";
+
+        public const string Facebook = "facebook";
+
+        public const string Fitbit = "fitbit";
+
+        public const string Github = "github";
+
+        public const string GoogleOauth2 = "google-oauth2";
+
+        public const string Instagram = "instagram";
+
+        public const string Line = "line";
+
+        public const string Linkedin = "linkedin";
+
+        public const string Oauth1 = "oauth1";
+
+        public const string Oauth2 = "oauth2";
+
+        public const string Paypal = "paypal";
+
+        public const string PaypalSandbox = "paypal-sandbox";
+
+        public const string Planningcenter = "planningcenter";
+
+        public const string SalesforceCommunity = "salesforce-community";
+
+        public const string SalesforceSandbox = "salesforce-sandbox";
+
+        public const string Salesforce = "salesforce";
+
+        public const string Shopify = "shopify";
+
+        public const string Soundcloud = "soundcloud";
+
+        public const string Thirtysevensignals = "thirtysevensignals";
+
+        public const string Twitter = "twitter";
+
+        public const string Untapped = "untapped";
+
+        public const string Vkontakte = "vkontakte";
+
+        public const string Weibo = "weibo";
+
+        public const string Windowslive = "windowslive";
+
+        public const string Wordpress = "wordpress";
+
+        public const string Yahoo = "yahoo";
+
+        public const string Yandex = "yandex";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId.cs
@@ -1,0 +1,260 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The IDP-specific identifer for the user.
+/// </summary>
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId.JsonConverter)
+)]
+[Serializable]
+public class EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId
+{
+    private EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId(
+        string type,
+        object? value
+    )
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a string value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId FromString(
+        string value
+    ) => new("string", value);
+
+    /// <summary>
+    /// Factory method to create a union from a int value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId FromInt(
+        int value
+    ) => new("int", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "string"
+    /// </summary>
+    public bool IsString() => Type == "string";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "int"
+    /// </summary>
+    public bool IsInt() => Type == "int";
+
+    /// <summary>
+    /// Returns the value as a <see cref="string"/> if <see cref="Type"/> is 'string', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'string'.</exception>
+    public string AsString() =>
+        IsString() ? (string)Value! : throw new ManagementException("Union type is not 'string'");
+
+    /// <summary>
+    /// Returns the value as a <see cref="int"/> if <see cref="Type"/> is 'int', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'int'.</exception>
+    public int AsInt() =>
+        IsInt() ? (int)Value! : throw new ManagementException("Union type is not 'int'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="string"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetString(out string? value)
+    {
+        if (Type == "string")
+        {
+            value = (string)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="int"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetInt(out int? value)
+    {
+        if (Type == "int")
+        {
+            value = (int)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(Func<string, T> onString, Func<int, T> onInt)
+    {
+        return Type switch
+        {
+            "string" => onString(AsString()),
+            "int" => onInt(AsInt()),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(global::System.Action<string> onString, global::System.Action<int> onInt)
+    {
+        switch (Type)
+        {
+            case "string":
+                onString(AsString());
+                break;
+            case "int":
+                onInt(AsInt());
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId(
+        string value
+    ) => new("string", value);
+
+    public static implicit operator EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId(
+        int value
+    ) => new("int", value);
+
+    [Serializable]
+    internal sealed class JsonConverter
+        : JsonConverter<EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId>
+    {
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out var intValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId intResult =
+                        new("int", intValue);
+                    return intResult;
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var stringValue = reader.GetString()!;
+
+                if (int.TryParse(stringValue, out var intFromStringValue))
+                {
+                    EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId intFromStringResult =
+                        new("int", intFromStringValue);
+                    return intFromStringResult;
+                }
+
+                EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId stringResult = new(
+                    "string",
+                    stringValue
+                );
+                return stringResult;
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(str => writer.WriteStringValue(str), num => writer.WriteNumberValue(num));
+        }
+
+        public override EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId result = new(
+                "string",
+                stringValue
+            );
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedObjectIdentitiesItemSocialUserId value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamCloudEventUserUpdatedTypeEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamCloudEventUserUpdatedTypeEnum.EventStreamCloudEventUserUpdatedTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamCloudEventUserUpdatedTypeEnum : IStringEnum
+{
+    public static readonly EventStreamCloudEventUserUpdatedTypeEnum UserUpdated = new(
+        Values.UserUpdated
+    );
+
+    public EventStreamCloudEventUserUpdatedTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamCloudEventUserUpdatedTypeEnum FromCustom(string value)
+    {
+        return new EventStreamCloudEventUserUpdatedTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(
+        EventStreamCloudEventUserUpdatedTypeEnum value1,
+        string value2
+    ) => value1.Value.Equals(value2);
+
+    public static bool operator !=(
+        EventStreamCloudEventUserUpdatedTypeEnum value1,
+        string value2
+    ) => !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamCloudEventUserUpdatedTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamCloudEventUserUpdatedTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamCloudEventUserUpdatedTypeEnumSerializer
+        : JsonConverter<EventStreamCloudEventUserUpdatedTypeEnum>
+    {
+        public override EventStreamCloudEventUserUpdatedTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamCloudEventUserUpdatedTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamCloudEventUserUpdatedTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamCloudEventUserUpdatedTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string UserUpdated = "user.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamSubscribeEventsEventTypeEnum.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamSubscribeEventsEventTypeEnum.cs
@@ -1,0 +1,237 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(EventStreamSubscribeEventsEventTypeEnum.EventStreamSubscribeEventsEventTypeEnumSerializer)
+)]
+[Serializable]
+public readonly record struct EventStreamSubscribeEventsEventTypeEnum : IStringEnum
+{
+    public static readonly EventStreamSubscribeEventsEventTypeEnum GroupCreated = new(
+        Values.GroupCreated
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum GroupDeleted = new(
+        Values.GroupDeleted
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum GroupMemberAdded = new(
+        Values.GroupMemberAdded
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum GroupMemberDeleted = new(
+        Values.GroupMemberDeleted
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum GroupRoleAssigned = new(
+        Values.GroupRoleAssigned
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum GroupRoleDeleted = new(
+        Values.GroupRoleDeleted
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum GroupUpdated = new(
+        Values.GroupUpdated
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationConnectionAdded =
+        new(Values.OrganizationConnectionAdded);
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationConnectionRemoved =
+        new(Values.OrganizationConnectionRemoved);
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationConnectionUpdated =
+        new(Values.OrganizationConnectionUpdated);
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationCreated = new(
+        Values.OrganizationCreated
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationDeleted = new(
+        Values.OrganizationDeleted
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationGroupRoleAssigned =
+        new(Values.OrganizationGroupRoleAssigned);
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationGroupRoleDeleted =
+        new(Values.OrganizationGroupRoleDeleted);
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationMemberAdded = new(
+        Values.OrganizationMemberAdded
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationMemberDeleted = new(
+        Values.OrganizationMemberDeleted
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationMemberRoleAssigned =
+        new(Values.OrganizationMemberRoleAssigned);
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationMemberRoleDeleted =
+        new(Values.OrganizationMemberRoleDeleted);
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum OrganizationUpdated = new(
+        Values.OrganizationUpdated
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum UserCreated = new(
+        Values.UserCreated
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum UserDeleted = new(
+        Values.UserDeleted
+    );
+
+    public static readonly EventStreamSubscribeEventsEventTypeEnum UserUpdated = new(
+        Values.UserUpdated
+    );
+
+    public EventStreamSubscribeEventsEventTypeEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static EventStreamSubscribeEventsEventTypeEnum FromCustom(string value)
+    {
+        return new EventStreamSubscribeEventsEventTypeEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(EventStreamSubscribeEventsEventTypeEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(EventStreamSubscribeEventsEventTypeEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(EventStreamSubscribeEventsEventTypeEnum value) =>
+        value.Value;
+
+    public static explicit operator EventStreamSubscribeEventsEventTypeEnum(string value) =>
+        new(value);
+
+    internal class EventStreamSubscribeEventsEventTypeEnumSerializer
+        : JsonConverter<EventStreamSubscribeEventsEventTypeEnum>
+    {
+        public override EventStreamSubscribeEventsEventTypeEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new EventStreamSubscribeEventsEventTypeEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamSubscribeEventsEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override EventStreamSubscribeEventsEventTypeEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new EventStreamSubscribeEventsEventTypeEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamSubscribeEventsEventTypeEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string GroupCreated = "group.created";
+
+        public const string GroupDeleted = "group.deleted";
+
+        public const string GroupMemberAdded = "group.member.added";
+
+        public const string GroupMemberDeleted = "group.member.deleted";
+
+        public const string GroupRoleAssigned = "group.role.assigned";
+
+        public const string GroupRoleDeleted = "group.role.deleted";
+
+        public const string GroupUpdated = "group.updated";
+
+        public const string OrganizationConnectionAdded = "organization.connection.added";
+
+        public const string OrganizationConnectionRemoved = "organization.connection.removed";
+
+        public const string OrganizationConnectionUpdated = "organization.connection.updated";
+
+        public const string OrganizationCreated = "organization.created";
+
+        public const string OrganizationDeleted = "organization.deleted";
+
+        public const string OrganizationGroupRoleAssigned = "organization.group.role.assigned";
+
+        public const string OrganizationGroupRoleDeleted = "organization.group.role.deleted";
+
+        public const string OrganizationMemberAdded = "organization.member.added";
+
+        public const string OrganizationMemberDeleted = "organization.member.deleted";
+
+        public const string OrganizationMemberRoleAssigned = "organization.member.role.assigned";
+
+        public const string OrganizationMemberRoleDeleted = "organization.member.role.deleted";
+
+        public const string OrganizationUpdated = "organization.updated";
+
+        public const string UserCreated = "user.created";
+
+        public const string UserDeleted = "user.deleted";
+
+        public const string UserUpdated = "user.updated";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamSubscribeEventsEventTypeParam.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamSubscribeEventsEventTypeParam.cs
@@ -1,0 +1,312 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Event type(s) to listen for. Specify multiple times for multiple types (e.g., ?event_type=user.created&event_type=user.updated). If not provided, all event types will be streamed.
+/// </summary>
+[JsonConverter(typeof(EventStreamSubscribeEventsEventTypeParam.JsonConverter))]
+[Serializable]
+public class EventStreamSubscribeEventsEventTypeParam
+{
+    private EventStreamSubscribeEventsEventTypeParam(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Type discriminator
+    /// </summary>
+    [JsonIgnore]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Union value
+    /// </summary>
+    [JsonIgnore]
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Factory method to create a union from a Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum value.
+    /// </summary>
+    public static EventStreamSubscribeEventsEventTypeParam FromEventStreamSubscribeEventsEventTypeEnum(
+        Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum value
+    ) => new("eventStreamSubscribeEventsEventTypeEnum", value);
+
+    /// <summary>
+    /// Factory method to create a union from a IEnumerable<EventStreamSubscribeEventsEventTypeEnum> value.
+    /// </summary>
+    public static EventStreamSubscribeEventsEventTypeParam FromListOfEventStreamSubscribeEventsEventTypeEnum(
+        IEnumerable<EventStreamSubscribeEventsEventTypeEnum> value
+    ) => new("list", value);
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "eventStreamSubscribeEventsEventTypeEnum"
+    /// </summary>
+    public bool IsEventStreamSubscribeEventsEventTypeEnum() =>
+        Type == "eventStreamSubscribeEventsEventTypeEnum";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "list"
+    /// </summary>
+    public bool IsListOfEventStreamSubscribeEventsEventTypeEnum() => Type == "list";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum"/> if <see cref="Type"/> is 'eventStreamSubscribeEventsEventTypeEnum', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'eventStreamSubscribeEventsEventTypeEnum'.</exception>
+    public Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum AsEventStreamSubscribeEventsEventTypeEnum() =>
+        IsEventStreamSubscribeEventsEventTypeEnum()
+            ? (Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum)Value!
+            : throw new ManagementException(
+                "Union type is not 'eventStreamSubscribeEventsEventTypeEnum'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="IEnumerable<EventStreamSubscribeEventsEventTypeEnum>"/> if <see cref="Type"/> is 'list', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="ManagementException">Thrown when <see cref="Type"/> is not 'list'.</exception>
+    public IEnumerable<EventStreamSubscribeEventsEventTypeEnum> AsListOfEventStreamSubscribeEventsEventTypeEnum() =>
+        IsListOfEventStreamSubscribeEventsEventTypeEnum()
+            ? (IEnumerable<EventStreamSubscribeEventsEventTypeEnum>)Value!
+            : throw new ManagementException("Union type is not 'list'");
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetEventStreamSubscribeEventsEventTypeEnum(
+        out Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum? value
+    )
+    {
+        if (Type == "eventStreamSubscribeEventsEventTypeEnum")
+        {
+            value = (Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="IEnumerable<EventStreamSubscribeEventsEventTypeEnum>"/> and returns true if successful.
+    /// </summary>
+    public bool TryGetListOfEventStreamSubscribeEventsEventTypeEnum(
+        out IEnumerable<EventStreamSubscribeEventsEventTypeEnum>? value
+    )
+    {
+        if (Type == "list")
+        {
+            value = (IEnumerable<EventStreamSubscribeEventsEventTypeEnum>)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public T Match<T>(
+        Func<
+            Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum,
+            T
+        > onEventStreamSubscribeEventsEventTypeEnum,
+        Func<
+            IEnumerable<EventStreamSubscribeEventsEventTypeEnum>,
+            T
+        > onListOfEventStreamSubscribeEventsEventTypeEnum
+    )
+    {
+        return Type switch
+        {
+            "eventStreamSubscribeEventsEventTypeEnum" => onEventStreamSubscribeEventsEventTypeEnum(
+                AsEventStreamSubscribeEventsEventTypeEnum()
+            ),
+            "list" => onListOfEventStreamSubscribeEventsEventTypeEnum(
+                AsListOfEventStreamSubscribeEventsEventTypeEnum()
+            ),
+            _ => throw new ManagementException($"Unknown union type: {Type}"),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum> onEventStreamSubscribeEventsEventTypeEnum,
+        global::System.Action<
+            IEnumerable<EventStreamSubscribeEventsEventTypeEnum>
+        > onListOfEventStreamSubscribeEventsEventTypeEnum
+    )
+    {
+        switch (Type)
+        {
+            case "eventStreamSubscribeEventsEventTypeEnum":
+                onEventStreamSubscribeEventsEventTypeEnum(
+                    AsEventStreamSubscribeEventsEventTypeEnum()
+                );
+                break;
+            case "list":
+                onListOfEventStreamSubscribeEventsEventTypeEnum(
+                    AsListOfEventStreamSubscribeEventsEventTypeEnum()
+                );
+                break;
+            default:
+                throw new ManagementException($"Unknown union type: {Type}");
+        }
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Type.GetHashCode();
+            if (Value != null)
+            {
+                hashCode = (hashCode * 397) ^ Value.GetHashCode();
+            }
+            return hashCode;
+        }
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null)
+            return false;
+        if (ReferenceEquals(this, obj))
+            return true;
+        if (obj is not EventStreamSubscribeEventsEventTypeParam other)
+            return false;
+
+        // Compare type discriminators
+        if (Type != other.Type)
+            return false;
+
+        // Compare values using EqualityComparer for deep comparison
+        return System.Collections.Generic.EqualityComparer<object?>.Default.Equals(
+            Value,
+            other.Value
+        );
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamSubscribeEventsEventTypeParam(
+        Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum value
+    ) => new("eventStreamSubscribeEventsEventTypeEnum", value);
+
+    [Serializable]
+    internal sealed class JsonConverter : JsonConverter<EventStreamSubscribeEventsEventTypeParam>
+    {
+        public override EventStreamSubscribeEventsEventTypeParam? Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            if (reader.TokenType == JsonTokenType.StartArray)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    ("list", typeof(IEnumerable<EventStreamSubscribeEventsEventTypeEnum>)),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamSubscribeEventsEventTypeParam result = new(key, value);
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            if (reader.TokenType == JsonTokenType.StartObject)
+            {
+                var document = JsonDocument.ParseValue(ref reader);
+
+                var types = new (string Key, System.Type Type)[]
+                {
+                    (
+                        "eventStreamSubscribeEventsEventTypeEnum",
+                        typeof(Auth0.ManagementApi.EventStreamSubscribeEventsEventTypeEnum)
+                    ),
+                };
+
+                foreach (var (key, type) in types)
+                {
+                    try
+                    {
+                        var value = document.Deserialize(type, options);
+                        if (value != null)
+                        {
+                            EventStreamSubscribeEventsEventTypeParam result = new(key, value);
+                            return result;
+                        }
+                    }
+                    catch (JsonException)
+                    {
+                        // Try next type;
+                    }
+                }
+            }
+
+            throw new JsonException(
+                $"Cannot deserialize JSON token {reader.TokenType} into EventStreamSubscribeEventsEventTypeParam"
+            );
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamSubscribeEventsEventTypeParam value,
+            JsonSerializerOptions options
+        )
+        {
+            if (value == null)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            value.Visit(
+                obj => JsonSerializer.Serialize(writer, obj, options),
+                obj => JsonSerializer.Serialize(writer, obj, options)
+            );
+        }
+
+        public override EventStreamSubscribeEventsEventTypeParam ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue = reader.GetString()!;
+            EventStreamSubscribeEventsEventTypeParam result = new("string", stringValue);
+            return result;
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamSubscribeEventsEventTypeParam value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value?.ToString() ?? "null");
+        }
+    }
+}

--- a/src/Auth0.ManagementApi/Types/EventStreamSubscribeEventsResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/EventStreamSubscribeEventsResponseContent.cs
@@ -1,0 +1,2156 @@
+// ReSharper disable NullableWarningSuppressionIsUsed
+// ReSharper disable InconsistentNaming
+
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Nodes;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// The JSON payload delivered in each SSE data line. The type field is injected from the SSE event field by the SDK. Discriminated by type: an event type name for events, "error" for errors, and "offset-only" for cursor-only heartbeats.
+/// </summary>
+[JsonConverter(typeof(EventStreamSubscribeEventsResponseContent.JsonConverter))]
+[Serializable]
+public record EventStreamSubscribeEventsResponseContent
+{
+    internal EventStreamSubscribeEventsResponseContent(string type, object? value)
+    {
+        Type = type;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.GroupCreated"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupCreated value
+    )
+    {
+        Type = "group.created";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.GroupDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupDeleted value
+    )
+    {
+        Type = "group.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.GroupMemberAdded"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupMemberAdded value
+    )
+    {
+        Type = "group.member.added";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.GroupMemberDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupMemberDeleted value
+    )
+    {
+        Type = "group.member.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.GroupRoleAssigned"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupRoleAssigned value
+    )
+    {
+        Type = "group.role.assigned";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.GroupRoleDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupRoleDeleted value
+    )
+    {
+        Type = "group.role.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.GroupUpdated"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupUpdated value
+    )
+    {
+        Type = "group.updated";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationConnectionAdded"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationConnectionAdded value
+    )
+    {
+        Type = "organization.connection.added";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationConnectionRemoved"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationConnectionRemoved value
+    )
+    {
+        Type = "organization.connection.removed";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationConnectionUpdated"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationConnectionUpdated value
+    )
+    {
+        Type = "organization.connection.updated";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationCreated"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationCreated value
+    )
+    {
+        Type = "organization.created";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationDeleted value
+    )
+    {
+        Type = "organization.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleAssigned"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleAssigned value
+    )
+    {
+        Type = "organization.group.role.assigned";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleDeleted value
+    )
+    {
+        Type = "organization.group.role.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationMemberAdded"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberAdded value
+    )
+    {
+        Type = "organization.member.added";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationMemberDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberDeleted value
+    )
+    {
+        Type = "organization.member.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleAssigned"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleAssigned value
+    )
+    {
+        Type = "organization.member.role.assigned";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleDeleted value
+    )
+    {
+        Type = "organization.member.role.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OrganizationUpdated"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationUpdated value
+    )
+    {
+        Type = "organization.updated";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.UserCreated"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.UserCreated value
+    )
+    {
+        Type = "user.created";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.UserDeleted"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.UserDeleted value
+    )
+    {
+        Type = "user.deleted";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.UserUpdated"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.UserUpdated value
+    )
+    {
+        Type = "user.updated";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.Error"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.Error value
+    )
+    {
+        Type = "error";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Create an instance of EventStreamSubscribeEventsResponseContent with <see cref="EventStreamSubscribeEventsResponseContent.OffsetOnly"/>.
+    /// </summary>
+    public EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OffsetOnly value
+    )
+    {
+        Type = "offset-only";
+        Value = value.Value;
+    }
+
+    /// <summary>
+    /// Discriminant value
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; internal set; }
+
+    /// <summary>
+    /// Discriminated union value
+    /// </summary>
+    public object? Value { get; internal set; }
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "group.created"
+    /// </summary>
+    public bool IsGroupCreated => Type == "group.created";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "group.deleted"
+    /// </summary>
+    public bool IsGroupDeleted => Type == "group.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "group.member.added"
+    /// </summary>
+    public bool IsGroupMemberAdded => Type == "group.member.added";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "group.member.deleted"
+    /// </summary>
+    public bool IsGroupMemberDeleted => Type == "group.member.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "group.role.assigned"
+    /// </summary>
+    public bool IsGroupRoleAssigned => Type == "group.role.assigned";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "group.role.deleted"
+    /// </summary>
+    public bool IsGroupRoleDeleted => Type == "group.role.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "group.updated"
+    /// </summary>
+    public bool IsGroupUpdated => Type == "group.updated";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.connection.added"
+    /// </summary>
+    public bool IsOrganizationConnectionAdded => Type == "organization.connection.added";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.connection.removed"
+    /// </summary>
+    public bool IsOrganizationConnectionRemoved => Type == "organization.connection.removed";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.connection.updated"
+    /// </summary>
+    public bool IsOrganizationConnectionUpdated => Type == "organization.connection.updated";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.created"
+    /// </summary>
+    public bool IsOrganizationCreated => Type == "organization.created";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.deleted"
+    /// </summary>
+    public bool IsOrganizationDeleted => Type == "organization.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.group.role.assigned"
+    /// </summary>
+    public bool IsOrganizationGroupRoleAssigned => Type == "organization.group.role.assigned";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.group.role.deleted"
+    /// </summary>
+    public bool IsOrganizationGroupRoleDeleted => Type == "organization.group.role.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.member.added"
+    /// </summary>
+    public bool IsOrganizationMemberAdded => Type == "organization.member.added";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.member.deleted"
+    /// </summary>
+    public bool IsOrganizationMemberDeleted => Type == "organization.member.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.member.role.assigned"
+    /// </summary>
+    public bool IsOrganizationMemberRoleAssigned => Type == "organization.member.role.assigned";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.member.role.deleted"
+    /// </summary>
+    public bool IsOrganizationMemberRoleDeleted => Type == "organization.member.role.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "organization.updated"
+    /// </summary>
+    public bool IsOrganizationUpdated => Type == "organization.updated";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "user.created"
+    /// </summary>
+    public bool IsUserCreated => Type == "user.created";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "user.deleted"
+    /// </summary>
+    public bool IsUserDeleted => Type == "user.deleted";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "user.updated"
+    /// </summary>
+    public bool IsUserUpdated => Type == "user.updated";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "error"
+    /// </summary>
+    public bool IsError => Type == "error";
+
+    /// <summary>
+    /// Returns true if <see cref="Type"/> is "offset-only"
+    /// </summary>
+    public bool IsOffsetOnly => Type == "offset-only";
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreated"/> if <see cref="Type"/> is 'group.created', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'group.created'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupCreated AsGroupCreated() =>
+        IsGroupCreated
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupCreated)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'group.created'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeleted"/> if <see cref="Type"/> is 'group.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'group.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupDeleted AsGroupDeleted() =>
+        IsGroupDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'group.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded"/> if <see cref="Type"/> is 'group.member.added', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'group.member.added'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded AsGroupMemberAdded() =>
+        IsGroupMemberAdded
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'group.member.added'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted"/> if <see cref="Type"/> is 'group.member.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'group.member.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted AsGroupMemberDeleted() =>
+        IsGroupMemberDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'group.member.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned"/> if <see cref="Type"/> is 'group.role.assigned', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'group.role.assigned'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned AsGroupRoleAssigned() =>
+        IsGroupRoleAssigned
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'group.role.assigned'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted"/> if <see cref="Type"/> is 'group.role.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'group.role.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted AsGroupRoleDeleted() =>
+        IsGroupRoleDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'group.role.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdated"/> if <see cref="Type"/> is 'group.updated', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'group.updated'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventGroupUpdated AsGroupUpdated() =>
+        IsGroupUpdated
+            ? (Auth0.ManagementApi.EventStreamCloudEventGroupUpdated)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'group.updated'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded"/> if <see cref="Type"/> is 'organization.connection.added', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.connection.added'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded AsOrganizationConnectionAdded() =>
+        IsOrganizationConnectionAdded
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.connection.added'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved"/> if <see cref="Type"/> is 'organization.connection.removed', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.connection.removed'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved AsOrganizationConnectionRemoved() =>
+        IsOrganizationConnectionRemoved
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.connection.removed'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated"/> if <see cref="Type"/> is 'organization.connection.updated', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.connection.updated'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated AsOrganizationConnectionUpdated() =>
+        IsOrganizationConnectionUpdated
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.connection.updated'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgCreated"/> if <see cref="Type"/> is 'organization.created', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.created'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgCreated AsOrganizationCreated() =>
+        IsOrganizationCreated
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgCreated)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.created'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgDeleted"/> if <see cref="Type"/> is 'organization.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgDeleted AsOrganizationDeleted() =>
+        IsOrganizationDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned"/> if <see cref="Type"/> is 'organization.group.role.assigned', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.group.role.assigned'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned AsOrganizationGroupRoleAssigned() =>
+        IsOrganizationGroupRoleAssigned
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.group.role.assigned'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted"/> if <see cref="Type"/> is 'organization.group.role.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.group.role.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted AsOrganizationGroupRoleDeleted() =>
+        IsOrganizationGroupRoleDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.group.role.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded"/> if <see cref="Type"/> is 'organization.member.added', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.member.added'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded AsOrganizationMemberAdded() =>
+        IsOrganizationMemberAdded
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.member.added'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted"/> if <see cref="Type"/> is 'organization.member.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.member.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted AsOrganizationMemberDeleted() =>
+        IsOrganizationMemberDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.member.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned"/> if <see cref="Type"/> is 'organization.member.role.assigned', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.member.role.assigned'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned AsOrganizationMemberRoleAssigned() =>
+        IsOrganizationMemberRoleAssigned
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.member.role.assigned'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted"/> if <see cref="Type"/> is 'organization.member.role.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.member.role.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted AsOrganizationMemberRoleDeleted() =>
+        IsOrganizationMemberRoleDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.member.role.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgUpdated"/> if <see cref="Type"/> is 'organization.updated', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'organization.updated'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOrgUpdated AsOrganizationUpdated() =>
+        IsOrganizationUpdated
+            ? (Auth0.ManagementApi.EventStreamCloudEventOrgUpdated)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'organization.updated'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreated"/> if <see cref="Type"/> is 'user.created', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'user.created'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserCreated AsUserCreated() =>
+        IsUserCreated
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserCreated)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'user.created'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeleted"/> if <see cref="Type"/> is 'user.deleted', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'user.deleted'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserDeleted AsUserDeleted() =>
+        IsUserDeleted
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserDeleted)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'user.deleted'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdated"/> if <see cref="Type"/> is 'user.updated', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'user.updated'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventUserUpdated AsUserUpdated() =>
+        IsUserUpdated
+            ? (Auth0.ManagementApi.EventStreamCloudEventUserUpdated)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'user.updated'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventErrorMessage"/> if <see cref="Type"/> is 'error', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'error'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventErrorMessage AsError() =>
+        IsError
+            ? (Auth0.ManagementApi.EventStreamCloudEventErrorMessage)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'error'"
+            );
+
+    /// <summary>
+    /// Returns the value as a <see cref="Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage"/> if <see cref="Type"/> is 'offset-only', otherwise throws an exception.
+    /// </summary>
+    /// <exception cref="Exception">Thrown when <see cref="Type"/> is not 'offset-only'.</exception>
+    public Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage AsOffsetOnly() =>
+        IsOffsetOnly
+            ? (Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage)Value!
+            : throw new global::System.Exception(
+                "EventStreamSubscribeEventsResponseContent.Type is not 'offset-only'"
+            );
+
+    public T Match<T>(
+        Func<Auth0.ManagementApi.EventStreamCloudEventGroupCreated, T> onGroupCreated,
+        Func<Auth0.ManagementApi.EventStreamCloudEventGroupDeleted, T> onGroupDeleted,
+        Func<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded, T> onGroupMemberAdded,
+        Func<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted, T> onGroupMemberDeleted,
+        Func<Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned, T> onGroupRoleAssigned,
+        Func<Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted, T> onGroupRoleDeleted,
+        Func<Auth0.ManagementApi.EventStreamCloudEventGroupUpdated, T> onGroupUpdated,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded,
+            T
+        > onOrganizationConnectionAdded,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved,
+            T
+        > onOrganizationConnectionRemoved,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated,
+            T
+        > onOrganizationConnectionUpdated,
+        Func<Auth0.ManagementApi.EventStreamCloudEventOrgCreated, T> onOrganizationCreated,
+        Func<Auth0.ManagementApi.EventStreamCloudEventOrgDeleted, T> onOrganizationDeleted,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned,
+            T
+        > onOrganizationGroupRoleAssigned,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted,
+            T
+        > onOrganizationGroupRoleDeleted,
+        Func<Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded, T> onOrganizationMemberAdded,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted,
+            T
+        > onOrganizationMemberDeleted,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned,
+            T
+        > onOrganizationMemberRoleAssigned,
+        Func<
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted,
+            T
+        > onOrganizationMemberRoleDeleted,
+        Func<Auth0.ManagementApi.EventStreamCloudEventOrgUpdated, T> onOrganizationUpdated,
+        Func<Auth0.ManagementApi.EventStreamCloudEventUserCreated, T> onUserCreated,
+        Func<Auth0.ManagementApi.EventStreamCloudEventUserDeleted, T> onUserDeleted,
+        Func<Auth0.ManagementApi.EventStreamCloudEventUserUpdated, T> onUserUpdated,
+        Func<Auth0.ManagementApi.EventStreamCloudEventErrorMessage, T> onError,
+        Func<Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage, T> onOffsetOnly,
+        Func<string, object?, T> onUnknown_
+    )
+    {
+        return Type switch
+        {
+            "group.created" => onGroupCreated(AsGroupCreated()),
+            "group.deleted" => onGroupDeleted(AsGroupDeleted()),
+            "group.member.added" => onGroupMemberAdded(AsGroupMemberAdded()),
+            "group.member.deleted" => onGroupMemberDeleted(AsGroupMemberDeleted()),
+            "group.role.assigned" => onGroupRoleAssigned(AsGroupRoleAssigned()),
+            "group.role.deleted" => onGroupRoleDeleted(AsGroupRoleDeleted()),
+            "group.updated" => onGroupUpdated(AsGroupUpdated()),
+            "organization.connection.added" => onOrganizationConnectionAdded(
+                AsOrganizationConnectionAdded()
+            ),
+            "organization.connection.removed" => onOrganizationConnectionRemoved(
+                AsOrganizationConnectionRemoved()
+            ),
+            "organization.connection.updated" => onOrganizationConnectionUpdated(
+                AsOrganizationConnectionUpdated()
+            ),
+            "organization.created" => onOrganizationCreated(AsOrganizationCreated()),
+            "organization.deleted" => onOrganizationDeleted(AsOrganizationDeleted()),
+            "organization.group.role.assigned" => onOrganizationGroupRoleAssigned(
+                AsOrganizationGroupRoleAssigned()
+            ),
+            "organization.group.role.deleted" => onOrganizationGroupRoleDeleted(
+                AsOrganizationGroupRoleDeleted()
+            ),
+            "organization.member.added" => onOrganizationMemberAdded(AsOrganizationMemberAdded()),
+            "organization.member.deleted" => onOrganizationMemberDeleted(
+                AsOrganizationMemberDeleted()
+            ),
+            "organization.member.role.assigned" => onOrganizationMemberRoleAssigned(
+                AsOrganizationMemberRoleAssigned()
+            ),
+            "organization.member.role.deleted" => onOrganizationMemberRoleDeleted(
+                AsOrganizationMemberRoleDeleted()
+            ),
+            "organization.updated" => onOrganizationUpdated(AsOrganizationUpdated()),
+            "user.created" => onUserCreated(AsUserCreated()),
+            "user.deleted" => onUserDeleted(AsUserDeleted()),
+            "user.updated" => onUserUpdated(AsUserUpdated()),
+            "error" => onError(AsError()),
+            "offset-only" => onOffsetOnly(AsOffsetOnly()),
+            _ => onUnknown_(Type, Value),
+        };
+    }
+
+    public void Visit(
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupCreated> onGroupCreated,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupDeleted> onGroupDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded> onGroupMemberAdded,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted> onGroupMemberDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned> onGroupRoleAssigned,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted> onGroupRoleDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventGroupUpdated> onGroupUpdated,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded> onOrganizationConnectionAdded,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved> onOrganizationConnectionRemoved,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated> onOrganizationConnectionUpdated,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgCreated> onOrganizationCreated,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgDeleted> onOrganizationDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned> onOrganizationGroupRoleAssigned,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted> onOrganizationGroupRoleDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded> onOrganizationMemberAdded,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted> onOrganizationMemberDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned> onOrganizationMemberRoleAssigned,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted> onOrganizationMemberRoleDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOrgUpdated> onOrganizationUpdated,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserCreated> onUserCreated,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserDeleted> onUserDeleted,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventUserUpdated> onUserUpdated,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventErrorMessage> onError,
+        global::System.Action<Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage> onOffsetOnly,
+        global::System.Action<string, object?> onUnknown_
+    )
+    {
+        switch (Type)
+        {
+            case "group.created":
+                onGroupCreated(AsGroupCreated());
+                break;
+            case "group.deleted":
+                onGroupDeleted(AsGroupDeleted());
+                break;
+            case "group.member.added":
+                onGroupMemberAdded(AsGroupMemberAdded());
+                break;
+            case "group.member.deleted":
+                onGroupMemberDeleted(AsGroupMemberDeleted());
+                break;
+            case "group.role.assigned":
+                onGroupRoleAssigned(AsGroupRoleAssigned());
+                break;
+            case "group.role.deleted":
+                onGroupRoleDeleted(AsGroupRoleDeleted());
+                break;
+            case "group.updated":
+                onGroupUpdated(AsGroupUpdated());
+                break;
+            case "organization.connection.added":
+                onOrganizationConnectionAdded(AsOrganizationConnectionAdded());
+                break;
+            case "organization.connection.removed":
+                onOrganizationConnectionRemoved(AsOrganizationConnectionRemoved());
+                break;
+            case "organization.connection.updated":
+                onOrganizationConnectionUpdated(AsOrganizationConnectionUpdated());
+                break;
+            case "organization.created":
+                onOrganizationCreated(AsOrganizationCreated());
+                break;
+            case "organization.deleted":
+                onOrganizationDeleted(AsOrganizationDeleted());
+                break;
+            case "organization.group.role.assigned":
+                onOrganizationGroupRoleAssigned(AsOrganizationGroupRoleAssigned());
+                break;
+            case "organization.group.role.deleted":
+                onOrganizationGroupRoleDeleted(AsOrganizationGroupRoleDeleted());
+                break;
+            case "organization.member.added":
+                onOrganizationMemberAdded(AsOrganizationMemberAdded());
+                break;
+            case "organization.member.deleted":
+                onOrganizationMemberDeleted(AsOrganizationMemberDeleted());
+                break;
+            case "organization.member.role.assigned":
+                onOrganizationMemberRoleAssigned(AsOrganizationMemberRoleAssigned());
+                break;
+            case "organization.member.role.deleted":
+                onOrganizationMemberRoleDeleted(AsOrganizationMemberRoleDeleted());
+                break;
+            case "organization.updated":
+                onOrganizationUpdated(AsOrganizationUpdated());
+                break;
+            case "user.created":
+                onUserCreated(AsUserCreated());
+                break;
+            case "user.deleted":
+                onUserDeleted(AsUserDeleted());
+                break;
+            case "user.updated":
+                onUserUpdated(AsUserUpdated());
+                break;
+            case "error":
+                onError(AsError());
+                break;
+            case "offset-only":
+                onOffsetOnly(AsOffsetOnly());
+                break;
+            default:
+                onUnknown_(Type, Value);
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupCreated"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsGroupCreated(out Auth0.ManagementApi.EventStreamCloudEventGroupCreated? value)
+    {
+        if (Type == "group.created")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupCreated)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsGroupDeleted(out Auth0.ManagementApi.EventStreamCloudEventGroupDeleted? value)
+    {
+        if (Type == "group.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsGroupMemberAdded(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded? value
+    )
+    {
+        if (Type == "group.member.added")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsGroupMemberDeleted(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted? value
+    )
+    {
+        if (Type == "group.member.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsGroupRoleAssigned(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned? value
+    )
+    {
+        if (Type == "group.role.assigned")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsGroupRoleDeleted(
+        out Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted? value
+    )
+    {
+        if (Type == "group.role.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventGroupUpdated"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsGroupUpdated(out Auth0.ManagementApi.EventStreamCloudEventGroupUpdated? value)
+    {
+        if (Type == "group.updated")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventGroupUpdated)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationConnectionAdded(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded? value
+    )
+    {
+        if (Type == "organization.connection.added")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationConnectionRemoved(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved? value
+    )
+    {
+        if (Type == "organization.connection.removed")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationConnectionUpdated(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated? value
+    )
+    {
+        if (Type == "organization.connection.updated")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgCreated"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationCreated(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgCreated? value
+    )
+    {
+        if (Type == "organization.created")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgCreated)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationDeleted(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgDeleted? value
+    )
+    {
+        if (Type == "organization.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationGroupRoleAssigned(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned? value
+    )
+    {
+        if (Type == "organization.group.role.assigned")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationGroupRoleDeleted(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted? value
+    )
+    {
+        if (Type == "organization.group.role.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationMemberAdded(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded? value
+    )
+    {
+        if (Type == "organization.member.added")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationMemberDeleted(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted? value
+    )
+    {
+        if (Type == "organization.member.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationMemberRoleAssigned(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned? value
+    )
+    {
+        if (Type == "organization.member.role.assigned")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationMemberRoleDeleted(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted? value
+    )
+    {
+        if (Type == "organization.member.role.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOrgUpdated"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOrganizationUpdated(
+        out Auth0.ManagementApi.EventStreamCloudEventOrgUpdated? value
+    )
+    {
+        if (Type == "organization.updated")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOrgUpdated)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserCreated"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsUserCreated(out Auth0.ManagementApi.EventStreamCloudEventUserCreated? value)
+    {
+        if (Type == "user.created")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserCreated)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserDeleted"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsUserDeleted(out Auth0.ManagementApi.EventStreamCloudEventUserDeleted? value)
+    {
+        if (Type == "user.deleted")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserDeleted)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventUserUpdated"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsUserUpdated(out Auth0.ManagementApi.EventStreamCloudEventUserUpdated? value)
+    {
+        if (Type == "user.updated")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventUserUpdated)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventErrorMessage"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsError(out Auth0.ManagementApi.EventStreamCloudEventErrorMessage? value)
+    {
+        if (Type == "error")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventErrorMessage)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to cast the value to a <see cref="Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage"/> and returns true if successful.
+    /// </summary>
+    public bool TryAsOffsetOnly(
+        out Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage? value
+    )
+    {
+        if (Type == "offset-only")
+        {
+            value = (Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage)Value!;
+            return true;
+        }
+        value = null;
+        return false;
+    }
+
+    public override string ToString() => JsonUtils.Serialize(this);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupCreated value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupMemberAdded value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupMemberDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupRoleAssigned value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupRoleDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.GroupUpdated value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationConnectionAdded value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationConnectionRemoved value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationConnectionUpdated value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationCreated value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleAssigned value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberAdded value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleAssigned value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OrganizationUpdated value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.UserCreated value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.UserDeleted value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.UserUpdated value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.Error value
+    ) => new(value);
+
+    public static implicit operator EventStreamSubscribeEventsResponseContent(
+        EventStreamSubscribeEventsResponseContent.OffsetOnly value
+    ) => new(value);
+
+    [Serializable]
+    internal sealed class JsonConverter : JsonConverter<EventStreamSubscribeEventsResponseContent>
+    {
+        public override bool CanConvert(global::System.Type typeToConvert) =>
+            typeof(EventStreamSubscribeEventsResponseContent).IsAssignableFrom(typeToConvert);
+
+        public override EventStreamSubscribeEventsResponseContent Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var json = JsonElement.ParseValue(ref reader);
+            if (!json.TryGetProperty("type", out var discriminatorElement))
+            {
+                throw new JsonException("Missing discriminator property 'type'");
+            }
+            if (discriminatorElement.ValueKind != JsonValueKind.String)
+            {
+                if (discriminatorElement.ValueKind == JsonValueKind.Null)
+                {
+                    throw new JsonException("Discriminator property 'type' is null");
+                }
+
+                throw new JsonException(
+                    $"Discriminator property 'type' is not a string, instead is {discriminatorElement.ToString()}"
+                );
+            }
+
+            var discriminator =
+                discriminatorElement.GetString()
+                ?? throw new JsonException("Discriminator property 'type' is null");
+
+            // Strip the discriminant property to prevent it from leaking into AdditionalProperties
+            var jsonObject = System.Text.Json.Nodes.JsonObject.Create(json);
+            jsonObject?.Remove("type");
+            var jsonWithoutDiscriminator =
+                jsonObject != null ? JsonSerializer.SerializeToElement(jsonObject, options) : json;
+
+            var value = discriminator switch
+            {
+                "group.created" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventGroupCreated?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventGroupCreated"
+                        ),
+                "group.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventGroupDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventGroupDeleted"
+                        ),
+                "group.member.added" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded"
+                        ),
+                "group.member.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted"
+                        ),
+                "group.role.assigned" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned"
+                        ),
+                "group.role.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted"
+                        ),
+                "group.updated" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventGroupUpdated?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventGroupUpdated"
+                        ),
+                "organization.connection.added" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded"
+                        ),
+                "organization.connection.removed" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved"
+                        ),
+                "organization.connection.updated" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated"
+                        ),
+                "organization.created" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgCreated?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgCreated"
+                        ),
+                "organization.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgDeleted"
+                        ),
+                "organization.group.role.assigned" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned"
+                        ),
+                "organization.group.role.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted"
+                        ),
+                "organization.member.added" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded"
+                        ),
+                "organization.member.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted"
+                        ),
+                "organization.member.role.assigned" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned"
+                        ),
+                "organization.member.role.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted"
+                        ),
+                "organization.updated" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOrgUpdated?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOrgUpdated"
+                        ),
+                "user.created" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventUserCreated?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventUserCreated"
+                        ),
+                "user.deleted" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventUserDeleted?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventUserDeleted"
+                        ),
+                "user.updated" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventUserUpdated?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventUserUpdated"
+                        ),
+                "error" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventErrorMessage?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventErrorMessage"
+                        ),
+                "offset-only" =>
+                    jsonWithoutDiscriminator.Deserialize<Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage?>(
+                        options
+                    )
+                        ?? throw new JsonException(
+                            "Failed to deserialize Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage"
+                        ),
+                _ => json.Deserialize<object?>(options),
+            };
+            return new EventStreamSubscribeEventsResponseContent(discriminator, value);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            EventStreamSubscribeEventsResponseContent value,
+            JsonSerializerOptions options
+        )
+        {
+            JsonNode json =
+                value.Type switch
+                {
+                    "group.created" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "group.deleted" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "group.member.added" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "group.member.deleted" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "group.role.assigned" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "group.role.deleted" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "group.updated" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "organization.connection.added" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.connection.removed" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.connection.updated" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.created" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "organization.deleted" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "organization.group.role.assigned" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.group.role.deleted" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.member.added" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.member.deleted" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.member.role.assigned" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.member.role.deleted" => JsonSerializer.SerializeToNode(
+                        value.Value,
+                        options
+                    ),
+                    "organization.updated" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "user.created" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "user.deleted" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "user.updated" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "error" => JsonSerializer.SerializeToNode(value.Value, options),
+                    "offset-only" => JsonSerializer.SerializeToNode(value.Value, options),
+                    _ => JsonSerializer.SerializeToNode(value.Value, options),
+                } ?? new JsonObject();
+            json["type"] = value.Type;
+            json.WriteTo(writer, options);
+        }
+
+        public override EventStreamSubscribeEventsResponseContent ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new JsonException("The JSON property name could not be read as a string.");
+            return new EventStreamSubscribeEventsResponseContent(stringValue, stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            EventStreamSubscribeEventsResponseContent value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Type);
+        }
+    }
+
+    /// <summary>
+    /// Discriminated union type for group.created
+    /// </summary>
+    [Serializable]
+    public struct GroupCreated
+    {
+        public GroupCreated(Auth0.ManagementApi.EventStreamCloudEventGroupCreated value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventGroupCreated Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.GroupCreated(
+            Auth0.ManagementApi.EventStreamCloudEventGroupCreated value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for group.deleted
+    /// </summary>
+    [Serializable]
+    public struct GroupDeleted
+    {
+        public GroupDeleted(Auth0.ManagementApi.EventStreamCloudEventGroupDeleted value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventGroupDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.GroupDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventGroupDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for group.member.added
+    /// </summary>
+    [Serializable]
+    public struct GroupMemberAdded
+    {
+        public GroupMemberAdded(Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.GroupMemberAdded(
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberAdded value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for group.member.deleted
+    /// </summary>
+    [Serializable]
+    public struct GroupMemberDeleted
+    {
+        public GroupMemberDeleted(Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.GroupMemberDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventGroupMemberDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for group.role.assigned
+    /// </summary>
+    [Serializable]
+    public struct GroupRoleAssigned
+    {
+        public GroupRoleAssigned(Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.GroupRoleAssigned(
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleAssigned value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for group.role.deleted
+    /// </summary>
+    [Serializable]
+    public struct GroupRoleDeleted
+    {
+        public GroupRoleDeleted(Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.GroupRoleDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventGroupRoleDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for group.updated
+    /// </summary>
+    [Serializable]
+    public struct GroupUpdated
+    {
+        public GroupUpdated(Auth0.ManagementApi.EventStreamCloudEventGroupUpdated value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventGroupUpdated Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.GroupUpdated(
+            Auth0.ManagementApi.EventStreamCloudEventGroupUpdated value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.connection.added
+    /// </summary>
+    [Serializable]
+    public struct OrganizationConnectionAdded
+    {
+        public OrganizationConnectionAdded(
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationConnectionAdded(
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionAdded value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.connection.removed
+    /// </summary>
+    [Serializable]
+    public struct OrganizationConnectionRemoved
+    {
+        public OrganizationConnectionRemoved(
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationConnectionRemoved(
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionRemoved value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.connection.updated
+    /// </summary>
+    [Serializable]
+    public struct OrganizationConnectionUpdated
+    {
+        public OrganizationConnectionUpdated(
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationConnectionUpdated(
+            Auth0.ManagementApi.EventStreamCloudEventOrgConnectionUpdated value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.created
+    /// </summary>
+    [Serializable]
+    public struct OrganizationCreated
+    {
+        public OrganizationCreated(Auth0.ManagementApi.EventStreamCloudEventOrgCreated value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgCreated Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationCreated(
+            Auth0.ManagementApi.EventStreamCloudEventOrgCreated value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.deleted
+    /// </summary>
+    [Serializable]
+    public struct OrganizationDeleted
+    {
+        public OrganizationDeleted(Auth0.ManagementApi.EventStreamCloudEventOrgDeleted value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventOrgDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.group.role.assigned
+    /// </summary>
+    [Serializable]
+    public struct OrganizationGroupRoleAssigned
+    {
+        public OrganizationGroupRoleAssigned(
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleAssigned(
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleAssigned value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.group.role.deleted
+    /// </summary>
+    [Serializable]
+    public struct OrganizationGroupRoleDeleted
+    {
+        public OrganizationGroupRoleDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationGroupRoleDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventOrgGroupRoleDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.member.added
+    /// </summary>
+    [Serializable]
+    public struct OrganizationMemberAdded
+    {
+        public OrganizationMemberAdded(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationMemberAdded(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberAdded value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.member.deleted
+    /// </summary>
+    [Serializable]
+    public struct OrganizationMemberDeleted
+    {
+        public OrganizationMemberDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationMemberDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.member.role.assigned
+    /// </summary>
+    [Serializable]
+    public struct OrganizationMemberRoleAssigned
+    {
+        public OrganizationMemberRoleAssigned(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleAssigned(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleAssigned value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.member.role.deleted
+    /// </summary>
+    [Serializable]
+    public struct OrganizationMemberRoleDeleted
+    {
+        public OrganizationMemberRoleDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted value
+        )
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationMemberRoleDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventOrgMemberRoleDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for organization.updated
+    /// </summary>
+    [Serializable]
+    public struct OrganizationUpdated
+    {
+        public OrganizationUpdated(Auth0.ManagementApi.EventStreamCloudEventOrgUpdated value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOrgUpdated Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OrganizationUpdated(
+            Auth0.ManagementApi.EventStreamCloudEventOrgUpdated value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for user.created
+    /// </summary>
+    [Serializable]
+    public struct UserCreated
+    {
+        public UserCreated(Auth0.ManagementApi.EventStreamCloudEventUserCreated value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventUserCreated Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.UserCreated(
+            Auth0.ManagementApi.EventStreamCloudEventUserCreated value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for user.deleted
+    /// </summary>
+    [Serializable]
+    public struct UserDeleted
+    {
+        public UserDeleted(Auth0.ManagementApi.EventStreamCloudEventUserDeleted value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventUserDeleted Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.UserDeleted(
+            Auth0.ManagementApi.EventStreamCloudEventUserDeleted value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for user.updated
+    /// </summary>
+    [Serializable]
+    public struct UserUpdated
+    {
+        public UserUpdated(Auth0.ManagementApi.EventStreamCloudEventUserUpdated value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventUserUpdated Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.UserUpdated(
+            Auth0.ManagementApi.EventStreamCloudEventUserUpdated value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for error
+    /// </summary>
+    [Serializable]
+    public struct Error
+    {
+        public Error(Auth0.ManagementApi.EventStreamCloudEventErrorMessage value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventErrorMessage Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.Error(
+            Auth0.ManagementApi.EventStreamCloudEventErrorMessage value
+        ) => new(value);
+    }
+
+    /// <summary>
+    /// Discriminated union type for offset-only
+    /// </summary>
+    [Serializable]
+    public struct OffsetOnly
+    {
+        public OffsetOnly(Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage value)
+        {
+            Value = value;
+        }
+
+        internal Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage Value { get; set; }
+
+        public override string ToString() => Value.ToString() ?? "null";
+
+        public static implicit operator EventStreamSubscribeEventsResponseContent.OffsetOnly(
+            Auth0.ManagementApi.EventStreamCloudEventOffsetOnlyMessage value
+        ) => new(value);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/GetBrandingResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/GetBrandingResponseContent.cs
@@ -29,6 +29,10 @@ public record GetBrandingResponseContent : IJsonOnDeserialized, IJsonOnSerializi
     public string? LogoUrl { get; set; }
 
     [Optional]
+    [JsonPropertyName("identifiers")]
+    public BrandingIdentifiers? Identifiers { get; set; }
+
+    [Optional]
     [JsonPropertyName("font")]
     public BrandingFont? Font { get; set; }
 

--- a/src/Auth0.ManagementApi/Types/GetSelfServiceProfileResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/GetSelfServiceProfileResponseContent.cs
@@ -33,7 +33,7 @@ public record GetSelfServiceProfileResponseContent : IJsonOnDeserialized
     public string? Description { get; set; }
 
     /// <summary>
-    /// List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
+    /// List of attributes to be mapped that will be shown to the user during the Self-Service Enterprise Configuration flow.
     /// </summary>
     [Optional]
     [JsonPropertyName("user_attributes")]
@@ -58,7 +58,7 @@ public record GetSelfServiceProfileResponseContent : IJsonOnDeserialized
     public SelfServiceProfileBrandingProperties? Branding { get; set; }
 
     /// <summary>
-    /// List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
+    /// List of IdP strategies that will be shown to users during the Self-Service Enterprise Configuration flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
     /// </summary>
     [Optional]
     [JsonPropertyName("allowed_strategies")]

--- a/src/Auth0.ManagementApi/Types/OauthScope.cs
+++ b/src/Auth0.ManagementApi/Types/OauthScope.cs
@@ -436,6 +436,11 @@ public readonly record struct OauthScope : IStringEnum
     public static readonly OauthScope DeleteEventStreams = new(Values.DeleteEventStreams);
 
     /// <summary>
+    /// Read Events
+    /// </summary>
+    public static readonly OauthScope ReadEvents = new(Values.ReadEvents);
+
+    /// <summary>
     /// Read Federated Connections Tokens
     /// </summary>
     public static readonly OauthScope ReadFederatedConnectionsTokens = new(
@@ -1714,6 +1719,11 @@ public readonly record struct OauthScope : IStringEnum
         /// Delete Event Streams
         /// </summary>
         public const string DeleteEventStreams = "delete:event_streams";
+
+        /// <summary>
+        /// Read Events
+        /// </summary>
+        public const string ReadEvents = "read:events";
 
         /// <summary>
         /// Read Federated Connections Tokens

--- a/src/Auth0.ManagementApi/Types/SelfServiceProfile.cs
+++ b/src/Auth0.ManagementApi/Types/SelfServiceProfile.cs
@@ -33,7 +33,7 @@ public record SelfServiceProfile : IJsonOnDeserialized
     public string? Description { get; set; }
 
     /// <summary>
-    /// List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
+    /// List of attributes to be mapped that will be shown to the user during the Self-Service Enterprise Configuration flow.
     /// </summary>
     [Optional]
     [JsonPropertyName("user_attributes")]
@@ -58,7 +58,7 @@ public record SelfServiceProfile : IJsonOnDeserialized
     public SelfServiceProfileBrandingProperties? Branding { get; set; }
 
     /// <summary>
-    /// List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
+    /// List of IdP strategies that will be shown to users during the Self-Service Enterprise Configuration flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
     /// </summary>
     [Optional]
     [JsonPropertyName("allowed_strategies")]

--- a/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketConnectionConfig.cs
+++ b/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketConnectionConfig.cs
@@ -5,7 +5,7 @@ using global::System.Text.Json.Serialization;
 namespace Auth0.ManagementApi;
 
 /// <summary>
-/// If provided, this will create a new connection for the SSO flow with the given configuration
+/// If provided, this will create a new connection for the Self-Service Enterprise Configuration flow with the given configuration
 /// </summary>
 [Serializable]
 public record SelfServiceProfileSsoTicketConnectionConfig : IJsonOnDeserialized
@@ -15,7 +15,7 @@ public record SelfServiceProfileSsoTicketConnectionConfig : IJsonOnDeserialized
         new Dictionary<string, JsonElement>();
 
     /// <summary>
-    /// The name of the connection that will be created as a part of the SSO flow.
+    /// The name of the connection that will be created as a part of the Self-Service Enterprise Configuration flow.
     /// </summary>
     [JsonPropertyName("name")]
     public required string Name { get; set; }

--- a/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketDomainAliasesConfig.cs
+++ b/src/Auth0.ManagementApi/Types/SelfServiceProfileSsoTicketDomainAliasesConfig.cs
@@ -5,7 +5,7 @@ using global::System.Text.Json.Serialization;
 namespace Auth0.ManagementApi;
 
 /// <summary>
-/// Configuration for the setup of the connection’s domain_aliases in the self-service SSO flow.
+/// Configuration for the setup of the connection’s domain_aliases in the Self-Service Enterprise Configuration flow.
 /// </summary>
 [Serializable]
 public record SelfServiceProfileSsoTicketDomainAliasesConfig : IJsonOnDeserialized
@@ -18,7 +18,7 @@ public record SelfServiceProfileSsoTicketDomainAliasesConfig : IJsonOnDeserializ
     public required SelfServiceProfileSsoTicketDomainVerificationEnum DomainVerification { get; set; }
 
     /// <summary>
-    /// List of domains that will be submitted for verification during the self-service SSO flow.
+    /// List of domains that will be submitted for verification during the Self-Service Enterprise Configuration flow.
     /// </summary>
     [Optional]
     [JsonPropertyName("pending_domains")]

--- a/src/Auth0.ManagementApi/Types/UpdateBrandingIdentifiers.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateBrandingIdentifiers.cs
@@ -1,0 +1,43 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Identifier input display settings.
+/// </summary>
+[Serializable]
+public record UpdateBrandingIdentifiers : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [Optional]
+    [JsonPropertyName("login_display")]
+    public UpdateBrandingLoginDisplayEnum? LoginDisplay { get; set; }
+
+    /// <summary>
+    /// Whether OTP autocomplete (autocomplete="one-time-code") is enabled.
+    /// </summary>
+    [Optional]
+    [JsonPropertyName("otp_autocomplete")]
+    public bool? OtpAutocomplete { get; set; }
+
+    [Nullable, Optional]
+    [JsonPropertyName("phone_display")]
+    public Optional<UpdateBrandingPhoneDisplay?> PhoneDisplay { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/UpdateBrandingLoginDisplayEnum.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateBrandingLoginDisplayEnum.cs
@@ -1,0 +1,116 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(UpdateBrandingLoginDisplayEnum.UpdateBrandingLoginDisplayEnumSerializer))]
+[Serializable]
+public readonly record struct UpdateBrandingLoginDisplayEnum : IStringEnum
+{
+    public static readonly UpdateBrandingLoginDisplayEnum Unified = new(Values.Unified);
+
+    public static readonly UpdateBrandingLoginDisplayEnum Separate = new(Values.Separate);
+
+    public UpdateBrandingLoginDisplayEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static UpdateBrandingLoginDisplayEnum FromCustom(string value)
+    {
+        return new UpdateBrandingLoginDisplayEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(UpdateBrandingLoginDisplayEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(UpdateBrandingLoginDisplayEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(UpdateBrandingLoginDisplayEnum value) => value.Value;
+
+    public static explicit operator UpdateBrandingLoginDisplayEnum(string value) => new(value);
+
+    internal class UpdateBrandingLoginDisplayEnumSerializer
+        : JsonConverter<UpdateBrandingLoginDisplayEnum>
+    {
+        public override UpdateBrandingLoginDisplayEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new UpdateBrandingLoginDisplayEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            UpdateBrandingLoginDisplayEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override UpdateBrandingLoginDisplayEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new UpdateBrandingLoginDisplayEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            UpdateBrandingLoginDisplayEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Unified = "unified";
+
+        public const string Separate = "separate";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/UpdateBrandingPhoneDisplay.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateBrandingPhoneDisplay.cs
@@ -1,0 +1,34 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Phone number display settings.
+/// </summary>
+[Serializable]
+public record UpdateBrandingPhoneDisplay : IJsonOnDeserialized
+{
+    [JsonExtensionData]
+    private readonly IDictionary<string, JsonElement> _extensionData =
+        new Dictionary<string, JsonElement>();
+
+    [JsonPropertyName("masking")]
+    public required UpdateBrandingPhoneMaskingEnum Masking { get; set; }
+
+    [JsonPropertyName("formatting")]
+    public required UpdateBrandingPhoneFormattingEnum Formatting { get; set; }
+
+    [JsonIgnore]
+    public ReadOnlyAdditionalProperties AdditionalProperties { get; private set; } = new();
+
+    void IJsonOnDeserialized.OnDeserialized() =>
+        AdditionalProperties.CopyFromExtensionData(_extensionData);
+
+    /// <inheritdoc />
+    public override string ToString()
+    {
+        return JsonUtils.Serialize(this);
+    }
+}

--- a/src/Auth0.ManagementApi/Types/UpdateBrandingPhoneFormattingEnum.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateBrandingPhoneFormattingEnum.cs
@@ -1,0 +1,120 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(
+    typeof(UpdateBrandingPhoneFormattingEnum.UpdateBrandingPhoneFormattingEnumSerializer)
+)]
+[Serializable]
+public readonly record struct UpdateBrandingPhoneFormattingEnum : IStringEnum
+{
+    public static readonly UpdateBrandingPhoneFormattingEnum Regional = new(Values.Regional);
+
+    public static readonly UpdateBrandingPhoneFormattingEnum International = new(
+        Values.International
+    );
+
+    public UpdateBrandingPhoneFormattingEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static UpdateBrandingPhoneFormattingEnum FromCustom(string value)
+    {
+        return new UpdateBrandingPhoneFormattingEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(UpdateBrandingPhoneFormattingEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(UpdateBrandingPhoneFormattingEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(UpdateBrandingPhoneFormattingEnum value) => value.Value;
+
+    public static explicit operator UpdateBrandingPhoneFormattingEnum(string value) => new(value);
+
+    internal class UpdateBrandingPhoneFormattingEnumSerializer
+        : JsonConverter<UpdateBrandingPhoneFormattingEnum>
+    {
+        public override UpdateBrandingPhoneFormattingEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new UpdateBrandingPhoneFormattingEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            UpdateBrandingPhoneFormattingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override UpdateBrandingPhoneFormattingEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new UpdateBrandingPhoneFormattingEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            UpdateBrandingPhoneFormattingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string Regional = "regional";
+
+        public const string International = "international";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/UpdateBrandingPhoneMaskingEnum.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateBrandingPhoneMaskingEnum.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi;
+
+[JsonConverter(typeof(UpdateBrandingPhoneMaskingEnum.UpdateBrandingPhoneMaskingEnumSerializer))]
+[Serializable]
+public readonly record struct UpdateBrandingPhoneMaskingEnum : IStringEnum
+{
+    public static readonly UpdateBrandingPhoneMaskingEnum ShowAll = new(Values.ShowAll);
+
+    public static readonly UpdateBrandingPhoneMaskingEnum HideCountryCode = new(
+        Values.HideCountryCode
+    );
+
+    public static readonly UpdateBrandingPhoneMaskingEnum MaskDigits = new(Values.MaskDigits);
+
+    public UpdateBrandingPhoneMaskingEnum(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// The string value of the enum.
+    /// </summary>
+    public string Value { get; }
+
+    /// <summary>
+    /// Create a string enum with the given value.
+    /// </summary>
+    public static UpdateBrandingPhoneMaskingEnum FromCustom(string value)
+    {
+        return new UpdateBrandingPhoneMaskingEnum(value);
+    }
+
+    public bool Equals(string? other)
+    {
+        return Value.Equals(other);
+    }
+
+    /// <summary>
+    /// Returns the string value of the enum.
+    /// </summary>
+    public override string ToString()
+    {
+        return Value;
+    }
+
+    public static bool operator ==(UpdateBrandingPhoneMaskingEnum value1, string value2) =>
+        value1.Value.Equals(value2);
+
+    public static bool operator !=(UpdateBrandingPhoneMaskingEnum value1, string value2) =>
+        !value1.Value.Equals(value2);
+
+    public static explicit operator string(UpdateBrandingPhoneMaskingEnum value) => value.Value;
+
+    public static explicit operator UpdateBrandingPhoneMaskingEnum(string value) => new(value);
+
+    internal class UpdateBrandingPhoneMaskingEnumSerializer
+        : JsonConverter<UpdateBrandingPhoneMaskingEnum>
+    {
+        public override UpdateBrandingPhoneMaskingEnum Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON value could not be read as a string."
+                );
+            return new UpdateBrandingPhoneMaskingEnum(stringValue);
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            UpdateBrandingPhoneMaskingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WriteStringValue(value.Value);
+        }
+
+        public override UpdateBrandingPhoneMaskingEnum ReadAsPropertyName(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            var stringValue =
+                reader.GetString()
+                ?? throw new global::System.Exception(
+                    "The JSON property name could not be read as a string."
+                );
+            return new UpdateBrandingPhoneMaskingEnum(stringValue);
+        }
+
+        public override void WriteAsPropertyName(
+            Utf8JsonWriter writer,
+            UpdateBrandingPhoneMaskingEnum value,
+            JsonSerializerOptions options
+        )
+        {
+            writer.WritePropertyName(value.Value);
+        }
+    }
+
+    /// <summary>
+    /// Constant strings for enum values
+    /// </summary>
+    [Serializable]
+    public static class Values
+    {
+        public const string ShowAll = "show_all";
+
+        public const string HideCountryCode = "hide_country_code";
+
+        public const string MaskDigits = "mask_digits";
+    }
+}

--- a/src/Auth0.ManagementApi/Types/UpdateBrandingResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateBrandingResponseContent.cs
@@ -29,6 +29,10 @@ public record UpdateBrandingResponseContent : IJsonOnDeserialized, IJsonOnSerial
     public string? LogoUrl { get; set; }
 
     [Optional]
+    [JsonPropertyName("identifiers")]
+    public BrandingIdentifiers? Identifiers { get; set; }
+
+    [Optional]
     [JsonPropertyName("font")]
     public BrandingFont? Font { get; set; }
 

--- a/src/Auth0.ManagementApi/Types/UpdateConnectionOptions.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateConnectionOptions.cs
@@ -158,6 +158,22 @@ public record UpdateConnectionOptions : IJsonOnDeserialized, IJsonOnSerializing
     [JsonPropertyName("password_options")]
     public ConnectionPasswordOptions? PasswordOptions { get; set; }
 
+    [Nullable, Optional]
+    [JsonPropertyName("id_token_signed_response_algs")]
+    public Optional<IEnumerable<ConnectionIdTokenSignedResponseAlgEnum>?> IdTokenSignedResponseAlgs { get; set; }
+
+    [Nullable, Optional]
+    [JsonPropertyName("token_endpoint_auth_method")]
+    public Optional<ConnectionTokenEndpointAuthMethodEnum?> TokenEndpointAuthMethod { get; set; }
+
+    [Nullable, Optional]
+    [JsonPropertyName("token_endpoint_auth_signing_alg")]
+    public Optional<ConnectionTokenEndpointAuthSigningAlgEnum?> TokenEndpointAuthSigningAlg { get; set; }
+
+    [Optional]
+    [JsonPropertyName("token_endpoint_jwtca_aud_format")]
+    public ConnectionTokenEndpointJwtcaAudFormatEnumOidc? TokenEndpointJwtcaAudFormat { get; set; }
+
     [JsonIgnore]
     public AdditionalProperties AdditionalProperties { get; set; } = new();
 

--- a/src/Auth0.ManagementApi/Types/UpdateSelfServiceProfileResponseContent.cs
+++ b/src/Auth0.ManagementApi/Types/UpdateSelfServiceProfileResponseContent.cs
@@ -33,7 +33,7 @@ public record UpdateSelfServiceProfileResponseContent : IJsonOnDeserialized
     public string? Description { get; set; }
 
     /// <summary>
-    /// List of attributes to be mapped that will be shown to the user during the SS-SSO flow.
+    /// List of attributes to be mapped that will be shown to the user during the Self-Service Enterprise Configuration flow.
     /// </summary>
     [Optional]
     [JsonPropertyName("user_attributes")]
@@ -58,7 +58,7 @@ public record UpdateSelfServiceProfileResponseContent : IJsonOnDeserialized
     public SelfServiceProfileBrandingProperties? Branding { get; set; }
 
     /// <summary>
-    /// List of IdP strategies that will be shown to users during the Self-Service SSO flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
+    /// List of IdP strategies that will be shown to users during the Self-Service Enterprise Configuration flow. Possible values: [`oidc`, `samlp`, `waad`, `google-apps`, `adfs`, `okta`, `auth0-samlp`, `okta-samlp`, `keycloak-samlp`, `pingfederate`]
     /// </summary>
     [Optional]
     [JsonPropertyName("allowed_strategies")]

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Branding/GetTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Branding/GetTest.cs
@@ -19,6 +19,14 @@ public class GetTest : BaseMockServerTest
               },
               "favicon_url": "favicon_url",
               "logo_url": "logo_url",
+              "identifiers": {
+                "login_display": "unified",
+                "otp_autocomplete": true,
+                "phone_display": {
+                  "masking": "show_all",
+                  "formatting": "regional"
+                }
+              },
               "font": {
                 "url": "url"
               }

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Branding/UpdateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Branding/UpdateTest.cs
@@ -24,6 +24,14 @@ public class UpdateTest : BaseMockServerTest
               },
               "favicon_url": "favicon_url",
               "logo_url": "logo_url",
+              "identifiers": {
+                "login_display": "unified",
+                "otp_autocomplete": true,
+                "phone_display": {
+                  "masking": "show_all",
+                  "formatting": "regional"
+                }
+              },
               "font": {
                 "url": "url"
               }

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Flows/ListTest.cs
@@ -12,21 +12,21 @@ public class ListTest : BaseMockServerTest
     public async Task MockServerTest()
     {
         const string mockResponse = """
-                                    {
-                                      "start": 1.1,
-                                      "limit": 1.1,
-                                      "total": 1.1,
-                                      "flows": [
-                                        {
-                                          "id": "id",
-                                          "name": "name",
-                                          "created_at": "2024-01-15T09:30:00.000Z",
-                                          "updated_at": "2024-01-15T09:30:00.000Z",
-                                          "executed_at": "executed_at"
-                                        }
-                                      ]
-                                    }
-                                    """;
+            {
+              "start": 1.1,
+              "limit": 1.1,
+              "total": 1.1,
+              "flows": [
+                {
+                  "id": "id",
+                  "name": "name",
+                  "created_at": "2024-01-15T09:30:00.000Z",
+                  "updated_at": "2024-01-15T09:30:00.000Z",
+                  "executed_at": "executed_at"
+                }
+              ]
+            }
+            """;
 
         Server
             .Given(

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/Forms/ListTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/Forms/ListTest.cs
@@ -12,22 +12,22 @@ public class ListTest : BaseMockServerTest
     public async Task MockServerTest()
     {
         const string mockResponse = """
-                                    {
-                                      "start": 1.1,
-                                      "limit": 1.1,
-                                      "total": 1.1,
-                                      "forms": [
-                                        {
-                                          "id": "id",
-                                          "name": "name",
-                                          "created_at": "2024-01-15T09:30:00.000Z",
-                                          "updated_at": "2024-01-15T09:30:00.000Z",
-                                          "embedded_at": "embedded_at",
-                                          "submitted_at": "submitted_at"
-                                        }
-                                      ]
-                                    }
-                                    """;
+            {
+              "start": 1.1,
+              "limit": 1.1,
+              "total": 1.1,
+              "forms": [
+                {
+                  "id": "id",
+                  "name": "name",
+                  "created_at": "2024-01-15T09:30:00.000Z",
+                  "updated_at": "2024-01-15T09:30:00.000Z",
+                  "embedded_at": "embedded_at",
+                  "submitted_at": "submitted_at"
+                }
+              ]
+            }
+            """;
 
         Server
             .Given(

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/RefreshTokens/RevokeTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/RefreshTokens/RevokeTest.cs
@@ -1,0 +1,33 @@
+using Auth0.ManagementApi;
+using Auth0.ManagementApi.Test.Unit.MockServer;
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Unit.MockServer.RefreshTokens;
+
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class RevokeTest : BaseMockServerTest
+{
+    [NUnit.Framework.Test]
+    public void MockServerTest()
+    {
+        const string requestJson = """
+            {}
+            """;
+
+        Server
+            .Given(
+                WireMock
+                    .RequestBuilders.Request.Create()
+                    .WithPath("/refresh-tokens/revoke")
+                    .WithHeader("Content-Type", "application/json")
+                    .UsingPost()
+                    .WithBodyAsJson(requestJson)
+            )
+            .RespondWith(WireMock.ResponseBuilders.Response.Create().WithStatusCode(200));
+
+        Assert.DoesNotThrowAsync(async () =>
+            await Client.RefreshTokens.RevokeAsync(new RevokeRefreshTokensRequestContent())
+        );
+    }
+}


### PR DESCRIPTION
### Changes

This PR updates the generated Management API SDK surface from the latest API spec and adds support for new endpoints/types.

- **Endpoints added/changed**
  - Added support for `GET /events` via SSE streaming:
    - `IEventsClient.SubscribeAsync(...)`
    - `EventsClient.SubscribeAsync(...)`
    - `IManagementApiClient.Events` / `ManagementApiClient.Events`
  - Added support for bulk refresh token revocation:
    - `POST /refresh-tokens/revoke`
    - `IRefreshTokensClient.RevokeAsync(...)`
    - `RefreshTokensClient.RevokeAsync(...)`
- **Classes and methods added/changed**
  - Added `EventsClient`, `IEventsClient`, and `SubscribeEventsRequestParameters`
  - Added `RevokeRefreshTokensRequestContent`
  - Added `GoneError` (410 response mapping for events subscription)
  - Added/updated branding identifier models and wiring (`UpdateBrandingRequestContent.Identifiers`, related branding types)
  - Updated JSON serialization configuration in `JsonConfiguration` to better handle Optional/Nullable behavior and extension data fields
  - Regenerated API reference docs (`reference.md`) and related generated event stream types

- Updated project dependency configuration in `src/Auth0.ManagementApi/Auth0.ManagementApi.Custom.props` to add compatibility packages for non-`net9.0` targets:
  - `System.Net.ServerSentEvents` (`9.0.14`)
  - `Microsoft.Bcl.AsyncInterfaces` (`9.0.14`)
- This ensures the new Events/SSE client compiles and runs correctly on `net462` and `netstandard2.0`.

### References

- Uses Fern dotnet generator version `2.63.0`

### Testing

New/updated unit mock-server tests included.

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors