### PR TITLE
Chore: Bump GitHub Actions and NuGet dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Save build artifacts
-      uses: actions/cache/save@v5
+      uses: actions/cache/save@v6
       with:
         path: .
         key: ${{ env.CACHE_KEY }}
@@ -56,7 +56,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Restore build artifacts
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: .
         key: ${{ env.CACHE_KEY }}
@@ -83,7 +83,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Restore build artifacts
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: .
         key: ${{ env.CACHE_KEY }}
@@ -109,7 +109,7 @@ jobs:
       with:
         dotnet-version: 8.0.x
     - name: Restore build artifacts
-      uses: actions/cache/restore@v5
+      uses: actions/cache/restore@v6
       with:
         path: .
         key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Auth0.Core
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Auth0.AuthenticationApi
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Test Auth0.ManagementApi
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - name: Setup .NET
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
       run: dotnet test tests/Auth0.Core.UnitTests/Auth0.Core.UnitTests.csproj  --collect:"XPlat Code coverage" --results-directory ./TestResults/ /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
     
     - name: Update codecov report
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # pin@6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # pin@7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./TestResults/**/coverage.cobertura.xml
@@ -91,7 +91,7 @@ jobs:
       run: dotnet test tests/Auth0.AuthenticationApi.IntegrationTests/Auth0.AuthenticationApi.IntegrationTests.csproj --collect:"XPlat Code coverage" --results-directory ./TestResults/ /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
 
     - name: Update codecov report
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # pin@6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # pin@7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./TestResults/**/coverage.cobertura.xml
@@ -119,7 +119,7 @@ jobs:
         dotnet test tests/Auth0.ManagementApi.Test/Auth0.ManagementApi.Test.csproj --collect:"XPlat Code coverage" --results-directory ./TestResults/ /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura
 
     - name: Update codecov report
-      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # pin@6.0.0
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # pin@7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: ./TestResults/**/coverage.cobertura.xml

--- a/.github/workflows/nuget-release.yml
+++ b/.github/workflows/nuget-release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       # Checkout the code
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       

--- a/.github/workflows/rl-secure.yml
+++ b/.github/workflows/rl-secure.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -29,7 +29,7 @@ jobs:
       - if: github.actor == 'dependabot[bot]' || github.event_name == 'merge_group'
         run: exit 0 # Skip unnecessary test runs for dependabot and merge queues. Artifically flag as successful, as this is a required check for branch protection.
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha || github.ref }}
 

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet restore
 
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/dotnet@b98d498629f1c368650224d6d212bf7dfa89e4bf # pin@0.4.0
+        uses: snyk/actions/dotnet@9adf32b1121593767fc3c057af55b55db032dc04 # pin@1.0.0
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:

--- a/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
+++ b/src/Auth0.AuthenticationApi/Auth0.AuthenticationApi.csproj
@@ -16,8 +16,8 @@
 
   <!-- Package Dependencies -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.18.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.18.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="8.19.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 

--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.Custom.props
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.Custom.props
@@ -12,7 +12,7 @@
        then re-add a single canonical reference to silence NU1504. -->
   <ItemGroup>
     <PackageReference Remove="PolySharp" />
-    <PackageReference Include="PolySharp" Version="1.15.0">
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="PolySharp" Version="1.15.0">
+    <PackageReference Include="PolySharp" Version="1.16.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
### Changes

This PR consolidates several Dependabot dependency updates into a single change. It bumps both GitHub Actions used in CI workflows and NuGet package references. No production/public API surface is affected — these are build, CI, and transitive/security dependency updates.

**GitHub Actions**
- `actions/cache` 5 → 6
- `actions/checkout` 5 → 7
- `codecov/codecov-action` 6.0.0 → 7.0.0
- `snyk/actions/dotnet` 0.4.0 → 1.0.0

**NuGet packages**
- `System.IdentityModel.Tokens.Jwt` 8.18.0 → 8.19.1 (`Auth0.AuthenticationApi`)
- `Microsoft.IdentityModel.Protocols.OpenIdConnect` 8.18.0 → 8.19.1 (`Auth0.AuthenticationApi`)
- `PolySharp` 1.15.0 → 1.16.0 (`src/Directory.Build.props`)

These keep dependencies current with the latest patch/minor releases and pick up upstream fixes and security updates.

### References

- Supersedes the individual Dependabot PRs: #1041, #1040, #1036, #1029, #1024, #1020
- Note: #1025 (`System.IdentityModel.Tokens.Jwt` → 8.19.1) is intentionally omitted because #1024 already bumps that package to the same version alongside `Microsoft.IdentityModel.Protocols.OpenIdConnect`.

### Testing

No source code changes — only dependency version bumps and CI workflow action versions. Verification is via the existing CI pipeline (build + full test suite) passing on this branch.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not — covered by the existing CI build and test run against the bumped dependencies

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors