### PR TITLE
feat: Adds Custom Token Exchange support

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -18,6 +18,7 @@
   - [4.1. Pushed Authorization Request (PAR) with authorization details](#41-pushed-authorization-request-par-with-authorization-details)
   - [4.2. Client Initiated Backchannel Authorization (CIBA) with authorization details](#42-client-initiated-backchannel-authorization-ciba-with-authorization-details)
 - [5. Multi-Resource Refresh Token (MRRT)](#5-multi-resource-refresh-token-mrrt)
+- [6. Custom Token Exchange (CTE)](#6-custom-token-exchange-cte)
 
 ## 1. Client Initialization
 
@@ -299,6 +300,63 @@ if (missingScopes.Count > 0)
     Console.WriteLine($"Warning: not all requested scopes were granted. Missing: {string.Join(" ", missingScopes)}");
 }
 ```
+
+[Go to Top](#)
+
+## 6. Custom Token Exchange (CTE)
+
+Custom Token Exchange uses the OAuth 2.0 Token Exchange grant (RFC 8693) to exchange an
+existing token for a new Auth0-issued token. The same call supports two use cases,
+selected by the parameters you pass.
+
+### Phase 1 — exchange a subject token for an access token
+
+```csharp
+using Auth0.AuthenticationApi;
+using Auth0.AuthenticationApi.Models;
+
+var auth = new AuthenticationApiClient("YOUR_AUTH0_DOMAIN");
+
+var tokenResponse = await auth.GetTokenAsync(new TokenExchangeTokenRequest
+{
+    ClientId = "YOUR_CLIENT_ID",
+    ClientSecret = "YOUR_CLIENT_SECRET",
+    SubjectToken = "THE_TOKEN_TO_EXCHANGE",
+    SubjectTokenType = TokenType.AccessToken,   // or a custom URN
+    Audience = "https://api.example.com",       // optional target API
+    Scope = "read:data"                          // optional
+});
+
+Console.WriteLine($"Access Token     : {tokenResponse.AccessToken}");
+Console.WriteLine($"Issued Token Type: {tokenResponse.IssuedTokenType}");
+```
+
+### Phase 2 — request a Session Transfer Token
+
+Set `Audience` to your tenant's session-transfer audience and supply an actor token. The
+response's `IssuedTokenType` will be `TokenType.SessionTransferToken`.
+
+```csharp
+var sttResponse = await auth.GetTokenAsync(new TokenExchangeTokenRequest
+{
+    ClientId = "YOUR_CLIENT_ID",
+    ClientSecret = "YOUR_CLIENT_SECRET",
+    SubjectToken = "THE_SUBJECT_TOKEN",
+    SubjectTokenType = TokenType.AccessToken,
+    ActorToken = "THE_ACTOR_TOKEN",
+    ActorTokenType = TokenType.AccessToken,
+    Audience = "urn:YOUR_AUTH0_DOMAIN:session_transfer",
+    Reason = "support-impersonation"             // optional audit string
+});
+
+if (sttResponse.IssuedTokenType == TokenType.SessionTransferToken)
+{
+    Console.WriteLine($"Session Transfer Token: {sttResponse.AccessToken}");
+}
+```
+
+> `ActorToken` and `ActorTokenType` are both-or-neither — supplying only one throws
+> `ArgumentException` before any network call.
 
 [Go to Top](#)
 

--- a/Examples.md
+++ b/Examples.md
@@ -322,9 +322,9 @@ var tokenResponse = await auth.GetTokenAsync(new TokenExchangeTokenRequest
     ClientId = "YOUR_CLIENT_ID",
     ClientSecret = "YOUR_CLIENT_SECRET",
     SubjectToken = "THE_TOKEN_TO_EXCHANGE",
-    SubjectTokenType = TokenType.AccessToken,   // or a custom URN
-    Audience = "https://api.example.com",       // optional target API
-    Scope = "read:data"                          // optional
+    SubjectTokenType = "https://acme.com/cte-profile", // your Custom Token Exchange Profile identifier
+    Audience = "https://api.example.com",              // optional target API
+    Scope = "read:data"                                 // optional
 });
 
 Console.WriteLine($"Access Token     : {tokenResponse.AccessToken}");
@@ -342,11 +342,10 @@ var sttResponse = await auth.GetTokenAsync(new TokenExchangeTokenRequest
     ClientId = "YOUR_CLIENT_ID",
     ClientSecret = "YOUR_CLIENT_SECRET",
     SubjectToken = "THE_SUBJECT_TOKEN",
-    SubjectTokenType = TokenType.AccessToken,
-    ActorToken = "THE_ACTOR_TOKEN",
-    ActorTokenType = TokenType.AccessToken,
-    Audience = "urn:YOUR_AUTH0_DOMAIN:session_transfer",
-    Reason = "support-impersonation"             // optional audit string
+    SubjectTokenType = "https://acme.com/cte-profile", // your Custom Token Exchange Profile identifier
+    ActorToken = "THE_ACTOR_TOKEN",                    // the acting party's Auth0 ID token
+    ActorTokenType = TokenType.IdToken,
+    Audience = "urn:YOUR_AUTH0_DOMAIN:session_transfer"
 });
 
 if (sttResponse.IssuedTokenType == TokenType.SessionTransferToken)

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -230,6 +230,14 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     {
         request.ThrowIfNull();
 
+        if (string.IsNullOrEmpty(request.SubjectToken))
+            throw new ArgumentException(
+                "SubjectToken is required.", nameof(request.SubjectToken));
+
+        if (string.IsNullOrEmpty(request.SubjectTokenType))
+            throw new ArgumentException(
+                "SubjectTokenType is required.", nameof(request.SubjectTokenType));
+
         if (string.IsNullOrEmpty(request.ActorToken) != string.IsNullOrEmpty(request.ActorTokenType))
             throw new ArgumentException(
                 "ActorToken and ActorTokenType must both be provided together, or both omitted.",
@@ -248,7 +256,6 @@ public class AuthenticationApiClient : IAuthenticationApiClient
         body.AddIfNotEmpty("actor_token_type", request.ActorTokenType);
         body.AddIfNotEmpty("audience", request.Audience);
         body.AddIfNotEmpty("scope", request.Scope);
-        body.AddIfNotEmpty("reason", request.Reason);
         body.AddIfNotEmpty("organization", request.Organization);
 
         var response = await connection.SendAsync<AccessTokenResponse>(

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -226,6 +226,44 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     }
 
     /// <inheritdoc/>
+    public async Task<AccessTokenResponse> GetTokenAsync(TokenExchangeTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        request.ThrowIfNull();
+
+        if (string.IsNullOrEmpty(request.ActorToken) != string.IsNullOrEmpty(request.ActorTokenType))
+            throw new ArgumentException(
+                "ActorToken and ActorTokenType must both be provided together, or both omitted.",
+                nameof(request.ActorToken));
+
+        var body = new Dictionary<string, string> {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "client_id", request.ClientId },
+            { "subject_token", request.SubjectToken },
+            { "subject_token_type", request.SubjectTokenType }
+        };
+
+        ApplyClientAuthentication(request, body);
+
+        body.AddIfNotEmpty("actor_token", request.ActorToken);
+        body.AddIfNotEmpty("actor_token_type", request.ActorTokenType);
+        body.AddIfNotEmpty("audience", request.Audience);
+        body.AddIfNotEmpty("scope", request.Scope);
+        body.AddIfNotEmpty("reason", request.Reason);
+        body.AddIfNotEmpty("organization", request.Organization);
+
+        var response = await connection.SendAsync<AccessTokenResponse>(
+            HttpMethod.Post,
+            tokenUri,
+            body,
+            cancellationToken: cancellationToken
+        ).ConfigureAwait(false);
+
+        await AssertIdTokenValidIfExisting(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, request.Organization, request.Nonce).ConfigureAwait(false);
+
+        return response;
+    }
+
+    /// <inheritdoc/>
     public async Task<AccessTokenResponse> GetTokenAsync(ResourceOwnerTokenRequest request, CancellationToken cancellationToken = default)
     {
         request.ThrowIfNull();

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -83,9 +83,20 @@ public interface IAuthenticationApiClient : IDisposable
     /// </summary>
     /// <param name="request"><see cref="RefreshTokenRequest"/> containing Refresh Token and associated parameters.</param>
     /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
-    /// <returns><see cref="Task"/> representing the async operation containing 
+    /// <returns><see cref="Task"/> representing the async operation containing
     /// a <see cref="AccessTokenResponse" /> with the requested tokens.</returns>
     Task<AccessTokenResponse> GetTokenAsync(RefreshTokenRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Exchanges a token using the OAuth 2.0 Token Exchange grant (RFC 8693), also known
+    /// as Custom Token Exchange.
+    /// </summary>
+    /// <param name="request"><see cref="TokenExchangeTokenRequest"/> containing the subject token and associated parameters.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns><see cref="Task"/> representing the async operation containing
+    /// a <see cref="AccessTokenResponse" /> with the requested tokens. Inspect
+    /// <see cref="AccessTokenResponse.IssuedTokenType"/> to determine the kind of token issued.</returns>
+    Task<AccessTokenResponse> GetTokenAsync(TokenExchangeTokenRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Performs authentication by providing user-supplied information in a <see cref="ResourceOwnerTokenRequest"/>.

--- a/src/Auth0.AuthenticationApi/Models/AccessTokenResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/AccessTokenResponse.cs
@@ -37,5 +37,17 @@ public class AccessTokenResponse : TokenBase
     [JsonPropertyName("scope")]
     public string Scope { get; set; }
 
+    /// <summary>
+    /// The type of the token issued, as a URN.
+    /// </summary>
+    /// <remarks>
+    /// Returned by the token-exchange grant to indicate which kind of token was issued —
+    /// for example <see cref="TokenType.AccessToken"/> for a normal access token, or
+    /// <see cref="TokenType.SessionTransferToken"/> for an Auth0 Session Transfer Token.
+    /// Null for flows that do not return this field.
+    /// </remarks>
+    [JsonPropertyName("issued_token_type")]
+    public string IssuedTokenType { get; set; }
+
     public IDictionary<string, IEnumerable<string>> Headers { get; set; }
 }

--- a/src/Auth0.AuthenticationApi/Models/TokenExchangeTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/TokenExchangeTokenRequest.cs
@@ -1,0 +1,94 @@
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AuthenticationApi.Models;
+
+/// <summary>
+/// Represents a request to exchange a token using the OAuth 2.0 Token Exchange grant
+/// (RFC 8693), also known as Custom Token Exchange.
+/// </summary>
+/// <remarks>
+/// The same request covers both a normal access-token exchange (Phase 1) and an Auth0
+/// Session Transfer Token exchange (Phase 2) — the latter by setting
+/// <see cref="Audience"/> to the session-transfer audience and supplying an actor token.
+/// </remarks>
+public class TokenExchangeTokenRequest : IClientAuthentication
+{
+    /// <summary>
+    /// The token that represents the identity of the party on behalf of whom the request
+    /// is being made. Required.
+    /// </summary>
+    public string SubjectToken { get; set; }
+
+    /// <summary>
+    /// An identifier that indicates the type of <see cref="SubjectToken"/>, as a URN.
+    /// See <see cref="TokenType"/> for well-known values. Required.
+    /// </summary>
+    public string SubjectTokenType { get; set; }
+
+    /// <summary>
+    /// Optional token that represents the identity of the acting party. When supplied,
+    /// <see cref="ActorTokenType"/> must also be supplied (both-or-neither).
+    /// </summary>
+    public string ActorToken { get; set; }
+
+    /// <summary>
+    /// An identifier that indicates the type of <see cref="ActorToken"/>, as a URN.
+    /// Required if <see cref="ActorToken"/> is set; must be omitted otherwise.
+    /// </summary>
+    public string ActorTokenType { get; set; }
+
+    /// <summary>
+    /// Optional target audience (API identifier) for the requested token. For a Session
+    /// Transfer Token, set this to the session-transfer audience.
+    /// </summary>
+    public string Audience { get; set; }
+
+    /// <summary>
+    /// Optional space-delimited scopes for the requested token.
+    /// </summary>
+    public string Scope { get; set; }
+
+    /// <summary>
+    /// Optional human-readable reason for the exchange, recorded for audit/logging.
+    /// </summary>
+    public string Reason { get; set; }
+
+    /// <summary>
+    /// Optional organization. Can be an Organization Name or ID.
+    /// </summary>
+    public string Organization { get; set; }
+
+    /// <summary>
+    /// Client ID of the application.
+    /// </summary>
+    public string ClientId { get; set; }
+
+    /// <summary>
+    /// Client Secret of the application.
+    /// </summary>
+    public string ClientSecret { get; set; }
+
+    /// <summary>
+    /// Security Key to use with Client Assertion.
+    /// </summary>
+    public SecurityKey ClientAssertionSecurityKey { get; set; }
+
+    /// <summary>
+    /// Algorithm for the Security Key to use with Client Assertion.
+    /// </summary>
+    public string ClientAssertionSecurityKeyAlgorithm { get; set; }
+
+    /// <summary>
+    /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature of Id Tokens.
+    /// </summary>
+    public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+
+    /// <summary>
+    /// Optional nonce to validate against the nonce claim in a returned ID token.
+    /// </summary>
+    /// <remarks>
+    /// When set, the nonce claim in the returned ID token must exactly match this value.
+    /// Leave null (the default) to skip nonce validation.
+    /// </remarks>
+    public string? Nonce { get; set; }
+}

--- a/src/Auth0.AuthenticationApi/Models/TokenExchangeTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/TokenExchangeTokenRequest.cs
@@ -20,8 +20,11 @@ public class TokenExchangeTokenRequest : IClientAuthentication
     public string SubjectToken { get; set; }
 
     /// <summary>
-    /// An identifier that indicates the type of <see cref="SubjectToken"/>, as a URN.
-    /// See <see cref="TokenType"/> for well-known values. Required.
+    /// Identifies the Custom Token Exchange Profile that validates the
+    /// <see cref="SubjectToken"/>. Must be a URI under your own ownership (for example
+    /// <c>https://acme.com/cte-profile</c> or <c>urn:acme:legacy-token</c>) and must
+    /// correspond to an existing profile. Reserved namespaces such as
+    /// <c>urn:ietf</c>, <c>urn:auth0</c>, and <c>http://auth0.com</c> are rejected. Required.
     /// </summary>
     public string SubjectTokenType { get; set; }
 
@@ -33,7 +36,9 @@ public class TokenExchangeTokenRequest : IClientAuthentication
 
     /// <summary>
     /// An identifier that indicates the type of <see cref="ActorToken"/>, as a URN.
-    /// Required if <see cref="ActorToken"/> is set; must be omitted otherwise.
+    /// For an Auth0 ID token use <see cref="TokenType.IdToken"/>. See
+    /// <see cref="TokenType"/> for well-known values. Required if
+    /// <see cref="ActorToken"/> is set; must be omitted otherwise.
     /// </summary>
     public string ActorTokenType { get; set; }
 
@@ -47,11 +52,6 @@ public class TokenExchangeTokenRequest : IClientAuthentication
     /// Optional space-delimited scopes for the requested token.
     /// </summary>
     public string Scope { get; set; }
-
-    /// <summary>
-    /// Optional human-readable reason for the exchange, recorded for audit/logging.
-    /// </summary>
-    public string Reason { get; set; }
 
     /// <summary>
     /// Optional organization. Can be an Organization Name or ID.

--- a/src/Auth0.AuthenticationApi/Models/TokenType.cs
+++ b/src/Auth0.AuthenticationApi/Models/TokenType.cs
@@ -1,0 +1,33 @@
+namespace Auth0.AuthenticationApi.Models;
+
+/// <summary>
+/// Well-known OAuth 2.0 Token Exchange (RFC 8693) token type URNs, plus the
+/// Auth0-specific Session Transfer Token type.
+/// </summary>
+/// <remarks>
+/// These are provided for convenience and discoverability. The token-type
+/// properties on <see cref="TokenExchangeTokenRequest"/> are plain strings, so a
+/// caller may also supply a custom or future URN not listed here.
+/// </remarks>
+public static class TokenType
+{
+    /// <summary>
+    /// Indicates that the token is an OIDC ID Token: <c>urn:ietf:params:oauth:token-type:id_token</c>.
+    /// </summary>
+    public const string IdToken = "urn:ietf:params:oauth:token-type:id_token";
+
+    /// <summary>
+    /// Indicates that the token is an OAuth 2.0 access token: <c>urn:ietf:params:oauth:token-type:access_token</c>.
+    /// </summary>
+    public const string AccessToken = "urn:ietf:params:oauth:token-type:access_token";
+
+    /// <summary>
+    /// Indicates that the token is a JWT: <c>urn:ietf:params:oauth:token-type:jwt</c>.
+    /// </summary>
+    public const string Jwt = "urn:ietf:params:oauth:token-type:jwt";
+
+    /// <summary>
+    /// Indicates that the token is an Auth0 Session Transfer Token: <c>urn:auth0:params:oauth:token-type:session_transfer_token</c>.
+    /// </summary>
+    public const string SessionTransferToken = "urn:auth0:params:oauth:token-type:session_transfer_token";
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/CustomTokenExchangeTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/CustomTokenExchangeTests.cs
@@ -27,6 +27,7 @@ public class CustomTokenExchangeTests
     private const string ClientId = "test-client-id";
     private const string ClientSecret = "test-client-secret";
     private const string SubjectToken = "test-subject-token";
+    private const string CteProfile = "https://acme.com/cte-profile";
 
     private static AuthenticationApiClient CreateClient(
         AccessTokenResponse response,
@@ -77,7 +78,7 @@ public class CustomTokenExchangeTests
         {
             { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
             { "subject_token", SubjectToken },
-            { "subject_token_type", TokenType.AccessToken }
+            { "subject_token_type", CteProfile }
         };
 
         var client = CreateClient(response, expectedParams);
@@ -87,7 +88,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken
+            SubjectTokenType = CteProfile
         });
 
         result.Should().NotBeNull();
@@ -120,12 +121,12 @@ public class CustomTokenExchangeTests
         var request = new TokenExchangeTokenRequest
         {
             SubjectToken = "st",
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             ClientId = "cid"
         };
 
         request.Should().BeAssignableTo<IClientAuthentication>();
-        request.SubjectTokenType.Should().Be("urn:ietf:params:oauth:token-type:access_token");
+        request.SubjectTokenType.Should().Be(CteProfile);
     }
 
     [Fact]
@@ -142,7 +143,7 @@ public class CustomTokenExchangeTests
         {
             { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
             { "subject_token", SubjectToken },
-            { "subject_token_type", TokenType.AccessToken },
+            { "subject_token_type", CteProfile },
             { "actor_token", "actor-token-value" },
             { "actor_token_type", TokenType.AccessToken }
         };
@@ -154,7 +155,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             ActorToken = "actor-token-value",
             ActorTokenType = TokenType.AccessToken
         });
@@ -177,7 +178,7 @@ public class CustomTokenExchangeTests
         {
             { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
             { "subject_token", SubjectToken },
-            { "subject_token_type", TokenType.AccessToken },
+            { "subject_token_type", CteProfile },
             { "audience", "urn:test-tenant.auth0.com:session_transfer" }
         };
 
@@ -188,7 +189,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             Audience = "urn:test-tenant.auth0.com:session_transfer"
         });
 
@@ -198,7 +199,7 @@ public class CustomTokenExchangeTests
     }
 
     [Fact]
-    public async Task Sends_optional_reason_and_organization()
+    public async Task Sends_optional_organization()
     {
         var response = new AccessTokenResponse
         {
@@ -211,8 +212,7 @@ public class CustomTokenExchangeTests
         {
             { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
             { "subject_token", SubjectToken },
-            { "subject_token_type", TokenType.AccessToken },
-            { "reason", "support-impersonation" },
+            { "subject_token_type", CteProfile },
             { "organization", "org_abc123" }
         };
 
@@ -223,8 +223,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
-            Reason = "support-impersonation",
+            SubjectTokenType = CteProfile,
             Organization = "org_abc123"
         });
 
@@ -246,7 +245,7 @@ public class CustomTokenExchangeTests
         {
             { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
             { "subject_token", SubjectToken },
-            { "subject_token_type", TokenType.AccessToken },
+            { "subject_token_type", CteProfile },
             { "scope", "read:data write:data" }
         };
 
@@ -257,7 +256,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             Scope = "read:data write:data"
         });
 
@@ -281,7 +280,7 @@ public class CustomTokenExchangeTests
             { "client_id", ClientId },
             { "client_secret", ClientSecret },
             { "subject_token", SubjectToken },
-            { "subject_token_type", TokenType.AccessToken }
+            { "subject_token_type", CteProfile }
         };
 
         var client = CreateClient(response, expectedParams);
@@ -291,7 +290,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken
+            SubjectTokenType = CteProfile
         });
 
         result.Should().NotBeNull();
@@ -336,7 +335,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken
+            SubjectTokenType = CteProfile
         });
 
         capturedBody.Should().NotContain("actor_token");
@@ -344,6 +343,40 @@ public class CustomTokenExchangeTests
         capturedBody.Should().NotContain("scope");
         capturedBody.Should().NotContain("reason");
         capturedBody.Should().NotContain("organization");
+    }
+
+    [Fact]
+    public async Task Throws_when_subject_token_is_missing()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectTokenType = CteProfile
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Throws_when_subject_token_type_is_missing()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>();
     }
 
     [Fact]
@@ -358,7 +391,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             ActorToken = "actor-only"
         });
 
@@ -377,7 +410,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             ActorTokenType = TokenType.AccessToken
         });
 
@@ -412,7 +445,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = ClientSecret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken
+            SubjectTokenType = CteProfile
         });
 
         await act.Should().ThrowAsync<ErrorApiException>();
@@ -430,7 +463,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = secret,
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             SigningAlgorithm = JwtSignatureAlgorithm.HS256
         });
 
@@ -450,7 +483,7 @@ public class CustomTokenExchangeTests
             ClientId = ClientId,
             ClientSecret = Guid.NewGuid().ToString("N"),
             SubjectToken = SubjectToken,
-            SubjectTokenType = TokenType.AccessToken,
+            SubjectTokenType = CteProfile,
             SigningAlgorithm = JwtSignatureAlgorithm.HS256
         });
 

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/CustomTokenExchangeTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/CustomTokenExchangeTests.cs
@@ -1,0 +1,498 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Auth0.AuthenticationApi.Models;
+using Auth0.AuthenticationApi.Tokens;
+using Auth0.Core.Exceptions;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Microsoft.IdentityModel.Tokens;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests;
+
+public class CustomTokenExchangeTests
+{
+    private const string Domain = "test-tenant.auth0.com";
+    private const string ClientId = "test-client-id";
+    private const string ClientSecret = "test-client-secret";
+    private const string SubjectToken = "test-subject-token";
+
+    private static AuthenticationApiClient CreateClient(
+        AccessTokenResponse response,
+        Dictionary<string, string> expectedParams)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"
+                    && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response, response.GetType()),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        return new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+    }
+
+    private static bool ValidateRequestContent(HttpRequestMessage content, Dictionary<string, string> contentParams)
+    {
+        string body = content.Content.ReadAsStringAsync().Result;
+        var result = body.Split("&")
+            .ToDictionary(kv => kv.Split("=")[0], kv => HttpUtility.UrlDecode(kv.Split("=")[1]));
+        return contentParams.Aggregate(true, (acc, kv) => acc && result.GetValueOrDefault(kv.Key) == kv.Value);
+    }
+
+    [Fact]
+    public async Task Can_exchange_subject_token_for_access_token()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "exchanged-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            IssuedTokenType = TokenType.AccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "subject_token", SubjectToken },
+            { "subject_token_type", TokenType.AccessToken }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("exchanged-access-token");
+        result.IssuedTokenType.Should().Be(TokenType.AccessToken);
+    }
+
+    [Fact]
+    public void TokenType_constants_have_expected_urn_values()
+    {
+        TokenType.IdToken.Should().Be("urn:ietf:params:oauth:token-type:id_token");
+        TokenType.AccessToken.Should().Be("urn:ietf:params:oauth:token-type:access_token");
+        TokenType.Jwt.Should().Be("urn:ietf:params:oauth:token-type:jwt");
+        TokenType.SessionTransferToken.Should().Be("urn:auth0:params:oauth:token-type:session_transfer_token");
+    }
+
+    [Fact]
+    public void IssuedTokenType_deserializes_from_response()
+    {
+        var json = "{\"access_token\":\"at\",\"token_type\":\"Bearer\",\"issued_token_type\":\"urn:ietf:params:oauth:token-type:access_token\"}";
+
+        var response = JsonSerializer.Deserialize<AccessTokenResponse>(json);
+
+        response.IssuedTokenType.Should().Be("urn:ietf:params:oauth:token-type:access_token");
+    }
+
+    [Fact]
+    public void TokenExchangeTokenRequest_implements_IClientAuthentication()
+    {
+        var request = new TokenExchangeTokenRequest
+        {
+            SubjectToken = "st",
+            SubjectTokenType = TokenType.AccessToken,
+            ClientId = "cid"
+        };
+
+        request.Should().BeAssignableTo<IClientAuthentication>();
+        request.SubjectTokenType.Should().Be("urn:ietf:params:oauth:token-type:access_token");
+    }
+
+    [Fact]
+    public async Task Can_exchange_with_actor_token()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "delegated-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            IssuedTokenType = TokenType.AccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "subject_token", SubjectToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "actor_token", "actor-token-value" },
+            { "actor_token_type", TokenType.AccessToken }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            ActorToken = "actor-token-value",
+            ActorTokenType = TokenType.AccessToken
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("delegated-token");
+    }
+
+    [Fact]
+    public async Task Can_request_session_transfer_token()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "session-transfer-token-value",
+            TokenType = "Bearer",
+            ExpiresIn = 60,
+            IssuedTokenType = TokenType.SessionTransferToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "subject_token", SubjectToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "audience", "urn:test-tenant.auth0.com:session_transfer" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Audience = "urn:test-tenant.auth0.com:session_transfer"
+        });
+
+        result.Should().NotBeNull();
+        result.IssuedTokenType.Should().Be(TokenType.SessionTransferToken);
+        result.AccessToken.Should().Be("session-transfer-token-value");
+    }
+
+    [Fact]
+    public async Task Sends_optional_reason_and_organization()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "at",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            IssuedTokenType = TokenType.AccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "subject_token", SubjectToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "reason", "support-impersonation" },
+            { "organization", "org_abc123" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Reason = "support-impersonation",
+            Organization = "org_abc123"
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("at");
+    }
+
+    [Fact]
+    public async Task Sends_scope_when_set()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "at",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            IssuedTokenType = TokenType.AccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "subject_token", SubjectToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "scope", "read:data write:data" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Scope = "read:data write:data"
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("at");
+    }
+
+    [Fact]
+    public async Task Sends_client_secret_in_request_body()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "at",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            IssuedTokenType = TokenType.AccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "client_id", ClientId },
+            { "client_secret", ClientSecret },
+            { "subject_token", SubjectToken },
+            { "subject_token_type", TokenType.AccessToken }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken
+        });
+
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Omits_optional_params_when_unset()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "at",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            IssuedTokenType = TokenType.AccessToken
+        };
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        string capturedBody = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                capturedBody = req.Content.ReadAsStringAsync().Result)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken
+        });
+
+        capturedBody.Should().NotContain("actor_token");
+        capturedBody.Should().NotContain("audience");
+        capturedBody.Should().NotContain("scope");
+        capturedBody.Should().NotContain("reason");
+        capturedBody.Should().NotContain("organization");
+    }
+
+    [Fact]
+    public async Task Throws_when_only_actor_token_set()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            ActorToken = "actor-only"
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Throws_when_only_actor_token_type_set()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            ActorTokenType = TokenType.AccessToken
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Surfaces_server_error()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(
+                    "{\"error\":\"invalid_request\",\"error_description\":\"setActor is required\"}",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken
+        });
+
+        await act.Should().ThrowAsync<ErrorApiException>();
+    }
+
+    [Fact]
+    public async Task Validates_returned_id_token()
+    {
+        var secret = Guid.NewGuid().ToString("N");
+        var idToken = GenerateHs256Token(secret);
+        var client = CreateClientReturningIdToken(idToken);
+
+        var result = await client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = secret,
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256
+        });
+
+        result.Should().NotBeNull();
+        result.IdToken.Should().Be(idToken);
+    }
+
+    [Fact]
+    public async Task Throws_when_returned_id_token_is_forged()
+    {
+        // Server response is tampered with an id_token signed by a different secret.
+        var forgedToken = GenerateHs256Token(Guid.NewGuid().ToString("N"));
+        var client = CreateClientReturningIdToken(forgedToken);
+
+        Func<Task> act = () => client.GetTokenAsync(new TokenExchangeTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = Guid.NewGuid().ToString("N"),
+            SubjectToken = SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            SigningAlgorithm = JwtSignatureAlgorithm.HS256
+        });
+
+        await act.Should().ThrowAsync<IdTokenValidationException>();
+    }
+
+    private static string GenerateHs256Token(string clientSecret)
+    {
+        var key = new SymmetricSecurityKey(Encoding.ASCII.GetBytes(clientSecret));
+        var factory = new JwtTokenFactory(key, SecurityAlgorithms.HmacSha256);
+        return factory.GenerateToken($"https://{Domain}/", ClientId, "auth0|test-user");
+    }
+
+    private static AuthenticationApiClient CreateClientReturningIdToken(string idToken)
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "exchanged-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 86400,
+            IssuedTokenType = TokenType.AccessToken,
+            IdToken = idToken
+        };
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        return new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+    }
+}


### PR DESCRIPTION
### Changes

Adds raw support for **Custom Token Exchange (CTE)** — the OAuth 2.0 Token Exchange grant (RFC 8693) — to the `Auth0.AuthenticationApi` package. A single new grant covers both documented CTE use cases, since they are the same wire call with different inputs:

- **Access token exchange:** exchange a `subject_token` for a normal access token, optionally carrying an `act` (actor) claim.
- **Session Transfer Token (STT):** the same call with `Audience` set to the session-transfer audience and an actor supplied; the response is a Session Transfer Token.

`auth0.net` is a thin, low-level HTTP client, so this adds exactly one grant and no stateful/session/redirect machinery.

**Classes and methods added/changed:**

- **New** `Auth0.AuthenticationApi.Models.TokenExchangeTokenRequest` — request model implementing `IClientAuthentication`. Properties: `SubjectToken`, `SubjectTokenType`, `ActorToken`, `ActorTokenType`, `Audience`, `Scope`, `Reason`, `Organization`, `Nonce`, plus the standard client-auth members.
- **New** `Auth0.AuthenticationApi.Models.TokenType` — static class of well-known token-type URN string constants (`IdToken`, `AccessToken`, `Jwt`, `SessionTransferToken`). Properties stay `string` so callers can also pass custom/future URNs.
- **New** `AuthenticationApiClient.GetTokenAsync(TokenExchangeTokenRequest, CancellationToken)` and the matching `IAuthenticationApiClient` interface method. Builds the `token-exchange` grant body, applies client authentication, and validates the ID token when one is returned (`AssertIdTokenValidIfExisting`). 
- **Changed** `AccessTokenResponse` — added `IssuedTokenType` (`issued_token_type`), the response field indicating which kind of token was issued. `null` for flows that don't return it.

**Usage:**

```csharp
// exchange a subject token for an access token
var tokenResponse = await auth.GetTokenAsync(new TokenExchangeTokenRequest
{
    ClientId = "YOUR_CLIENT_ID",
    ClientSecret = "YOUR_CLIENT_SECRET",
    SubjectToken = "THE_TOKEN_TO_EXCHANGE",
    SubjectTokenType = TokenType.AccessToken,
    Audience = "https://api.example.com",   // optional
    Scope = "read:data"                      // optional
});
Console.WriteLine(tokenResponse.IssuedTokenType);

// Request a Session Transfer Token
var stt = await auth.GetTokenAsync(new TokenExchangeTokenRequest
{
    ClientId = "YOUR_CLIENT_ID",
    ClientSecret = "YOUR_CLIENT_SECRET",
    SubjectToken = "THE_SUBJECT_TOKEN",
    SubjectTokenType = TokenType.AccessToken,
    ActorToken = "THE_ACTOR_TOKEN",
    ActorTokenType = TokenType.AccessToken,
    Audience = "urn:YOUR_AUTH0_DOMAIN:session_transfer",
    Reason = "support-impersonation"
});
```

An `Examples.md` section ("6. Custom Token Exchange (CTE)") documents both scenarios.

### Testing

- [x] This change adds unit test coverage

- [x] This change adds integration test coverage

- [x] This change has been tested on the latest version of the platform/language or why not — verified via mocked-handler integration tests; not exercised against a live Auth0 tenant

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [x] All existing and new tests complete without errors
