### PR TITLE
feat: Adds MRRT support

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -17,6 +17,7 @@
 - [4. Rich Authorization Requests (RAR)](#4-rich-authorization-requests-rar)
   - [4.1. Pushed Authorization Request (PAR) with authorization details](#41-pushed-authorization-request-par-with-authorization-details)
   - [4.2. Client Initiated Backchannel Authorization (CIBA) with authorization details](#42-client-initiated-backchannel-authorization-ciba-with-authorization-details)
+- [5. Multi-Resource Refresh Token (MRRT)](#5-multi-resource-refresh-token-mrrt)
 
 ## 1. Client Initialization
 
@@ -257,6 +258,41 @@ if (tokenResponse.AuthorizationDetails != null)
     {
         Console.WriteLine(detail.Type);
     }
+}
+```
+
+[Go to Top](#)
+
+## 5. Multi-Resource Refresh Token (MRRT)
+
+A Multi-Resource Refresh Token lets you exchange a single refresh token for access
+tokens targeting different APIs (`Audience`) and/or broader scopes, without a full
+re-authentication. At the protocol level this is a standard refresh-token grant with
+`Audience` and/or `Scope` set.
+
+The token endpoint returns the scopes that were **actually granted** in
+`AccessTokenResponse.Scope` (RFC 6749 §5.1), which may be narrower than what you
+requested. Compare the two to detect an insufficient-scope grant.
+
+```csharp
+var requestedScope = "read:data write:data";
+
+var tokenResponse = await authClient.GetTokenAsync(new RefreshTokenRequest
+{
+    ClientId = _clientId,
+    ClientSecret = _clientSecret,
+    RefreshToken = _refreshToken,
+    Audience = "https://my-api.example.com", // target a different API (optional)
+    Scope = requestedScope                    // request broader scopes (optional)
+});
+
+Console.WriteLine($"Access Token : {tokenResponse.AccessToken}");
+Console.WriteLine($"Granted Scope: {tokenResponse.Scope}");
+
+// The server may grant fewer scopes than requested — check before relying on them.
+if (tokenResponse.Scope != requestedScope)
+{
+    Console.WriteLine("Warning: not all requested scopes were granted.");
 }
 ```
 

--- a/Examples.md
+++ b/Examples.md
@@ -289,10 +289,14 @@ var tokenResponse = await authClient.GetTokenAsync(new RefreshTokenRequest
 Console.WriteLine($"Access Token : {tokenResponse.AccessToken}");
 Console.WriteLine($"Granted Scope: {tokenResponse.Scope}");
 
-// The server may grant fewer scopes than requested — check before relying on them.
-if (tokenResponse.Scope != requestedScope)
+// The server may grant fewer scopes than requested, and returns them in no guaranteed
+// order — compare as sets rather than comparing the raw strings.
+var requested = requestedScope.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+var granted = (tokenResponse.Scope ?? string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries);
+var missingScopes = requested.Except(granted).ToList();
+if (missingScopes.Count > 0)
 {
-    Console.WriteLine("Warning: not all requested scopes were granted.");
+    Console.WriteLine($"Warning: not all requested scopes were granted. Missing: {string.Join(" ", missingScopes)}");
 }
 ```
 

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -220,7 +220,7 @@ public class AuthenticationApiClient : IAuthenticationApiClient
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
-        await AssertIdTokenValid(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization, request.Nonce).ConfigureAwait(false);
+        await AssertIdTokenValidIfExisting(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization, request.Nonce).ConfigureAwait(false);
 
         return response;
     }

--- a/src/Auth0.AuthenticationApi/Models/AccessTokenResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/AccessTokenResponse.cs
@@ -25,6 +25,17 @@ public class AccessTokenResponse : TokenBase
     /// </summary>
     [JsonPropertyName("refresh_token")]
     public string RefreshToken { get; set; }
-        
+
+    /// <summary>
+    /// The scopes that were actually granted for this token.
+    /// </summary>
+    /// <remarks>
+    /// The authorization server returns the granted scope, which
+    /// may be narrower than the scope that was requested. Compare this against the
+    /// requested scope to detect an insufficient-scope grant.
+    /// </remarks>
+    [JsonPropertyName("scope")]
+    public string Scope { get; set; }
+
     public IDictionary<string, IEnumerable<string>> Headers { get; set; }
 }

--- a/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/Ciba/ClientInitiatedBackchannelAuthorizationTokenResponse.cs
@@ -10,9 +10,6 @@ namespace Auth0.AuthenticationApi.Models.Ciba;
 
 public class ClientInitiatedBackchannelAuthorizationTokenResponse : AccessTokenResponse
 {
-    [JsonPropertyName("scope")]
-    public string Scope { get; set; }
-
     /// <summary>
     /// Raw <c>authorization_details</c> JSON returned by the token endpoint as part of a
     /// Rich Authorization Requests (RAR) flow. Use <see cref="AuthorizationDetails"/> for a strongly-typed view.

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTokenResponseTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/ClientInitiatedBackchannelAuthorizationTokenResponseTests.cs
@@ -57,4 +57,15 @@ public class ClientInitiatedBackchannelAuthorizationTokenResponseTests
 
         first.Should().BeSameAs(second);
     }
+
+    [Fact]
+    public void Scope_deserializes_onto_inherited_base_property()
+    {
+        var json = "{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"scope\":\"openid profile\"}";
+
+        var response = System.Text.Json.JsonSerializer
+            .Deserialize<ClientInitiatedBackchannelAuthorizationTokenResponse>(json);
+
+        response.Scope.Should().Be("openid profile");
+    }
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/MrrtTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/MrrtTests.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Auth0.AuthenticationApi.Models;
+using Auth0.Core.Exceptions;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests;
+
+public class MrrtTests
+{
+    private const string Domain = "test-tenant.auth0.com";
+    private const string ClientId = "test-client-id";
+    private const string ClientSecret = "test-client-secret";
+    private const string RefreshToken = "test-refresh-token";
+
+    private static AuthenticationApiClient CreateClient(
+        AccessTokenResponse response,
+        Dictionary<string, string> expectedParams)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"
+                    && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response, response.GetType()),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        return new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+    }
+
+    private static bool ValidateRequestContent(HttpRequestMessage content, Dictionary<string, string> contentParams)
+    {
+        string body = content.Content.ReadAsStringAsync().Result;
+        var result = body.Split("&")
+            .ToDictionary(kv => kv.Split("=")[0], kv => HttpUtility.UrlDecode(kv.Split("=")[1]));
+        return contentParams.Aggregate(true, (acc, kv) => acc && result.GetValueOrDefault(kv.Key) == kv.Value);
+    }
+
+    [Fact]
+    public async Task Can_upscope_for_existing_audience()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "new-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            Scope = "read:data write:data"
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "refresh_token" },
+            { "refresh_token", RefreshToken },
+            { "audience", "https://api.example.com" },
+            { "scope", "read:data write:data" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new RefreshTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            RefreshToken = RefreshToken,
+            Audience = "https://api.example.com",
+            Scope = "read:data write:data"
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("new-access-token");
+        result.Scope.Should().Be("read:data write:data");
+    }
+
+    [Fact]
+    public async Task Can_exchange_token_for_different_audience()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "audience-b-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            Scope = "read:b"
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "refresh_token" },
+            { "refresh_token", RefreshToken },
+            { "audience", "https://api-b.example.com" },
+            { "scope", "read:b" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new RefreshTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            RefreshToken = RefreshToken,
+            Audience = "https://api-b.example.com",
+            Scope = "read:b"
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("audience-b-token");
+        result.Scope.Should().Be("read:b");
+    }
+
+    [Fact]
+    public async Task Can_upscope_for_default_audience()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "default-audience-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            Scope = "openid profile email"
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "refresh_token" },
+            { "refresh_token", RefreshToken },
+            { "scope", "openid profile email" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new RefreshTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            RefreshToken = RefreshToken,
+            Scope = "openid profile email"
+        });
+
+        result.Should().NotBeNull();
+        result.Scope.Should().Be("openid profile email");
+    }
+
+    [Fact]
+    public async Task Can_exchange_from_default_to_specific_audience()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "specific-api-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            Scope = "read:tickets"
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "refresh_token" },
+            { "refresh_token", RefreshToken },
+            { "audience", "https://named-api.example.com" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new RefreshTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            RefreshToken = RefreshToken,
+            Audience = "https://named-api.example.com"
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("specific-api-token");
+        result.Scope.Should().Be("read:tickets");
+    }
+
+    [Fact]
+    public async Task Scope_field_reflects_actual_grants()
+    {
+        const string requestedScope = "read:data write:data delete:data";
+        const string grantedScope = "read:data";
+
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "narrow-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            Scope = grantedScope
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "refresh_token" },
+            { "refresh_token", RefreshToken },
+            { "scope", requestedScope }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new RefreshTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            RefreshToken = RefreshToken,
+            Scope = requestedScope
+        });
+
+        result.Scope.Should().Be(grantedScope);
+        result.Scope.Should().NotBe(requestedScope);
+    }
+
+    [Fact]
+    public async Task Returns_error_when_no_refresh_token()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(
+                    "{\"error\":\"invalid_request\",\"error_description\":\"Missing required parameter: refresh_token\"}",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new RefreshTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            RefreshToken = null
+        });
+
+        await act.Should().ThrowAsync<ErrorApiException>();
+    }
+}


