### PR TITLE
Update dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
         run: docfx docs-source/docfx.json        
 
       - name: Uploading Artifacts
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: docs
 

--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -16,8 +16,8 @@
 
   <!-- Package Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.17.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
   </ItemGroup>
 
   <!-- Framework-specific References -->


### PR DESCRIPTION
### Changes

Consolidates open Dependabot dependency updates into a single PR:

- Bump `actions/upload-pages-artifact` from 4 to 5 (closes #980)
- Bump `Microsoft.IdentityModel.Protocols.OpenIdConnect` and `System.IdentityModel.Tokens.Jwt` from 8.17.0 to 8.18.0 


### References

- Closes #1001 
- Closes #1002 

### Testing

These are dependency version bumps with no logic changes. No new tests are required.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not — dependency-only updates, no behavioral changes to test.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors