### PR TITLE
fix: Fix casing issue in header parsing logic

### DIFF
--- a/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
+++ b/src/Auth0.AuthenticationApi/HttpClientAuthenticationConnection.cs
@@ -141,7 +141,7 @@ public class HttpClientAuthenticationConnection : IAuthenticationConnection, IDi
     {
         if (parsedResponse == null || httpResponse == null) return;
 
-        var headers = httpResponse.Headers?.ToDictionary(h => h.Key, h => h.Value);
+        var headers = httpResponse.Headers?.ToDictionary(h => h.Key, h => h.Value, StringComparer.OrdinalIgnoreCase);
         var headersProperty = typeof(T).GetProperty("Headers");
             
         if (headersProperty != null && headersProperty.PropertyType == typeof(IDictionary<string, IEnumerable<string>>))

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/HttpClientAuthenticationConnectionTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/HttpClientAuthenticationConnectionTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using Auth0.AuthenticationApi.Models;
 using Auth0.AuthenticationApi.Models.Ciba;
+using Auth0.Core;
 using FluentAssertions;
 using Xunit;
 
@@ -87,8 +88,29 @@ public class HttpClientAuthenticationConnectionTests : TestBase
     {
         // Arrange
         var parsedResponse = new ClientInitiatedBackchannelAuthorizationResponse();
-        
+
         // Act & Assert
         HttpClientAuthenticationConnection.AddResponseHeaders(parsedResponse, null);
+    }
+
+    [Fact]
+    public void AddResponseHeaders_Should_Build_Case_Insensitive_Header_Lookup()
+    {
+        // HTTP headers are case-insensitive; the server may return the quota
+        // header with different casing than the SDK looks it up with.
+        var parsedResponse = new AccessTokenResponse();
+        var httpResponse = new HttpResponseMessage
+        {
+            Headers = { { "auth0-client-quota-limit", ["b=per_hour;q=2;r=1;t=924"] } }
+        };
+
+        HttpClientAuthenticationConnection.AddResponseHeaders(parsedResponse, httpResponse);
+
+        var clientQuota = parsedResponse.Headers.GetClientQuotaLimit();
+
+        clientQuota.Should().NotBeNull();
+        clientQuota.PerHour.Quota.Should().Be(2);
+        clientQuota.PerHour.Remaining.Should().Be(1);
+        clientQuota.PerHour.ResetAfter.Should().Be(924);
     }
 }


### PR DESCRIPTION
### Changes

The SDK was building its header lookup dictionary with the default (case-sensitive) `StringComparer`. When the server returned a header (e.g. `auth0-client-quota-limit`) with different casing than the SDK used to look it up, the lookup silently failed and the value was lost.

- `HttpClientAuthenticationConnection.AddResponseHeaders<T>` now builds the headers dictionary with `StringComparer.OrdinalIgnoreCase`, so response headers are matched regardless of casing.

### References

### Testing

Added an integration test (`AddResponseHeaders_Should_Build_Case_Insensitive_Header_Lookup`) that supplies the quota header in lowercase and asserts the parsed `ClientQuotaLimit` values are populated correctly. Existing tests continue to pass.

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors