### PR TITLE
feat: Adds Token Vault support

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -19,6 +19,7 @@
   - [4.2. Client Initiated Backchannel Authorization (CIBA) with authorization details](#42-client-initiated-backchannel-authorization-ciba-with-authorization-details)
 - [5. Multi-Resource Refresh Token (MRRT)](#5-multi-resource-refresh-token-mrrt)
 - [6. Custom Token Exchange (CTE)](#6-custom-token-exchange-cte)
+- [7. Token Vault (Federated Connection Access Token)](#7-token-vault-federated-connection-access-token)
 
 ## 1. Client Initialization
 
@@ -356,6 +357,36 @@ if (sttResponse.IssuedTokenType == TokenType.SessionTransferToken)
 
 > `ActorToken` and `ActorTokenType` are both-or-neither — supplying only one throws
 > `ArgumentException` before any network call.
+
+[Go to Top](#)
+
+## 7. Token Vault (Federated Connection Access Token)
+
+Token Vault lets you exchange an Auth0 Access Token / Refresh Token for an access token issued by one of
+your federated connections (Google, Facebook, etc.), so your app can call that provider's
+APIs on the user's behalf. The client must be a private client.
+
+```csharp
+using Auth0.AuthenticationApi;
+using Auth0.AuthenticationApi.Models;
+
+var auth = new AuthenticationApiClient("YOUR_AUTH0_DOMAIN");
+
+var tokenResponse = await auth.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+{
+    ClientId = "YOUR_CLIENT_ID",
+    ClientSecret = "YOUR_CLIENT_SECRET",
+    SubjectToken = "THE_AUTH0_ACCESS_TOKEN",
+    SubjectTokenType = TokenType.AccessToken,
+    Connection = "google-oauth2",
+    LoginHint = "THE_GOOGLE_USER_ID"          // optional
+});
+
+Console.WriteLine($"Federated Access Token: {tokenResponse.AccessToken}");
+```
+
+> `Connection` is required — omitting it throws `ArgumentException` before any network
+> call. `requested_token_type` is fixed to the federated-connection URN and set for you.
 
 [Go to Top](#)
 

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -275,6 +275,16 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     {
         request.ThrowIfNull();
 
+        if (string.IsNullOrEmpty(request.SubjectToken))
+            throw new ArgumentException(
+                "SubjectToken is required for a federated connection access token exchange.",
+                nameof(request.SubjectToken));
+
+        if (string.IsNullOrEmpty(request.SubjectTokenType))
+            throw new ArgumentException(
+                "SubjectTokenType is required for a federated connection access token exchange.",
+                nameof(request.SubjectTokenType));
+
         if (string.IsNullOrEmpty(request.Connection))
             throw new ArgumentException(
                 "Connection is required for a federated connection access token exchange.",

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -271,6 +271,41 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     }
 
     /// <inheritdoc/>
+    public async Task<AccessTokenResponse> GetTokenAsync(FederatedConnectionAccessTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        request.ThrowIfNull();
+
+        if (string.IsNullOrEmpty(request.Connection))
+            throw new ArgumentException(
+                "Connection is required for a federated connection access token exchange.",
+                nameof(request.Connection));
+
+        var body = new Dictionary<string, string> {
+            { "grant_type", "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token" },
+            { "client_id", request.ClientId },
+            { "subject_token", request.SubjectToken },
+            { "subject_token_type", request.SubjectTokenType },
+            { "requested_token_type", TokenType.FederatedConnectionAccessToken },
+            { "connection", request.Connection }
+        };
+
+        ApplyClientAuthentication(request, body);
+
+        body.AddIfNotEmpty("login_hint", request.LoginHint);
+
+        var response = await connection.SendAsync<AccessTokenResponse>(
+            HttpMethod.Post,
+            tokenUri,
+            body,
+            cancellationToken: cancellationToken
+        ).ConfigureAwait(false);
+
+        await AssertIdTokenValidIfExisting(response.IdToken, request.ClientId, request.SigningAlgorithm, request.ClientSecret, null, request.Nonce).ConfigureAwait(false);
+
+        return response;
+    }
+
+    /// <inheritdoc/>
     public async Task<AccessTokenResponse> GetTokenAsync(ResourceOwnerTokenRequest request, CancellationToken cancellationToken = default)
     {
         request.ThrowIfNull();

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -99,6 +99,17 @@ public interface IAuthenticationApiClient : IDisposable
     Task<AccessTokenResponse> GetTokenAsync(TokenExchangeTokenRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Exchanges an Auth0 token for an access token issued by a federated connection
+    /// (Token Vault), using the Auth0 federated-connection-access-token grant.
+    /// </summary>
+    /// <param name="request"><see cref="FederatedConnectionAccessTokenRequest"/> containing the subject token, connection, and associated parameters.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns><see cref="Task"/> representing the async operation containing
+    /// a <see cref="AccessTokenResponse" />. The federated connection access token is
+    /// returned in <see cref="TokenBase.AccessToken"/>.</returns>
+    Task<AccessTokenResponse> GetTokenAsync(FederatedConnectionAccessTokenRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Performs authentication by providing user-supplied information in a <see cref="ResourceOwnerTokenRequest"/>.
     /// </summary>
     /// <param name="request"><see cref="ResourceOwnerTokenRequest"/> containing information regarding the username, password etc.</param>

--- a/src/Auth0.AuthenticationApi/Models/FederatedConnectionAccessTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/FederatedConnectionAccessTokenRequest.cs
@@ -1,0 +1,74 @@
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AuthenticationApi.Models;
+
+/// <summary>
+/// Represents a request to exchange an Auth0 token for an access token issued by one of
+/// Auth0's federated connections (Token Vault), using the Auth0 token-exchange grant
+/// <c>urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token</c>.
+/// </summary>
+/// <remarks>
+/// The client must be a private client. Today the subject token must be an Auth0 refresh
+/// token (<see cref="TokenType.RefreshToken"/>); support for access-token subjects is
+/// planned by Auth0.
+/// </remarks>
+public class FederatedConnectionAccessTokenRequest : IClientAuthentication
+{
+    /// <summary>
+    /// The Auth0 token being exchanged. Currently this must be a valid Auth0 refresh token.
+    /// Required.
+    /// </summary>
+    public string SubjectToken { get; set; }
+
+    /// <summary>
+    /// An identifier that indicates the type of <see cref="SubjectToken"/>, as a URN.
+    /// Currently only <see cref="TokenType.RefreshToken"/> is accepted. Required.
+    /// </summary>
+    public string SubjectTokenType { get; set; }
+
+    /// <summary>
+    /// The federated connection to obtain the access token for (for example
+    /// <c>google-oauth2</c>). Required.
+    /// </summary>
+    public string Connection { get; set; }
+
+    /// <summary>
+    /// Optional user ID of the current user within the IdP named by <see cref="Connection"/>.
+    /// For example, if the connection is <c>google-oauth2</c>, this is the Google user ID.
+    /// </summary>
+    public string LoginHint { get; set; }
+
+    /// <summary>
+    /// Client ID of the application.
+    /// </summary>
+    public string ClientId { get; set; }
+
+    /// <summary>
+    /// Client Secret of the application.
+    /// </summary>
+    public string ClientSecret { get; set; }
+
+    /// <summary>
+    /// Security Key to use with Client Assertion.
+    /// </summary>
+    public SecurityKey ClientAssertionSecurityKey { get; set; }
+
+    /// <summary>
+    /// Algorithm for the Security Key to use with Client Assertion.
+    /// </summary>
+    public string ClientAssertionSecurityKeyAlgorithm { get; set; }
+
+    /// <summary>
+    /// What <see cref="JwtSignatureAlgorithm"/> is used to verify the signature of Id Tokens.
+    /// </summary>
+    public JwtSignatureAlgorithm SigningAlgorithm { get; set; }
+
+    /// <summary>
+    /// Optional nonce to validate against the nonce claim in a returned ID token.
+    /// </summary>
+    /// <remarks>
+    /// When set, the nonce claim in the returned ID token must exactly match this value.
+    /// Leave null (the default) to skip nonce validation.
+    /// </remarks>
+    public string? Nonce { get; set; }
+}

--- a/src/Auth0.AuthenticationApi/Models/FederatedConnectionAccessTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/FederatedConnectionAccessTokenRequest.cs
@@ -8,21 +8,20 @@ namespace Auth0.AuthenticationApi.Models;
 /// <c>urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token</c>.
 /// </summary>
 /// <remarks>
-/// The client must be a private client. Today the subject token must be an Auth0 refresh
-/// token (<see cref="TokenType.RefreshToken"/>); support for access-token subjects is
-/// planned by Auth0.
+/// The client must be a private client. The subject token may be an Auth0 access token
+/// (<see cref="TokenType.AccessToken"/>) or refresh token (<see cref="TokenType.RefreshToken"/>).
 /// </remarks>
 public class FederatedConnectionAccessTokenRequest : IClientAuthentication
 {
     /// <summary>
-    /// The Auth0 token being exchanged. Currently this must be a valid Auth0 refresh token.
+    /// The Auth0 token being exchanged. This may be a valid Auth0 access token or refresh token.
     /// Required.
     /// </summary>
     public string SubjectToken { get; set; }
 
     /// <summary>
     /// An identifier that indicates the type of <see cref="SubjectToken"/>, as a URN.
-    /// Currently only <see cref="TokenType.RefreshToken"/> is accepted. Required.
+    /// Either <see cref="TokenType.AccessToken"/> or <see cref="TokenType.RefreshToken"/>. Required.
     /// </summary>
     public string SubjectTokenType { get; set; }
 

--- a/src/Auth0.AuthenticationApi/Models/TokenType.cs
+++ b/src/Auth0.AuthenticationApi/Models/TokenType.cs
@@ -30,4 +30,14 @@ public static class TokenType
     /// Indicates that the token is an Auth0 Session Transfer Token: <c>urn:auth0:params:oauth:token-type:session_transfer_token</c>.
     /// </summary>
     public const string SessionTransferToken = "urn:auth0:params:oauth:token-type:session_transfer_token";
+
+    /// <summary>
+    /// Indicates that the token is an OAuth 2.0 refresh token: <c>urn:ietf:params:oauth:token-type:refresh_token</c>.
+    /// </summary>
+    public const string RefreshToken = "urn:ietf:params:oauth:token-type:refresh_token";
+
+    /// <summary>
+    /// Indicates that the token is an Auth0 federated connection access token: <c>http://auth0.com/oauth/token-type/federated-connection-access-token</c>.
+    /// </summary>
+    public const string FederatedConnectionAccessToken = "http://auth0.com/oauth/token-type/federated-connection-access-token";
 }

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TokenVaultTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TokenVaultTests.cs
@@ -123,6 +123,42 @@ public class TokenVaultTests
     }
 
     [Fact]
+    public async Task Can_exchange_refresh_token_for_federated_connection_access_token()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "federated-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            IssuedTokenType = TokenType.FederatedConnectionAccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", GrantType },
+            { "client_id", ClientId },
+            { "subject_token", "test-refresh-token" },
+            { "subject_token_type", TokenType.RefreshToken },
+            { "requested_token_type", TokenType.FederatedConnectionAccessToken },
+            { "connection", Connection }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = "test-refresh-token",
+            SubjectTokenType = TokenType.RefreshToken,
+            Connection = Connection
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("federated-access-token");
+        result.IssuedTokenType.Should().Be(TokenType.FederatedConnectionAccessToken);
+    }
+
+    [Fact]
     public async Task Sends_login_hint_when_set()
     {
         var response = new AccessTokenResponse
@@ -265,6 +301,42 @@ public class TokenVaultTests
             ClientSecret = ClientSecret,
             SubjectToken = AccessToken,
             SubjectTokenType = TokenType.AccessToken
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Throws_when_subject_token_is_missing()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Throws_when_subject_token_type_is_missing()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            Connection = Connection
         });
 
         await act.Should().ThrowAsync<ArgumentException>();

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/TokenVaultTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/TokenVaultTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Auth0.AuthenticationApi.Models;
+using Auth0.Core.Exceptions;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests;
+
+public class TokenVaultTests
+{
+    private const string Domain = "test-tenant.auth0.com";
+    private const string ClientId = "test-client-id";
+    private const string ClientSecret = "test-client-secret";
+    private const string AccessToken = "test-access-token";
+    private const string Connection = "google-oauth2";
+    private const string GrantType = "urn:auth0:params:oauth:grant-type:token-exchange:federated-connection-access-token";
+
+    private static AuthenticationApiClient CreateClient(
+        AccessTokenResponse response,
+        Dictionary<string, string> expectedParams)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"
+                    && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response, response.GetType()),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        return new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+    }
+
+    private static bool ValidateRequestContent(HttpRequestMessage content, Dictionary<string, string> contentParams)
+    {
+        string body = content.Content.ReadAsStringAsync().Result;
+        var result = body.Split("&")
+            .ToDictionary(kv => kv.Split("=")[0], kv => HttpUtility.UrlDecode(kv.Split("=")[1]));
+        return contentParams.Aggregate(true, (acc, kv) => acc && result.GetValueOrDefault(kv.Key) == kv.Value);
+    }
+
+    [Fact]
+    public void TokenType_constants_have_expected_token_vault_values()
+    {
+        TokenType.RefreshToken.Should().Be("urn:ietf:params:oauth:token-type:refresh_token");
+        TokenType.AccessToken.Should().Be("urn:ietf:params:oauth:token-type:access_token");
+        TokenType.FederatedConnectionAccessToken.Should().Be("http://auth0.com/oauth/token-type/federated-connection-access-token");
+    }
+
+    [Fact]
+    public void FederatedConnectionAccessTokenRequest_implements_IClientAuthentication()
+    {
+        var request = new FederatedConnectionAccessTokenRequest
+        {
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection,
+            ClientId = ClientId
+        };
+
+        request.Should().BeAssignableTo<IClientAuthentication>();
+        request.SubjectTokenType.Should().Be("urn:ietf:params:oauth:token-type:access_token");
+        request.Connection.Should().Be(Connection);
+    }
+
+    [Fact]
+    public async Task Can_exchange_access_token_for_federated_connection_access_token()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "federated-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            IssuedTokenType = TokenType.FederatedConnectionAccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", GrantType },
+            { "client_id", ClientId },
+            { "subject_token", AccessToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "requested_token_type", TokenType.FederatedConnectionAccessToken },
+            { "connection", Connection }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("federated-access-token");
+        result.IssuedTokenType.Should().Be(TokenType.FederatedConnectionAccessToken);
+    }
+
+    [Fact]
+    public async Task Sends_login_hint_when_set()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "federated-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            IssuedTokenType = TokenType.FederatedConnectionAccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", GrantType },
+            { "subject_token", AccessToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "connection", Connection },
+            { "login_hint", "google-user-123" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection,
+            LoginHint = "google-user-123"
+        });
+
+        result.Should().NotBeNull();
+        result.AccessToken.Should().Be("federated-access-token");
+    }
+
+    [Fact]
+    public async Task Omits_login_hint_when_unset()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "federated-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            IssuedTokenType = TokenType.FederatedConnectionAccessToken
+        };
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        string capturedBody = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                capturedBody = req.Content.ReadAsStringAsync().Result)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        await client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection
+        });
+
+        capturedBody.Should().NotContain("login_hint");
+    }
+
+    [Fact]
+    public async Task Sends_requested_token_type_as_fixed_federated_urn()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "federated-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            IssuedTokenType = TokenType.FederatedConnectionAccessToken
+        };
+
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        string capturedBody = null;
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) =>
+                capturedBody = req.Content.ReadAsStringAsync().Result)
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        await client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection
+        });
+
+        capturedBody.Should().Contain("requested_token_type=");
+        var parsed = capturedBody.Split("&")
+            .ToDictionary(kv => kv.Split("=")[0], kv => HttpUtility.UrlDecode(kv.Split("=")[1]));
+        parsed["requested_token_type"].Should().Be("http://auth0.com/oauth/token-type/federated-connection-access-token");
+    }
+
+    [Fact]
+    public async Task Throws_when_connection_is_missing()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Applies_client_authentication()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "federated-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            IssuedTokenType = TokenType.FederatedConnectionAccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", GrantType },
+            { "client_id", ClientId },
+            { "client_secret", ClientSecret },
+            { "subject_token", AccessToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "connection", Connection }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection
+        });
+
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Surfaces_server_error()
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent(
+                    "{\"error\":\"invalid_request\",\"error_description\":\"connection is not enabled for token vault\"}",
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        var client = new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+
+        Func<Task> act = () => client.GetTokenAsync(new FederatedConnectionAccessTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = AccessToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Connection = Connection
+        });
+
+        await act.Should().ThrowAsync<ErrorApiException>();
+    }
+
+    [Fact]
+    public void Deserializes_issued_token_type()
+    {
+        var json = "{\"access_token\":\"fat\",\"token_type\":\"Bearer\",\"issued_token_type\":\"http://auth0.com/oauth/token-type/federated-connection-access-token\"}";
+
+        var response = JsonSerializer.Deserialize<AccessTokenResponse>(json);
+
+        response.IssuedTokenType.Should().Be("http://auth0.com/oauth/token-type/federated-connection-access-token");
+    }
+}


