### PR TITLE
mgmt: (fix): Handle boolean fields returned as strings

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -53,5 +53,8 @@ src/Auth0.ManagementApi/Core/CustomDomainInterceptor.cs
 src/Auth0.ManagementApi/CustomDomainHeader.cs
 tests/Auth0.ManagementApi.Test/Core/CustomDomainInterceptorTest.cs
 tests/Auth0.ManagementApi.Test/Unit/MockServer/CustomDomainHeaderTest.cs
+src/Auth0.ManagementApi/Core/BooleanStringConverter.cs
+tests/Auth0.ManagementApi.Test/Unit/BooleanStringConverterTest.cs
+
 .fern/replay.lock
 .fern/replay.yml

--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,4 @@ MigrationBackup/
 .vscode/*
 .DS_Store
 .idea
+*.lscache

--- a/src/Auth0.ManagementApi/Core/BooleanStringConverter.cs
+++ b/src/Auth0.ManagementApi/Core/BooleanStringConverter.cs
@@ -1,0 +1,36 @@
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi.Core;
+
+/// <summary>
+/// Handles deserialization of boolean values that may arrive as JSON strings
+/// (e.g., "true"/"false") from the Auth0 API, particularly for SAML/SSO users.
+/// </summary>
+internal class BooleanStringConverter : JsonConverter<bool>
+{
+    public override bool Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options)
+    {
+        return reader.TokenType switch
+        {
+            JsonTokenType.True => true,
+            JsonTokenType.False => false,
+            JsonTokenType.String when bool.TryParse(reader.GetString(), out var b) => b,
+            JsonTokenType.String => throw new JsonException(
+                $"Cannot convert \"{reader.GetString()}\" to boolean."),
+            _ => throw new JsonException(
+                $"Cannot convert token type '{reader.TokenType}' to boolean.")
+        };
+    }
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        bool value,
+        JsonSerializerOptions options)
+    {
+        writer.WriteBooleanValue(value);
+    }
+}

--- a/src/Auth0.ManagementApi/Core/JsonConfiguration.cs
+++ b/src/Auth0.ManagementApi/Core/JsonConfiguration.cs
@@ -17,6 +17,7 @@ internal static partial class JsonOptions
         var options = new JsonSerializerOptions
         {
             Converters = { new DateTimeSerializer(),
+                new BooleanStringConverter(),
 #if USE_PORTABLE_DATE_ONLY
                 new DateOnlyConverter(),
 #endif

--- a/tests/Auth0.ManagementApi.Test/Unit/BooleanStringConverterTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/BooleanStringConverterTest.cs
@@ -1,0 +1,122 @@
+using Auth0.ManagementApi.Core;
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Unit;
+
+[TestFixture]
+public class BooleanStringConverterTest
+{
+    [Test]
+    public void Deserialize_NativeBoolTrue_ReturnsTrue()
+    {
+        var result = JsonUtils.Deserialize<TestModel>("""{"value": true}""");
+        Assert.That(result.Value, Is.EqualTo(true));
+    }
+
+    [Test]
+    public void Deserialize_NativeBoolFalse_ReturnsFalse()
+    {
+        var result = JsonUtils.Deserialize<TestModel>("""{"value": false}""");
+        Assert.That(result.Value, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void Deserialize_StringTrue_ReturnsTrue()
+    {
+        var result = JsonUtils.Deserialize<TestModel>("""{"value": "true"}""");
+        Assert.That(result.Value, Is.EqualTo(true));
+    }
+
+    [Test]
+    public void Deserialize_StringFalse_ReturnsFalse()
+    {
+        var result = JsonUtils.Deserialize<TestModel>("""{"value": "false"}""");
+        Assert.That(result.Value, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void Deserialize_StringTrueMixedCase_ReturnsTrue()
+    {
+        var result = JsonUtils.Deserialize<TestModel>("""{"value": "True"}""");
+        Assert.That(result.Value, Is.EqualTo(true));
+    }
+
+    [Test]
+    public void Deserialize_StringFalseMixedCase_ReturnsFalse()
+    {
+        var result = JsonUtils.Deserialize<TestModel>("""{"value": "False"}""");
+        Assert.That(result.Value, Is.EqualTo(false));
+    }
+
+    [Test]
+    public void Deserialize_InvalidString_ThrowsJsonException()
+    {
+        Assert.Throws<System.Text.Json.JsonException>(
+            () => JsonUtils.Deserialize<TestModel>("""{"value": "yes"}""")
+        );
+    }
+
+    [Test]
+    public void Deserialize_EmptyString_ThrowsJsonException()
+    {
+        Assert.Throws<System.Text.Json.JsonException>(
+            () => JsonUtils.Deserialize<TestModel>("""{"value": ""}""")
+        );
+    }
+
+    [Test]
+    public void Deserialize_NullableNativeBoolTrue_ReturnsTrue()
+    {
+        var result = JsonUtils.Deserialize<TestModelNullable>("""{"value": true}""");
+        Assert.That(result.Value, Is.EqualTo(true));
+    }
+
+    [Test]
+    public void Deserialize_NullableStringTrue_ReturnsTrue()
+    {
+        var result = JsonUtils.Deserialize<TestModelNullable>("""{"value": "true"}""");
+        Assert.That(result.Value, Is.EqualTo(true));
+    }
+
+    [Test]
+    public void Deserialize_NullableNull_ReturnsNull()
+    {
+        var result = JsonUtils.Deserialize<TestModelNullable>("""{"value": null}""");
+        Assert.That(result.Value, Is.Null);
+    }
+
+    [Test]
+    public void Deserialize_NullableMissing_ReturnsNull()
+    {
+        var result = JsonUtils.Deserialize<TestModelNullable>("""{}""");
+        Assert.That(result.Value, Is.Null);
+    }
+
+    [Test]
+    public void Serialize_TrueValue_WritesNativeBool()
+    {
+        var json = JsonUtils.Serialize(new TestModel { Value = true });
+        Assert.That(json, Does.Contain("true"));
+        Assert.That(json, Does.Not.Contain("\"true\""));
+    }
+
+    [Test]
+    public void Serialize_FalseValue_WritesNativeBool()
+    {
+        var json = JsonUtils.Serialize(new TestModel { Value = false });
+        Assert.That(json, Does.Contain("false"));
+        Assert.That(json, Does.Not.Contain("\"false\""));
+    }
+
+    private record TestModel
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
+        public bool Value { get; set; }
+    }
+
+    private record TestModelNullable
+    {
+        [System.Text.Json.Serialization.JsonPropertyName("value")]
+        public bool? Value { get; set; }
+    }
+}


### PR DESCRIPTION
### Changes

This PR adds a `BooleanStringConverter` to handle boolean fields that the Auth0 server may return as JSON strings (e.g., `"true"`/`"false"`) instead of native JSON booleans.

- **Classes added:**
  - `BooleanStringConverter` (`src/Auth0.ManagementApi/Core/BooleanStringConverter.cs`) - a `JsonConverter<bool>` that handles deserialization of both native JSON booleans and string-encoded booleans (`"true"`, `"false"`, case-insensitive). Serialization always writes native JSON booleans.

- **Classes modified:**
  - `JsonConfiguration` (`src/Auth0.ManagementApi/Core/JsonConfiguration.cs`) - registered the new converter globally in `JsonOptions`.

- **Other:**
  - Updated `.fernignore` to preserve the new converter and its tests from Fern code generation.


### References

### Testing

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors