### PR TITLE
Adds id token validation in CIBA flow

### DIFF
--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -532,6 +532,14 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
+        await AssertIdTokenValidIfExisting(
+            response.IdToken,
+            request.ClientId,
+            request.SigningAlgorithm,
+            request.ClientSecret,
+            request.Organization
+        ).ConfigureAwait(false);
+
         return response;
     }
 

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenRequest.cs
@@ -25,7 +25,21 @@ public class ClientInitiatedBackchannelAuthorizationTokenRequest : IClientAuthen
     /// Unique identifier of the authorization request. This value will be returned from the call to /bc-authorize.
     /// </summary>
     public string AuthRequestId { get; set; }
-        
+
+    /// <summary>
+    /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature of Id Tokens.
+    /// </summary>
+    public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+
+    /// <summary>
+    /// Organization for Id Token verification.
+    /// </summary>
+    /// <remarks>
+    /// - If you provide an Organization ID (a string with the prefix <c>org_</c>), it will be validated against the <c>org_id</c> claim of your user's ID Token. The validation is case-sensitive.
+    /// - If you provide an Organization Name (a string <em>without</em> the prefix <c>org_</c>), it will be validated against the <c>org_name</c> claim of your user's ID Token. The validation is case-insensitive.
+    /// </remarks>
+    public string Organization { get; set; }
+
     /// <summary>
     /// Any additional properties to use.
     /// </summary>

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTests.cs
@@ -29,7 +29,6 @@ public class ClientInitiatedBackchannelAuthorizationTests : TestBase
         var mockTokenResponse = new ClientInitiatedBackchannelAuthorizationTokenResponse()
         {
             AccessToken = "This is a mock access_token",
-            IdToken = "This is a mock ID token",
             ExpiresIn = 300,
             Scope = "openid"
         };

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/CibaIdTokenValidationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/Tokens/CibaIdTokenValidationTests.cs
@@ -1,0 +1,358 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Auth0.AuthenticationApi.Models.Ciba;
+using Auth0.AuthenticationApi.Tokens;
+using Auth0.Tests.Shared;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Moq.Protected;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests.Tokens;
+
+public class CibaIdTokenValidationTests
+{
+    private const string Issuer = "https://tokens-test.auth0.com/";
+    private const string ClientId = "tokens-test-123";
+    private const string Subject = "auth0|test-user";
+
+    // RSA key pair used to sign RS256 test tokens — generated once per test class.
+    private static readonly RsaSecurityKey RsaKey = new(new RSACryptoServiceProvider(2048));
+    private static readonly JwtTokenFactory RsaTokenFactory = new(RsaKey, SecurityAlgorithms.RsaSha256);
+
+    /// <summary>
+    /// Generates an HS256 ID token signed with the supplied client secret.
+    /// </summary>
+    private static string GenerateHs256Token(string clientSecret, IList<Claim> extraClaims = null)
+    {
+        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(clientSecret));
+        var factory = new JwtTokenFactory(key, SecurityAlgorithms.HmacSha256);
+        return factory.GenerateToken(Issuer, ClientId, Subject, extraClaims);
+    }
+
+    /// <summary>
+    /// Generates an HS256 ID token that is already expired.
+    /// </summary>
+    private static string GenerateExpiredHs256Token(string clientSecret)
+    {
+        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(clientSecret));
+        var signingCredentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var tokenHandler = new JwtSecurityTokenHandler();
+
+        var descriptor = new SecurityTokenDescriptor
+        {
+            Subject = new ClaimsIdentity(new[] { new Claim(JwtRegisteredClaimNames.Sub, Subject) }),
+            NotBefore = DateTime.UtcNow.AddHours(-3),
+            IssuedAt = DateTime.UtcNow.AddHours(-3),
+            Expires = DateTime.UtcNow.AddHours(-1),
+            Issuer = Issuer,
+            Audience = ClientId,
+            SigningCredentials = signingCredentials
+        };
+        return tokenHandler.WriteToken(tokenHandler.CreateToken(descriptor));
+    }
+
+    /// <summary>
+    /// Generates an RS256 ID token signed with the shared RSA key.
+    /// </summary>
+    private static string GenerateRs256Token(IList<Claim> extraClaims = null)
+        => RsaTokenFactory.GenerateToken(Issuer, ClientId, Subject, extraClaims);
+
+    /// <summary>
+    /// Builds a mock HttpMessageHandler that returns a CIBA token endpoint response
+    /// containing the given idToken (null omits the field).
+    /// </summary>
+    private static Mock<HttpMessageHandler> BuildMockHandlerReturning(string idToken)
+    {
+        var responseBody = idToken != null
+            ? new { access_token = "mock-access-token", token_type = "Bearer", expires_in = 86400, id_token = idToken }
+            : (object)new { access_token = "mock-access-token", token_type = "Bearer", expires_in = 86400 };
+
+        var json = JsonConvert.SerializeObject(responseBody);
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(json, Encoding.UTF8, "application/json")
+            });
+
+        return mockHandler;
+    }
+
+    /// <summary>
+    /// Builds a mock handler that handles the CIBA token POST plus the OIDC discovery
+    /// and JWKS GET requests required for RS256 signature validation.
+    /// </summary>
+    private static Mock<HttpMessageHandler> BuildMockHandlerWithDiscovery(string idToken)
+    {
+        var tokenJson = JsonConvert.SerializeObject(new
+        {
+            access_token = "mock-access-token",
+            token_type = "Bearer",
+            expires_in = 86400,
+            id_token = idToken
+        });
+
+        var rsaParams = RsaKey.Rsa.ExportParameters(false);
+        var jwksJson = JsonConvert.SerializeObject(new
+        {
+            keys = new[]
+            {
+                new
+                {
+                    kty = "RSA",
+                    n = Base64UrlEncoder.Encode(rsaParams.Modulus),
+                    e = Base64UrlEncoder.Encode(rsaParams.Exponent)
+                }
+            }
+        });
+
+        var discoveryJson = JsonConvert.SerializeObject(new
+        {
+            issuer = Issuer,
+            jwks_uri = $"{Issuer}.well-known/jwks.json"
+        });
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Post),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(tokenJson, Encoding.UTF8, "application/json")
+            });
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get && r.RequestUri.AbsolutePath.Contains("openid-configuration")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(discoveryJson, Encoding.UTF8, "application/json")
+            });
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(r => r.Method == HttpMethod.Get && r.RequestUri.AbsolutePath.Contains("jwks")),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(() => new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(jwksJson, Encoding.UTF8, "application/json")
+            });
+
+        return mockHandler;
+    }
+
+    private static TestAuthenticationApiClient BuildClient(HttpMessageHandler handler)
+    {
+        var domain = Issuer.TrimEnd('/').Replace("https://", "");
+        return new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(handler));
+    }
+    
+    private const string DummyClientSecret = "dummy-client-secret-for-testing";
+
+    private static ClientInitiatedBackchannelAuthorizationTokenRequest BuildRequest(
+        string clientSecret = DummyClientSecret,
+        JwtSignatureAlgorithm algorithm = JwtSignatureAlgorithm.RS256,
+        string organization = null)
+    {
+        return new ClientInitiatedBackchannelAuthorizationTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = clientSecret,
+            AuthRequestId = "test-auth-req-id",
+            SigningAlgorithm = algorithm,
+            Organization = organization
+        };
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Succeeds_WhenNoIdTokenInResponse()
+    {
+        using var client = BuildClient(BuildMockHandlerReturning(null).Object);
+
+        var result = await client.GetTokenAsync(BuildRequest());
+
+        Assert.NotNull(result);
+        Assert.Equal("mock-access-token", result.AccessToken);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Succeeds_WithValidHs256IdToken()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(clientSecret);
+
+        using var client = BuildClient(BuildMockHandlerReturning(idToken).Object);
+
+        var result = await client.GetTokenAsync(BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256));
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Succeeds_WithValidRs256IdToken()
+    {
+        var idToken = GenerateRs256Token();
+
+        using var client = BuildClient(BuildMockHandlerWithDiscovery(idToken).Object);
+
+        var result = await client.GetTokenAsync(BuildRequest(algorithm: JwtSignatureAlgorithm.RS256));
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Throws_WhenIdTokenSignatureIsForged()
+    {
+        // An attacker intercepts the token response (via proxy / MITM) and replaces
+        // the id_token with one signed using a different secret.
+        var realSecret = Guid.NewGuid().ToString("N");
+        var attackerSecret = Guid.NewGuid().ToString("N");
+        var forgedToken = GenerateHs256Token(attackerSecret); // signed with wrong key
+
+        using var client = BuildClient(BuildMockHandlerReturning(forgedToken).Object);
+
+        await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(BuildRequest(realSecret, JwtSignatureAlgorithm.HS256)));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Throws_WhenIdTokenIsExpired()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var expiredToken = GenerateExpiredHs256Token(clientSecret);
+
+        using var client = BuildClient(BuildMockHandlerReturning(expiredToken).Object);
+
+        await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256)));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Throws_WhenIdTokenHasWrongAudience()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        // Token is issued for a different audience.
+        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(clientSecret));
+        var factory = new JwtTokenFactory(key, SecurityAlgorithms.HmacSha256);
+        var wrongAudienceToken = factory.GenerateToken(Issuer, "wrong-audience", Subject);
+
+        using var client = BuildClient(BuildMockHandlerReturning(wrongAudienceToken).Object);
+
+        await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256)));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Throws_WhenIdTokenHasWrongIssuer()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        // Token is issued by a different issuer.
+        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(clientSecret));
+        var factory = new JwtTokenFactory(key, SecurityAlgorithms.HmacSha256);
+        var wrongIssuerToken = factory.GenerateToken("https://evil.example.com/", ClientId, Subject);
+
+        using var client = BuildClient(BuildMockHandlerReturning(wrongIssuerToken).Object);
+
+        await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256)));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Succeeds_WhenOrgIdClaimMatchesRequest()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var orgId = "org_abc123";
+        var idToken = GenerateHs256Token(clientSecret, new List<Claim> { new("org_id", orgId) });
+
+        using var client = BuildClient(BuildMockHandlerReturning(idToken).Object);
+
+        var result = await client.GetTokenAsync(
+            BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256, organization: orgId));
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Throws_WhenOrgIdClaimMismatch()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(clientSecret, new List<Claim> { new("org_id", "org_realorg") });
+
+        using var client = BuildClient(BuildMockHandlerReturning(idToken).Object);
+
+        await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(
+                BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256, organization: "org_differentorg")));
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Succeeds_WhenOrgNameClaimMatchesRequest()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(clientSecret, new List<Claim> { new("org_name", "mycompany") });
+
+        using var client = BuildClient(BuildMockHandlerReturning(idToken).Object);
+
+        var result = await client.GetTokenAsync(
+            BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256, organization: "mycompany"));
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Succeeds_WhenOrgNameMatchIsCaseInsensitive()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(clientSecret, new List<Claim> { new("org_name", "mycompany") });
+
+        using var client = BuildClient(BuildMockHandlerReturning(idToken).Object);
+
+        var result = await client.GetTokenAsync(
+            BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256, organization: "MyCompany"));
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_Ciba_Throws_WhenOrgNameClaimMismatch()
+    {
+        var clientSecret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(clientSecret, new List<Claim> { new("org_name", "acme") });
+
+        using var client = BuildClient(BuildMockHandlerReturning(idToken).Object);
+
+        await Assert.ThrowsAsync<IdTokenValidationException>(() =>
+            client.GetTokenAsync(
+                BuildRequest(clientSecret, JwtSignatureAlgorithm.HS256, organization: "differentcompany")));
+    }
+}


### PR DESCRIPTION
### Changes

Adds ID token validation to the CIBA (`GetTokenAsync`) flow, bringing it in line with how other grant types already handle ID tokens.

**Classes and methods changed:**

- `ClientInitiatedBackchannelAuthorizationTokenRequest` - two new optional properties:
- `SigningAlgorithm` (`JwtSignatureAlgorithm`) - specifies whether the ID token is signed with `RS256` or `HS256` (defaults to `RS256`).
- `Organization` - optional organization identifier for `org_id` / `org_name` claim validation. 
- `AuthenticationApiClient.GetTokenAsync(ClientInitiatedBackchannelAuthorizationTokenRequest)` - now calls `AssertIdTokenValidIfExisting` after receiving the token response, so that signature, expiry, issuer,
  audience, and (optionally) organisation claims are verified before the response is returned to the caller.

**Usage example:**

```csharp
  var tokenResponse = await authClient.GetTokenAsync(
      new ClientInitiatedBackchannelAuthorizationTokenRequest
      {
          ClientId = "...",
          ClientSecret = "...",
          AuthRequestId = authReqId,
          SigningAlgorithm = JwtSignatureAlgorithm.RS256, // or HS256
          Organization = "org_abc123"                    // optional
      });
```

### References

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language, or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
