### PR TITLE
fix: omit subseconds from redelivery dates

### DIFF
--- a/src/Auth0.ManagementApi/EventStreams/Redeliveries/Requests/CreateEventStreamRedeliveryRequestContent.cs
+++ b/src/Auth0.ManagementApi/EventStreams/Redeliveries/Requests/CreateEventStreamRedeliveryRequestContent.cs
@@ -1,5 +1,7 @@
 using Auth0.ManagementApi;
 using Auth0.ManagementApi.Core;
+using global::System.Globalization;
+using global::System.Text.Json;
 using global::System.Text.Json.Serialization;
 
 namespace Auth0.ManagementApi.EventStreams;
@@ -12,6 +14,7 @@ public record CreateEventStreamRedeliveryRequestContent
     /// </summary>
     [Optional]
     [JsonPropertyName("date_from")]
+    [JsonConverter(typeof(RedeliveryDateTimeSerializer))]
     public DateTime? DateFrom { get; set; }
 
     /// <summary>
@@ -19,6 +22,7 @@ public record CreateEventStreamRedeliveryRequestContent
     /// </summary>
     [Optional]
     [JsonPropertyName("date_to")]
+    [JsonConverter(typeof(RedeliveryDateTimeSerializer))]
     public DateTime? DateTo { get; set; }
 
     /// <summary>
@@ -39,5 +43,22 @@ public record CreateEventStreamRedeliveryRequestContent
     public override string ToString()
     {
         return JsonUtils.Serialize(this);
+    }
+
+    private class RedeliveryDateTimeSerializer : JsonConverter<DateTime>
+    {
+        public override DateTime Read(
+            ref Utf8JsonReader reader,
+            global::System.Type typeToConvert,
+            JsonSerializerOptions options
+        )
+        {
+            return DateTime.Parse(reader.GetString()!, null, DateTimeStyles.RoundtripKind);
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssK"));
+        }
     }
 }

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Redeliveries/CreateTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Redeliveries/CreateTest.cs
@@ -13,7 +13,10 @@ public class CreateTest : BaseMockServerTest
     public async Task MockServerTest()
     {
         const string requestJson = """
-            {}
+            {
+              "date_from": "2024-01-15T09:30:00Z",
+              "date_to": "2024-01-15T10:30:00Z"
+            }
             """;
 
         const string mockResponse = """
@@ -47,7 +50,11 @@ public class CreateTest : BaseMockServerTest
 
         var response = await Client.EventStreams.Redeliveries.CreateAsync(
             "id",
-            new CreateEventStreamRedeliveryRequestContent()
+            new CreateEventStreamRedeliveryRequestContent
+            {
+                DateFrom = new DateTime(2024, 1, 15, 9, 30, 0, 123, DateTimeKind.Utc),
+                DateTo = new DateTime(2024, 1, 15, 10, 30, 0, 456, DateTimeKind.Utc),
+            }
         );
         JsonAssert.AreEqual(response, mockResponse);
     }


### PR DESCRIPTION
# fix: omit subseconds from redelivery dates

## Summary

`Redeliveries.CreateAsync` serialized `date_from` and `date_to` with milliseconds, although the endpoint accepts RFC 3339 values only to whole-second precision. This change applies a request-specific serializer that omits fractional seconds while preserving the `DateTime` offset/kind. The behavior is covered through the redelivery mock-server request assertion.

Fixes #1067

## Changes

- Serialize `CreateEventStreamRedeliveryRequestContent.DateFrom` and `DateTo` without sub-second precision.
- Extend the redelivery creation test with millisecond-bearing inputs and the expected whole-second JSON payload.

## Testing

- `git diff --check` completed successfully.
- `sandbox-run "dotnet test tests/Auth0.ManagementApi.Test/Auth0.ManagementApi.Test.csproj --no-restore"` could not run because the sandbox image does not include `dotnet` (`dotnet: command not found`).
- `sandbox-run "dotnet test tests/Auth0.ManagementApi.Test/Auth0.ManagementApi.Test.csproj"` also could not run for the same reason.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