### PR DESCRIPTION
### Changes

Adds **Multi-Resource Refresh Token (MRRT)** support to the `Auth0.AuthenticationApi` package.

MRRT lets a single refresh token be exchanged for access tokens targeting different APIs (`audience`) and/or broader scopes, without a full re-authentication. At the protocol level this is already a standard `POST /oauth/token` refresh-token grant — `RefreshTokenRequest` already carries `Audience` and `Scope`, and `GetTokenAsync(RefreshTokenRequest)` already sends them. The gap this PR closes is on the **response** side: surfacing the actually-granted scopes so callers can detect under-granting.

**Classes/methods changed:**
- `AccessTokenResponse` — added `Scope` property (`[JsonPropertyName("scope")]`). 
The token endpoint returns the granted scope, which may be narrower than requested. Promoting it to the base response makes it available to every flow that returns `AccessTokenResponse`.
 - ClientInitiatedBackchannelAuthorizationTokenResponse — removed its duplicate Scope property; it now inherits from the base AccessTokenResponse. This is source-compatible but binary-breaking: the property
name, wire name (scope), type, and serialization are unchanged, so any code recompiled against this version behaves identically. However, an assembly compiled against a previous version that reads
`ClientInitiatedBackchannelAuthorizationTokenResponse.Scope` holds a member reference to the derived type; because the property now lives on the base, that reference will throw `MissingMethodException` at runtime
until the consuming assembly is recompiled.
- `AuthenticationApiClient.GetTokenAsync(RefreshTokenRequest)` — changed `AssertIdTokenValid` → `AssertIdTokenValidIfExisting`. A refresh-token grant only returns an `id_token` when `openid` scope is requested, which MRRT audience-targeted refreshes frequently omit; the previous call threw `"ID token is required but missing."` on an absent token. This aligns the refresh flow with the client-credentials, passwordless, and device-code flows, which already validate the ID token only when present. Backward-compatible: refresh responses that *do* carry an `id_token` are still validated.

**Usage** (also added to `Examples.md`, §5):
```csharp
var requestedScope = "read:data write:data";

var tokenResponse = await authClient.GetTokenAsync(new RefreshTokenRequest
{
    ClientId = _clientId,
    ClientSecret = _clientSecret,
    RefreshToken = _refreshToken,
    Audience = "https://my-api.example.com", // target a different API (optional)
    Scope = requestedScope                    // request broader scopes (optional)
});

// AccessTokenResponse.Scope reflects what was actually granted — may be narrower.
if (tokenResponse.Scope != requestedScope)
{
    // handle insufficient-scope grant
}
```

### References

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
