### PR TITLE
Adds RAR support

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -14,6 +14,9 @@
   - [3.4. Challenge an already enrolled user](#34-challenge-an-already-enrolled-user)
   - [3.5. Get the list of Authenticators for a user](#35-get-the-list-of-authenticators-for-a-user)
   - [3.6. Delete an enrolled authenticator](#36-delete-an-enrolled-authenticator)
+- [4. Rich Authorization Requests (RAR)](#4-rich-authorization-requests-rar)
+  - [4.1. Pushed Authorization Request (PAR) with authorization details](#41-pushed-authorization-request-par-with-authorization-details)
+  - [4.2. Client Initiated Backchannel Authorization (CIBA) with authorization details](#42-client-initiated-backchannel-authorization-ciba-with-authorization-details)
 
 ## 1. Client Initialization
 
@@ -184,6 +187,77 @@ await authClient.DeleteMfaAuthenticatorAsync(
         AccessToken = "AccessToken",
         AuthenticatorId = "id-random"
     });
+```
+
+## 4. Rich Authorization Requests (RAR)
+
+Rich Authorization Requests (RAR) let you pass fine-grained, structured authorization data via the
+`authorization_details` parameter. Each entry is an `AuthorizationDetail` identified by its `Type`; any
+additional, type-specific fields are supplied through `AdditionalData`.
+
+### 4.1. Pushed Authorization Request (PAR) with authorization details
+
+Set `AuthorizationDetailsObjects` to pass structured authorization details. When set, it takes precedence
+over the raw `AuthorizationDetails` string.
+
+```csharp
+var response = await authClient.PushedAuthorizationRequestAsync(
+    new PushedAuthorizationRequest()
+    {
+        ClientId = _clientId,
+        ClientSecret = _clientSecret,
+        ResponseType = AuthorizationResponseType.Code,
+        RedirectUri = "https://www.myapp.com/callback",
+        AuthorizationDetailsObjects = new List<AuthorizationDetail>
+        {
+            new AuthorizationDetail
+            {
+                Type = "payment_initiation",
+                AdditionalData = new Dictionary<string, JsonElement>
+                {
+                    ["instructedAmount"] = JsonSerializer.SerializeToElement(new { currency = "EUR", amount = "123.50" })
+                }
+            }
+        }
+    });
+```
+
+### 4.2. Client Initiated Backchannel Authorization (CIBA) with authorization details
+
+Pass `AuthorizationDetailsObjects` on the request, and read the strongly-typed details back from the token response.
+
+```csharp
+var authorizationResponse = await authClient.ClientInitiatedBackchannelAuthorization(
+    new ClientInitiatedBackchannelAuthorizationRequest()
+    {
+        ClientId = _clientId,
+        ClientSecret = _clientSecret,
+        BindingMessage = "ABC-123",
+        Scope = "openid",
+        LoginHint = new LoginHint { Format = "iss_sub", Issuer = _issuer, Subject = _subject },
+        AuthorizationDetailsObjects = new List<AuthorizationDetail>
+        {
+            new AuthorizationDetail { Type = "payment_initiation" }
+        }
+    });
+
+var tokenResponse = await authClient.GetTokenAsync(
+    new ClientInitiatedBackchannelAuthorizationTokenRequest()
+    {
+        AuthRequestId = authorizationResponse.AuthRequestId,
+        ClientId = _clientId,
+        ClientSecret = _clientSecret
+    });
+
+// Strongly-typed authorization details returned by the token endpoint.
+// AuthorizationDetails is null when the token endpoint returns no authorization details.
+if (tokenResponse.AuthorizationDetails != null)
+{
+    foreach (var detail in tokenResponse.AuthorizationDetails)
+    {
+        Console.WriteLine(detail.Type);
+    }
+}
 ```
 
 [Go to Top](#)

--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
   <!-- Framework-specific References -->

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Dynamic;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -470,8 +472,12 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         body.AddIfNotEmpty("scope", request.Scope);
         body.AddIfNotEmpty("audience", request.Audience);
         body.AddIfNotEmpty("request", request.Request);
-        body.AddIfNotEmpty("authorization_details", request.AuthorizationDetails);
-            
+
+        if (request.AuthorizationDetailsObjects?.Count > 0)
+            body.AddIfNotEmpty("authorization_details", JsonSerializer.Serialize(request.AuthorizationDetailsObjects));
+        else
+            body.AddIfNotEmpty("authorization_details", request.AuthorizationDetails);
+
         body.AddAll(request.AdditionalProperties);
 
         ApplyClientAuthentication(request, body, true);
@@ -498,7 +504,11 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             
         body.AddIfNotEmpty("scope", request.Scope);
         body.AddIfNotEmpty("audience", request.Audience);
-            
+        body.AddIfNotEmpty("requested_expiry", request.RequestExpiry?.ToString(CultureInfo.InvariantCulture));
+
+        if (request.AuthorizationDetailsObjects?.Count > 0)
+            body.AddIfNotEmpty("authorization_details", JsonSerializer.Serialize(request.AuthorizationDetailsObjects));
+
         body.AddAll(request.AdditionalProperties);
 
         ApplyClientAuthentication(request, body, true);

--- a/src/Auth0.AuthenticationApi/Models/AuthorizationDetail.cs
+++ b/src/Auth0.AuthenticationApi/Models/AuthorizationDetail.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Auth0.AuthenticationApi.Models;
+
+/// <summary>
+/// Represents a single entry in an OAuth 2.0 Rich Authorization Requests (RAR) <c>authorization_details</c> array.
+/// </summary>
+/// <remarks>
+/// Each entry is identified by its <see cref="Type"/>. All other, type-specific fields are captured in
+/// <see cref="AdditionalData"/> so that any RAR schema can be expressed without a fixed model.
+/// See <see href="https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar">Rich Authorization Requests</see>.
+/// </remarks>
+public class AuthorizationDetail
+{
+    /// <summary>
+    /// The authorization details type identifier. This is the only field required by RFC 9396.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    /// <summary>
+    /// Any additional, type-specific fields carried by this authorization detail.
+    /// </summary>
+    [JsonExtensionData]
+    public IDictionary<string, JsonElement> AdditionalData { get; set; } = new Dictionary<string, JsonElement>();
+}

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationRequest.cs
@@ -2,6 +2,8 @@ using System.Collections.Generic;
 
 using Microsoft.IdentityModel.Tokens;
 
+using Auth0.AuthenticationApi.Models;
+
 namespace Auth0.AuthenticationApi.Models.Ciba;
 
 /// <summary>
@@ -45,7 +47,14 @@ public class ClientInitiatedBackchannelAuthorizationRequest : IClientAuthenticat
     /// Used to configure a custom expiry time for this request.
     /// </summary>
     public int? RequestExpiry { get; set; }
-        
+
+    /// <summary>
+    /// Fine-grained authorization data to send as part of a Rich Authorization Requests (RAR) flow.
+    /// Serialized to the <c>authorization_details</c> parameter of the <c>/bc-authorize</c> request.
+    /// <see href="https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar">reference</see>
+    /// </summary>
+    public IList<AuthorizationDetail> AuthorizationDetailsObjects { get; set; }
+
     /// <summary>
     /// Any additional properties to use.
     /// </summary>

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenResponse.cs
@@ -1,4 +1,10 @@
+using System;
+using System.Collections.Generic;
+
 using Newtonsoft.Json;
+
+using Auth0.AuthenticationApi.Models;
+using Auth0.Core.Serialization;
 
 namespace Auth0.AuthenticationApi.Models.Ciba;
 
@@ -6,4 +12,44 @@ public class ClientInitiatedBackchannelAuthorizationTokenResponse : AccessTokenR
 {
     [JsonProperty("scope")]
     public string Scope { get; set; }
+
+    /// <summary>
+    /// Raw <c>authorization_details</c> JSON returned by the token endpoint as part of a
+    /// Rich Authorization Requests (RAR) flow. Use <see cref="AuthorizationDetails"/> for a strongly-typed view.
+    /// </summary>
+    [JsonProperty("authorization_details")]
+    [JsonConverter(typeof(StringOrObjectAsStringConverter))]
+    public string AuthorizationDetailsRaw { get; set; }
+
+    /// <summary>
+    /// Strongly-typed view of the <c>authorization_details</c> returned by the token endpoint.
+    /// Returns <see langword="null"/> when no authorization details were returned.
+    /// </summary>
+    private bool _authorizationDetailsParsed;
+    private IReadOnlyList<AuthorizationDetail> _authorizationDetails;
+
+    [Newtonsoft.Json.JsonIgnore]
+    public IReadOnlyList<AuthorizationDetail> AuthorizationDetails
+    {
+        get
+        {
+            if (_authorizationDetailsParsed)
+                return _authorizationDetails;
+
+            if (string.IsNullOrEmpty(AuthorizationDetailsRaw))
+                return null;
+
+            try
+            {
+                _authorizationDetails = System.Text.Json.JsonSerializer.Deserialize<IReadOnlyList<AuthorizationDetail>>(AuthorizationDetailsRaw);
+                _authorizationDetailsParsed = true;
+                return _authorizationDetails;
+            }
+            catch (System.Text.Json.JsonException ex)
+            {
+                throw new InvalidOperationException(
+                    "Failed to deserialize the 'authorization_details' returned by the token endpoint.", ex);
+            }
+        }
+    }
 }

--- a/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/PushedAuthorizationRequest.cs
@@ -100,5 +100,17 @@ public class PushedAuthorizationRequest : IClientAuthentication
     /// It can carry fine-grained authorization data in OAuth messages as part of Rich Authorization Requests (RAR)
     /// <see href="https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar">reference</see>
     /// </summary>
+    /// <remarks>
+    /// Prefer <see cref="AuthorizationDetailsObjects"/> for a strongly-typed alternative. When both are set,
+    /// <see cref="AuthorizationDetailsObjects"/> takes precedence.
+    /// </remarks>
     public string AuthorizationDetails { get; set; }
+
+    /// <summary>
+    /// Strongly-typed fine-grained authorization data to send as part of a Rich Authorization Requests (RAR) flow.
+    /// Serialized to the <c>authorization_details</c> parameter. When set, this takes precedence over
+    /// <see cref="AuthorizationDetails"/>.
+    /// <see href="https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow/authorization-code-flow-with-rar">reference</see>
+    /// </summary>
+    public IList<AuthorizationDetail> AuthorizationDetailsObjects { get; set; }
 }

--- a/src/Auth0.Core/Serialization/StringOrObjectAsStringConverter.cs
+++ b/src/Auth0.Core/Serialization/StringOrObjectAsStringConverter.cs
@@ -25,10 +25,14 @@ internal class StringOrObjectAsStringConverter : JsonConverter
         if (reader.TokenType == JsonToken.String)
         {
             instance =  reader.Value?.ToString();
-        } 
+        }
         else if (reader.TokenType == JsonToken.StartObject)
         {
             instance = JObject.Load(reader).ToString();
+        }
+        else if (reader.TokenType == JsonToken.StartArray)
+        {
+            instance = JArray.Load(reader).ToString();
         }
 
         return instance;

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTests.cs
@@ -1,12 +1,16 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using Moq;
 using Moq.Protected;
 using Newtonsoft.Json;
 using FluentAssertions;
+using Auth0.AuthenticationApi.Models;
 using Auth0.AuthenticationApi.Models.Ciba;
 using Auth0.Core.Exceptions;
 using Auth0.Tests.Shared;
@@ -171,6 +175,180 @@ public class ClientInitiatedBackchannelAuthorizationTests : TestBase
             }
         ));
         mockHandler.VerifyAll();
+    }
+
+    [Fact]
+    public async void Ciba_request_should_send_authorization_details_and_requested_expiry()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var mockResponse = new ClientInitiatedBackchannelAuthorizationResponse()
+        {
+            AuthRequestId = "Random-Guid",
+            ExpiresIn = 300
+        };
+        var domain = GetVariable("AUTH0_AUTHENTICATION_API_URL");
+
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "requested_expiry", "120" },
+            { "authorization_details", "[{\"type\":\"payment_initiation\"}]" }
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/bc-authorize" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(mockResponse), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var response = await authenticationApiClient.ClientInitiatedBackchannelAuthorization(
+            new ClientInitiatedBackchannelAuthorizationRequest()
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                Scope = "openid profile",
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                BindingMessage = "BindingMessage",
+                RequestExpiry = 120,
+                AuthorizationDetailsObjects = new List<AuthorizationDetail>
+                {
+                    new AuthorizationDetail { Type = "payment_initiation" }
+                },
+                LoginHint = new LoginHint()
+                {
+                    Format = "iss_sub",
+                    Issuer = "https://dx-sdks-testing.us.auth0.com/",
+                    Subject = "auth0|6746de965777c7fc70547a11"
+                }
+            }
+        );
+
+        response.AuthRequestId.Should().Be("Random-Guid");
+        mockHandler.VerifyAll();
+    }
+
+    [Fact]
+    public async void Ciba_token_response_should_expose_typed_authorization_details()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var mockResponse = new ClientInitiatedBackchannelAuthorizationResponse()
+        {
+            AuthRequestId = "Random-Guid",
+            ExpiresIn = 300
+        };
+
+        var mockTokenResponse =
+            "{\"access_token\":\"mock\",\"token_type\":\"Bearer\",\"expires_in\":300," +
+            "\"authorization_details\":[{\"type\":\"payment_initiation\",\"amount\":\"100\"}]}";
+
+        var domain = GetVariable("AUTH0_AUTHENTICATION_API_URL");
+
+        SetupMockWith(mockHandler, $"https://{domain}/bc-authorize", JsonConvert.SerializeObject(mockResponse));
+        SetupMockWith(mockHandler, $"https://{domain}/oauth/token", mockTokenResponse);
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        await authenticationApiClient.ClientInitiatedBackchannelAuthorization(
+            new ClientInitiatedBackchannelAuthorizationRequest()
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                Scope = "openid profile",
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                BindingMessage = "BindingMessage",
+                LoginHint = new LoginHint()
+                {
+                    Format = "iss_sub",
+                    Issuer = "https://dx-sdks-testing.us.auth0.com/",
+                    Subject = "auth0|6746de965777c7fc70547a11"
+                }
+            }
+        );
+
+        var cibaTokenResponse = await authenticationApiClient.GetTokenAsync(
+            new ClientInitiatedBackchannelAuthorizationTokenRequest()
+            {
+                AuthRequestId = "Random-Guid",
+                ClientId = "ClientId",
+                ClientSecret = "ClientSecret"
+            }
+        );
+
+        cibaTokenResponse.AuthorizationDetails.Should().NotBeNull();
+        cibaTokenResponse.AuthorizationDetails.Should().HaveCount(1);
+        cibaTokenResponse.AuthorizationDetails[0].Type.Should().Be("payment_initiation");
+        cibaTokenResponse.AuthorizationDetails[0].AdditionalData["amount"].GetString().Should().Be("100");
+        mockHandler.VerifyAll();
+    }
+
+    [Fact]
+    public async void Ciba_token_response_typed_authorization_details_should_handle_type_only_entry()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var mockResponse = new ClientInitiatedBackchannelAuthorizationResponse()
+        {
+            AuthRequestId = "Random-Guid",
+            ExpiresIn = 300
+        };
+
+        var mockTokenResponse =
+            "{\"access_token\":\"mock\",\"token_type\":\"Bearer\",\"expires_in\":300," +
+            "\"authorization_details\":[{\"type\":\"payment_initiation\"}]}";
+
+        var domain = GetVariable("AUTH0_AUTHENTICATION_API_URL");
+
+        SetupMockWith(mockHandler, $"https://{domain}/bc-authorize", JsonConvert.SerializeObject(mockResponse));
+        SetupMockWith(mockHandler, $"https://{domain}/oauth/token", mockTokenResponse);
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        await authenticationApiClient.ClientInitiatedBackchannelAuthorization(
+            new ClientInitiatedBackchannelAuthorizationRequest()
+            {
+                ClientId = GetVariable("AUTH0_CLIENT_ID"),
+                Scope = "openid profile",
+                ClientSecret = GetVariable("AUTH0_CLIENT_SECRET"),
+                BindingMessage = "BindingMessage",
+                LoginHint = new LoginHint()
+                {
+                    Format = "iss_sub",
+                    Issuer = "https://dx-sdks-testing.us.auth0.com/",
+                    Subject = "auth0|6746de965777c7fc70547a11"
+                }
+            }
+        );
+
+        var cibaTokenResponse = await authenticationApiClient.GetTokenAsync(
+            new ClientInitiatedBackchannelAuthorizationTokenRequest()
+            {
+                AuthRequestId = "Random-Guid",
+                ClientId = "ClientId",
+                ClientSecret = "ClientSecret"
+            }
+        );
+
+        cibaTokenResponse.AuthorizationDetails.Should().NotBeNull();
+        cibaTokenResponse.AuthorizationDetails.Should().HaveCount(1);
+        cibaTokenResponse.AuthorizationDetails[0].Type.Should().Be("payment_initiation");
+        cibaTokenResponse.AuthorizationDetails[0].AdditionalData.Should().NotBeNull();
+        cibaTokenResponse.AuthorizationDetails[0].AdditionalData.Should().BeEmpty();
+        mockHandler.VerifyAll();
+    }
+
+    private static bool ValidateRequestContent(HttpRequestMessage content, Dictionary<string, string> contentParams)
+    {
+        string jsonContent = content.Content.ReadAsStringAsync().Result;
+        var result = jsonContent.Split('&').ToDictionary(keyValue => keyValue.Split('=')[0], keyValue => HttpUtility.UrlDecode(keyValue.Split('=')[1]));
+
+        return contentParams.Aggregate(true, (acc, keyValue) => acc && result.GetValueOrDefault(keyValue.Key) == keyValue.Value);
     }
 
     private static void SetupMockWith(Mock<HttpMessageHandler> mockHandler, string domain, string stringContent, HttpStatusCode code = HttpStatusCode.OK)

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTokenResponseTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTokenResponseTests.cs
@@ -1,0 +1,60 @@
+using System;
+
+using FluentAssertions;
+using Auth0.AuthenticationApi.Models.Ciba;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests;
+
+public class ClientInitiatedBackchannelAuthorizationTokenResponseTests
+{
+    [Fact]
+    public void AuthorizationDetails_returns_null_when_raw_is_null()
+    {
+        var response = new ClientInitiatedBackchannelAuthorizationTokenResponse
+        {
+            AuthorizationDetailsRaw = null
+        };
+
+        response.AuthorizationDetails.Should().BeNull();
+    }
+
+    [Fact]
+    public void AuthorizationDetails_returns_null_when_raw_is_empty()
+    {
+        var response = new ClientInitiatedBackchannelAuthorizationTokenResponse
+        {
+            AuthorizationDetailsRaw = ""
+        };
+
+        response.AuthorizationDetails.Should().BeNull();
+    }
+
+    [Fact]
+    public void AuthorizationDetails_throws_InvalidOperationException_on_malformed_json()
+    {
+        var response = new ClientInitiatedBackchannelAuthorizationTokenResponse
+        {
+            AuthorizationDetailsRaw = "[{\"type\":"
+        };
+
+        Action act = () => _ = response.AuthorizationDetails;
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithInnerException<System.Text.Json.JsonException>();
+    }
+
+    [Fact]
+    public void AuthorizationDetails_caches_parsed_result_across_accesses()
+    {
+        var response = new ClientInitiatedBackchannelAuthorizationTokenResponse
+        {
+            AuthorizationDetailsRaw = "[{\"type\":\"payment_initiation\"}]"
+        };
+
+        var first = response.AuthorizationDetails;
+        var second = response.AuthorizationDetails;
+
+        first.Should().BeSameAs(second);
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/PushedAuthorizationRequestTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/PushedAuthorizationRequestTests.cs
@@ -197,6 +197,184 @@ public class PushedAuthorizationRequestTests
     }
 
     [Fact]
+    public async void Should_Call_OAuth_Par_With_Structured_AuthorizationDetails()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_secret", TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET") },
+            { "authorization_details", "[{\"type\":\"payment_initiation\"}]" }
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+            AuthorizationDetailsObjects = new List<AuthorizationDetail>
+            {
+                new AuthorizationDetail { Type = "payment_initiation" }
+            }
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+
+    [Fact]
+    public async void Should_Prefer_Structured_AuthorizationDetails_Over_String()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_secret", TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET") },
+            { "authorization_details", "[{\"type\":\"payment_initiation\"}]" }
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+            AuthorizationDetails = "THIS_RAW_STRING_SHOULD_BE_IGNORED",
+            AuthorizationDetailsObjects = new List<AuthorizationDetail>
+            {
+                new AuthorizationDetail { Type = "payment_initiation" }
+            }
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+
+    [Fact]
+    public async void Should_Call_OAuth_Par_With_AuthorizationDetails_AdditionalData()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_secret", TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET") },
+            { "authorization_details", "[{\"type\":\"payment_initiation\",\"instructedAmount\":{\"currency\":\"EUR\",\"amount\":\"123.50\"}}]" }
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+            AuthorizationDetailsObjects = new List<AuthorizationDetail>
+            {
+                new AuthorizationDetail
+                {
+                    Type = "payment_initiation",
+                    AdditionalData = new Dictionary<string, System.Text.Json.JsonElement>
+                    {
+                        ["instructedAmount"] = System.Text.Json.JsonSerializer.SerializeToElement(new { currency = "EUR", amount = "123.50" })
+                    }
+                }
+            }
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+
+    [Fact]
+    public async void Should_Fall_Back_To_Raw_AuthorizationDetails_When_Objects_List_Is_Empty()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var requestUri = new Uri("https://www.request.uri");
+        var response = new PushedAuthorizationRequestResponse() { RequestUri = requestUri, ExpiresIn = 500};
+        var domain = TestBaseUtils.GetVariable("AUTH0_AUTHENTICATION_API_URL");
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "client_id", TestBaseUtils.GetVariable("AUTH0_CLIENT_ID") },
+            { "client_secret", TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET") },
+            { "authorization_details", "[{\"type\":\"payment_initiation\"}]" }
+        };
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req => req.RequestUri.ToString() == $"https://{domain}/oauth/par" && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage()
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(JsonConvert.SerializeObject(response), Encoding.UTF8, "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var authenticationApiClient = new TestAuthenticationApiClient(domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        var tokenReponse = await authenticationApiClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest()
+        {
+            ClientId = TestBaseUtils.GetVariable("AUTH0_CLIENT_ID"),
+            ClientSecret = TestBaseUtils.GetVariable("AUTH0_CLIENT_SECRET"),
+            AuthorizationDetails = "[{\"type\":\"payment_initiation\"}]",
+            AuthorizationDetailsObjects = new List<AuthorizationDetail>()
+        });
+
+        tokenReponse.Should().NotBeNull();
+        tokenReponse.RequestUri.Should().Equals(requestUri);
+    }
+
+    [Fact]
     public async void Should_Call_OAuth_Par_With_AdditionalProperties()
     {
         var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);

--- a/tests/Auth0.Core.UnitTests/StringOrObjectAsStringConverterTests.cs
+++ b/tests/Auth0.Core.UnitTests/StringOrObjectAsStringConverterTests.cs
@@ -133,6 +133,37 @@ public class StringOrObjectAsStringConverterTests
     }
 
     [Fact]
+    public void ReadJson_WithArrayToken_ReturnsJsonArrayAsString()
+    {
+        var converter = new StringOrObjectAsStringConverter();
+        var json = "[{\"type\":\"payment_initiation\",\"amount\":\"100\"}]";
+        var reader = new JsonTextReader(new StringReader(json));
+        reader.Read();
+
+        var result = converter.ReadJson(reader, typeof(string), null, new JsonSerializer());
+
+        result.Should().NotBeNull();
+        result.ToString().Should().Contain("type");
+        result.ToString().Should().Contain("payment_initiation");
+        result.ToString().Should().Contain("amount");
+        result.ToString().Should().Contain("100");
+    }
+
+    [Fact]
+    public void ReadJson_WithEmptyArrayToken_ReturnsEmptyArrayString()
+    {
+        var converter = new StringOrObjectAsStringConverter();
+        var json = "[]";
+        var reader = new JsonTextReader(new StringReader(json));
+        reader.Read();
+
+        var result = converter.ReadJson(reader, typeof(string), null, new JsonSerializer());
+
+        result.Should().NotBeNull();
+        result.ToString().Should().Be("[]");
+    }
+
+    [Fact]
     public void CanConvert_WithAnyType_ReturnsTrue()
     {
         var converter = new StringOrObjectAsStringConverter();


### PR DESCRIPTION
  ### Changes

This change adds support for OAuth 2.0 Rich Authorization Requests (RAR) to the Authentication API client, allowing callers to pass fine-grained, structured `authorization_details` on Pushed Authorization Requests (PAR) and Client Initiated Backchannel Authorization (CIBA) flows, and to read strongly-typed authorization details back from the CIBA token response.

**Classes added:**
- `AuthorizationDetail` - represents a single entry in the `authorization_details` array. Identified by `Type`; all other type specific fields are captured via a `JsonExtensionData`, `AdditionalData` dictionary so any RAR schema can be expressed without a fixed model.

**Classes/methods changed:**
- `PushedAuthorizationRequest` - added strongly-typed `AuthorizationDetailsObjects` (`IList<AuthorizationDetail>`). When set, it takes precedence over the raw `AuthorizationDetails` string.
- `ClientInitiatedBackchannelAuthorizationRequest` - added `AuthorizationDetailsObjects`. Also now serializes the existing `RequestExpiry` to the `requested_expiry` parameter.
- `ClientInitiatedBackchannelAuthorizationTokenResponse` - added `AuthorizationDetailsRaw` (raw JSON) and a strongly-typed `AuthorizationDetails` (`IReadOnlyList<AuthorizationDetail>`)
view, returning `null` when no details are present.
- `AuthenticationApiClient.PushedAuthorizationRequestAsync` / `ClientInitiatedBackchannelAuthorization` - serialize `AuthorizationDetailsObjects` to the `authorization_details` body
parameter when provided.
- `StringOrObjectAsStringConverter` - now also handles JSON array tokens (`StartArray`), since `authorization_details` is returned as an array.

**Dependencies:**
- Added `System.Text.Json` (9.0.9) package reference to `Auth0.AuthenticationApi`.

**Docs:**
- `Examples.md` - added a new "Rich Authorization Requests (RAR)" section with PAR and CIBA usage examples.

**Usage summary:**

```csharp
// PAR with authorization details
await authClient.PushedAuthorizationRequestAsync(new PushedAuthorizationRequest
{
    ClientId = _clientId,
    ClientSecret = _clientSecret,
    ResponseType = AuthorizationResponseType.Code,
    RedirectUri = "https://www.myapp.com/callback",
    AuthorizationDetailsObjects = new List<AuthorizationDetail>
    {
        new AuthorizationDetail
        {
            Type = "payment_initiation",
            AdditionalData = new Dictionary<string, JsonElement>
            {
                ["instructedAmount"] = JsonSerializer.SerializeToElement(new { currency = "EUR", amount = "123.50" })
            }
        }
    }
});
```

### References

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
