### PR TITLE
mgmt: Adds extension to convert UserDateSchema to DateTime

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -33,12 +33,14 @@ src/Auth0.ManagementApi/.shiprc
 src/Auth0.ManagementApi/.version
 src/Auth0.ManagementApi/ManagementApiClient.Internal.cs
 src/Auth0.ManagementApi/Core/Public/ClientOptions.Custom.cs
+src/Auth0.ManagementApi/Types/UserDateSchemaExtensions.cs
 
 tests/Auth0.AuthenticationApi.IntegrationTests
 tests/Auth0.Core.UnitTests
 tests/Auth0.IntegrationTests.Shared
 tests/Auth0.ManagementApi.IntegrationTests
 tests/Auth0.ManagementApi.Test/Auth0.ManagementApi.Test.Custom.props
+tests/Auth0.ManagementApi.Test/Unit/Extensions/
 tests/Auth0.ManagementApi.Test/Unit/MockServer/Auth0ClientHeaderTest.cs
 tests/Auth0.ManagementApi.Test/Wrapper
 

--- a/src/Auth0.ManagementApi/Types/UserDateSchemaExtensions.cs
+++ b/src/Auth0.ManagementApi/Types/UserDateSchemaExtensions.cs
@@ -1,0 +1,63 @@
+using System.Globalization;
+
+namespace Auth0.ManagementApi;
+
+/// <summary>
+/// Extension methods for <see cref="UserDateSchema"/>.
+/// </summary>
+public static class UserDateSchemaExtensions
+{
+    /// <summary>
+    /// Parses the underlying string value into a <see cref="DateTime"/> using invariant culture and round-trip kind.
+    /// Returns <c>null</c> if the schema is null or does not contain a valid date-time string.
+    /// </summary>
+    public static DateTime? ToDateTime(this UserDateSchema? schema)
+    {
+        if (schema is null || !schema.IsString())
+            return null;
+
+        return DateTime.TryParse(
+            schema.AsString(),
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind,
+            out var result
+        )
+            ? result
+            : null;
+    }
+
+    /// <summary>
+    /// Parses the underlying string value into a <see cref="DateTime"/>, then converts it to the provided time zone.
+    /// Returns <c>null</c> if the schema is null or does not contain a valid date-time string.
+    /// </summary>
+    /// <remarks>
+    /// For timestamps without an explicit offset, parsing uses the local machine time zone.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="targetTimeZone"/> is null.</exception>
+    public static DateTime? ToDateTime(this UserDateSchema? schema, TimeZoneInfo targetTimeZone)
+    {
+        if (targetTimeZone is null)
+            throw new ArgumentNullException(nameof(targetTimeZone));
+
+        if (schema is null || !schema.IsString())
+            return null;
+
+        if (
+            !DateTimeOffset.TryParse(
+                schema.AsString(),
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.None,
+                out var parsedDateTimeOffset
+            )
+        )
+        {
+            return null;
+        }
+
+        var convertedDateTimeOffset = TimeZoneInfo.ConvertTime(parsedDateTimeOffset, targetTimeZone);
+
+        return targetTimeZone.Equals(TimeZoneInfo.Utc)
+            ? convertedDateTimeOffset.UtcDateTime
+            : DateTime.SpecifyKind(convertedDateTimeOffset.DateTime, DateTimeKind.Unspecified);
+    }
+}

--- a/tests/Auth0.ManagementApi.Test/Unit/Extensions/UserDateSchemaExtensionsTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/Extensions/UserDateSchemaExtensionsTest.cs
@@ -1,0 +1,95 @@
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Unit.Extensions;
+
+[TestFixture]
+public class UserDateSchemaExtensionsTest
+{
+    [Test]
+    public void ToDateTime_WithValidIso8601String_ReturnsUtcDateTime()
+    {
+        var schema = UserDateSchema.FromString("2024-03-15T10:30:00.000Z");
+
+        var result = schema.ToDateTime();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value, Is.EqualTo(new DateTime(2024, 3, 15, 10, 30, 0, DateTimeKind.Utc)));
+        Assert.That(result.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+    }
+
+    [Test]
+    public void ToDateTime_WithNull_ReturnsNull()
+    {
+        UserDateSchema? schema = null;
+
+        var result = schema.ToDateTime();
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ToDateTime_WithMapType_ReturnsNull()
+    {
+        var schema = UserDateSchema.FromMapOfStringToUnknown(new Dictionary<string, object?>
+        {
+            { "some_key", "some_value" }
+        });
+
+        var result = schema.ToDateTime();
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ToDateTime_WithMalformedString_ReturnsNull()
+    {
+        var schema = UserDateSchema.FromString("not-a-date");
+
+        var result = schema.ToDateTime();
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ToDateTime_WithOffsetString_PreservesLocalKind()
+    {
+        var schema = UserDateSchema.FromString("2024-06-20T14:00:00.000+05:30");
+
+        var result = schema.ToDateTime();
+        var expectedLocal = new DateTimeOffset(2024, 6, 20, 14, 0, 0, TimeSpan.FromMinutes(330)).LocalDateTime;
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value, Is.EqualTo(expectedLocal));
+        Assert.That(result.Value.Kind, Is.EqualTo(DateTimeKind.Local));
+    }
+
+    [Test]
+    public void ToDateTime_WithDateTimeOffset_ReturnsUtcConverted()
+    {
+        var schema = UserDateSchema.FromString("2024-06-20T14:00:00.000+05:30");
+
+        var result = schema.ToDateTime(TimeZoneInfo.Utc);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Value.Kind, Is.EqualTo(DateTimeKind.Utc));
+        Assert.That(result.Value, Is.EqualTo(new DateTime(2024, 6, 20, 8, 30, 0, DateTimeKind.Utc)));
+    }
+
+    [Test]
+    public void ToDateTime_WithMalformedStringAndTargetTimeZone_ReturnsNull()
+    {
+        var schema = UserDateSchema.FromString("not-a-date");
+
+        var result = schema.ToDateTime(TimeZoneInfo.Utc);
+
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ToDateTime_WithNullTargetTimeZone_ThrowsArgumentNullException()
+    {
+        var schema = UserDateSchema.FromString("2024-03-15T10:30:00.000Z");
+
+        Assert.Throws<ArgumentNullException>(() => schema.ToDateTime(null!));
+    }
+}


### PR DESCRIPTION
  ### Changes

  Adds extension methods to convert `UserDateSchema` to `DateTime`, addressing the inconvenience of working with the discriminated union type returned by the Management API for user date fields (e.g.,
  `created_at`, `updated_at`, `last_login`).

  **Classes and methods added:**

  - `UserDateSchemaExtensions` (static class in `Auth0.ManagementApi` namespace)
    - `ToDateTime(this UserDateSchema?)` - Parses the underlying string value into a `DateTime?` using invariant culture and round-trip kind. Returns `null` if the schema is null, not a string variant, or
  contains an unparseable value.
    - `ToDateTime(this UserDateSchema?, TimeZoneInfo targetTimeZone)` - Parses and converts to the specified time zone. Returns UTC `DateTimeKind.Utc` when targeting UTC, otherwise `DateTimeKind.Unspecified`.

  **Usage example:**

  ```csharp
  var user = await managementApiClient.Users.GetAsync("auth0|...");

  // Simple UTC parse
  DateTime? createdAt = user.CreatedAt.ToDateTime();

  // Convert to a specific time zone
  DateTime? createdAtPst = user.CreatedAt.ToDateTime(TimeZoneInfo.FindSystemTimeZoneById("America/Los_Angeles"));
```

### Testing

- [x] This change adds unit test coverage

- [ ] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