### PR DESCRIPTION
### Changes

Adds **Token Vault** support to the `Auth0.AuthenticationApi` package. Token Vault lets a private client exchange an Auth0 token for an access token issued by one of Auth0's *federated connections* (Google, Facebook, etc.), so the app can call that provider's APIs on the user's behalf. 

**Classes/methods added:**

- **New model** `FederatedConnectionAccessTokenRequest` (implements `IClientAuthentication`) — carries `SubjectToken`, `SubjectTokenType`, `Connection` (required), optional `LoginHint`, `Nonce`, and the standard client-auth members (`ClientId`, `ClientSecret`, `ClientAssertionSecurityKey`, `ClientAssertionSecurityKeyAlgorithm`, `SigningAlgorithm`).
- **New overload** `Task<AccessTokenResponse> GetTokenAsync(FederatedConnectionAccessTokenRequest request, CancellationToken)` on `IAuthenticationApiClient` / `AuthenticationApiClient`. Builds the request body, applies client authentication, hardcodes `requested_token_type`, POSTs to `/oauth/token`, and reuses the existing `AccessTokenResponse` (the federated token is returned in `AccessToken`; `issued_token_type` is surfaced via `IssuedTokenType`).
- **New `TokenType` constants**: `RefreshToken` (`urn:ietf:params:oauth:token-type:refresh_token`) and `FederatedConnectionAccessToken` (`http://auth0.com/oauth/token-type/federated-connection-access-token`).

**Usage:**

```csharp
var auth = new AuthenticationApiClient("YOUR_AUTH0_DOMAIN");

var tokenResponse = await auth.GetTokenAsync(new FederatedConnectionAccessTokenRequest
{
    ClientId = "YOUR_CLIENT_ID",
    ClientSecret = "YOUR_CLIENT_SECRET",
    SubjectToken = "THE_AUTH0_ACCESS_TOKEN",
    SubjectTokenType = TokenType.AccessToken,
    Connection = "google-oauth2",
    LoginHint = "THE_GOOGLE_USER_ID"   // optional
});

Console.WriteLine($"Federated Access Token: {tokenResponse.AccessToken}");
```

### References

- Auth0 docs: [Access token exchange with Token Vault](https://auth0.com/docs/secure/call-apis-on-users-behalf/token-vault/access-token-exchange-with-token-vault)

### Testing

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
