### PR TITLE
fix: Fixes redelivery datetime precision

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -57,6 +57,10 @@ tests/Auth0.ManagementApi.Test/Core/CustomDomainInterceptorTest.cs
 tests/Auth0.ManagementApi.Test/Unit/MockServer/CustomDomainHeaderTest.cs
 src/Auth0.ManagementApi/Core/BooleanStringConverter.cs
 tests/Auth0.ManagementApi.Test/Unit/BooleanStringConverterTest.cs
+
+src/Auth0.ManagementApi/Core/Rfc3339SecondsDateTimeConverter.cs
+tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
+src/Auth0.ManagementApi/EventStreams/Redeliveries/Requests/CreateEventStreamRedeliveryRequestContent.cs
 src/Auth0.ManagementApi/Core/Public/ManagementApiException.cs
 src/Auth0.ManagementApi/Core/Public/ApiError.cs
 src/Auth0.ManagementApi/Core/Public/RateLimit.cs

--- a/.fernignore
+++ b/.fernignore
@@ -60,6 +60,7 @@ tests/Auth0.ManagementApi.Test/Unit/BooleanStringConverterTest.cs
 
 src/Auth0.ManagementApi/Core/Rfc3339SecondsDateTimeConverter.cs
 tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
+tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Redeliveries/RedeliveryDateSerializationTest.cs
 src/Auth0.ManagementApi/EventStreams/Redeliveries/Requests/CreateEventStreamRedeliveryRequestContent.cs
 src/Auth0.ManagementApi/Core/Public/ManagementApiException.cs
 src/Auth0.ManagementApi/Core/Public/ApiError.cs

--- a/src/Auth0.ManagementApi/Core/Rfc3339SecondsDateTimeConverter.cs
+++ b/src/Auth0.ManagementApi/Core/Rfc3339SecondsDateTimeConverter.cs
@@ -14,6 +14,17 @@ namespace Auth0.ManagementApi.Core;
 /// <c>maxLength: 20</c> and reject sub-second precision with an HTTP 400. Apply
 /// this converter to those fields to keep native <see cref="DateTime"/>
 /// ergonomics while emitting a spec-compliant 20-character value.
+///
+/// Timezone handling preserves the wall-clock value the caller provided:
+/// <list type="bullet">
+/// <item><description><see cref="DateTimeKind.Utc"/> — emitted as-is.</description></item>
+/// <item><description><see cref="DateTimeKind.Local"/> — converted to the
+/// equivalent UTC instant (the offset is applied).</description></item>
+/// <item><description><see cref="DateTimeKind.Unspecified"/> — treated as though
+/// it is already UTC (labeled <c>Z</c> without shifting the clock), so
+/// <c>new DateTime(2026, 7, 1)</c> serializes to "2026-07-01T00:00:00Z"
+/// regardless of the machine's local timezone.</description></item>
+/// </list>
 /// </summary>
 internal class Rfc3339SecondsDateTimeConverter : JsonConverter<DateTime>
 {
@@ -34,8 +45,15 @@ internal class Rfc3339SecondsDateTimeConverter : JsonConverter<DateTime>
 
     public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
     {
-        writer.WriteStringValue(
-            value.ToUniversalTime().ToString(Format, CultureInfo.InvariantCulture)
-        );
+        // Normalize to UTC before formatting. Unspecified values carry no zone,
+        // so treat them as UTC rather than let ToUniversalTime() assume local
+        // time and silently shift the instant.
+        var utc = value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+        writer.WriteStringValue(utc.ToString(Format, CultureInfo.InvariantCulture));
     }
 }

--- a/src/Auth0.ManagementApi/Core/Rfc3339SecondsDateTimeConverter.cs
+++ b/src/Auth0.ManagementApi/Core/Rfc3339SecondsDateTimeConverter.cs
@@ -1,0 +1,41 @@
+using global::System.Globalization;
+using global::System.Text.Json;
+using global::System.Text.Json.Serialization;
+
+namespace Auth0.ManagementApi.Core;
+
+/// <summary>
+/// Serializes <see cref="DateTime"/> values as RFC 3339 date-times with second
+/// precision (no sub-second component) in UTC, e.g. "2026-07-01T00:00:00Z".
+///
+/// The default <see cref="DateTimeSerializer"/> emits millisecond precision
+/// ("2026-07-01T00:00:00.000Z", 24 chars). Some Auth0 endpoints — such as the
+/// event-stream redelivery request (<c>date_from</c>/<c>date_to</c>) — declare
+/// <c>maxLength: 20</c> and reject sub-second precision with an HTTP 400. Apply
+/// this converter to those fields to keep native <see cref="DateTime"/>
+/// ergonomics while emitting a spec-compliant 20-character value.
+/// </summary>
+internal class Rfc3339SecondsDateTimeConverter : JsonConverter<DateTime>
+{
+    private const string Format = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'Z'";
+
+    public override DateTime Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    )
+    {
+        return DateTime.Parse(
+            reader.GetString()!,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind
+        );
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(
+            value.ToUniversalTime().ToString(Format, CultureInfo.InvariantCulture)
+        );
+    }
+}

--- a/src/Auth0.ManagementApi/EventStreams/Redeliveries/Requests/CreateEventStreamRedeliveryRequestContent.cs
+++ b/src/Auth0.ManagementApi/EventStreams/Redeliveries/Requests/CreateEventStreamRedeliveryRequestContent.cs
@@ -12,6 +12,7 @@ public record CreateEventStreamRedeliveryRequestContent
     /// </summary>
     [Optional]
     [JsonPropertyName("date_from")]
+    [JsonConverter(typeof(Rfc3339SecondsDateTimeConverter))]
     public DateTime? DateFrom { get; set; }
 
     /// <summary>
@@ -19,6 +20,7 @@ public record CreateEventStreamRedeliveryRequestContent
     /// </summary>
     [Optional]
     [JsonPropertyName("date_to")]
+    [JsonConverter(typeof(Rfc3339SecondsDateTimeConverter))]
     public DateTime? DateTo { get; set; }
 
     /// <summary>

--- a/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Redeliveries/RedeliveryDateSerializationTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/MockServer/EventStreams/Redeliveries/RedeliveryDateSerializationTest.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using System.Text.Json;
+using Auth0.ManagementApi.EventStreams;
+using Auth0.ManagementApi.Test.Unit.MockServer;
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Unit.MockServer.EventStreams.Redeliveries;
+
+// Hand-written (see .fernignore). Complements the generated CreateTest, which
+// only sends an empty body. This exercises Rfc3339SecondsDateTimeConverter end
+// to end through the real serializer + HTTP pipeline, asserting that
+// date_from/date_to go on the wire as spec-compliant, seconds-only RFC 3339
+// values (maxLength 20) — the fix for the redelivery HTTP 400.
+[TestFixture]
+[Parallelizable(ParallelScope.Self)]
+public class RedeliveryDateSerializationTest : BaseMockServerTest
+{
+    [NUnit.Framework.Test]
+    public async Task Serializes_DateFrom_DateTo_AsSecondsOnlyRfc3339()
+    {
+        Server
+            .Given(
+                WireMock
+                    .RequestBuilders.Request.Create()
+                    .WithPath("/event-streams/id/redeliver")
+                    .UsingPost()
+            )
+            .RespondWith(
+                WireMock.ResponseBuilders.Response.Create().WithStatusCode(200).WithBody("{}")
+            );
+
+        await Client.EventStreams.Redeliveries.CreateAsync(
+            "id",
+            new CreateEventStreamRedeliveryRequestContent
+            {
+                DateFrom = new DateTime(2024, 1, 15, 9, 30, 0, DateTimeKind.Utc),
+                DateTo = new DateTime(2024, 1, 15, 10, 15, 30, DateTimeKind.Utc),
+            }
+        );
+
+        // Inspect the request body the SDK actually put on the wire.
+        var body = Server.LogEntries.Single().RequestMessage.Body;
+        Assert.That(body, Is.Not.Null);
+
+        using var doc = JsonDocument.Parse(body!);
+        var dateFrom = doc.RootElement.GetProperty("date_from").GetString();
+        var dateTo = doc.RootElement.GetProperty("date_to").GetString();
+
+        Assert.That(dateFrom, Is.EqualTo("2024-01-15T09:30:00Z"));
+        Assert.That(dateFrom!.Length, Is.EqualTo(20));
+        Assert.That(dateTo, Is.EqualTo("2024-01-15T10:15:30Z"));
+        Assert.That(dateTo!.Length, Is.EqualTo(20));
+    }
+}

--- a/tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Auth0.ManagementApi.Core;
 using NUnit.Framework;
@@ -14,6 +15,12 @@ public class Rfc3339SecondsDateTimeConverterTest
         public DateTime? Date { get; set; }
     }
 
+    private static string SerializedDate(TestModel model)
+    {
+        using var doc = JsonDocument.Parse(JsonUtils.Serialize(model));
+        return doc.RootElement.GetProperty("date").GetString()!;
+    }
+
     [Test]
     public void Serialize_WholeSecondUtc_EmitsTwentyCharValue()
     {
@@ -21,8 +28,9 @@ public class Rfc3339SecondsDateTimeConverterTest
         {
             Date = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
         };
-        var json = JsonUtils.Serialize(model);
-        Assert.That(json, Does.Contain("\"date\":\"2026-07-01T00:00:00Z\""));
+        var value = SerializedDate(model);
+        Assert.That(value, Is.EqualTo("2026-07-01T00:00:00Z"));
+        Assert.That(value.Length, Is.EqualTo(20));
     }
 
     [Test]
@@ -32,8 +40,9 @@ public class Rfc3339SecondsDateTimeConverterTest
         {
             Date = new DateTime(2026, 7, 1, 0, 0, 0, 123, DateTimeKind.Utc),
         };
-        var json = JsonUtils.Serialize(model);
-        Assert.That(json, Does.Contain("\"date\":\"2026-07-01T00:00:00Z\""));
+        var value = SerializedDate(model);
+        Assert.That(value, Is.EqualTo("2026-07-01T00:00:00Z"));
+        Assert.That(value.Length, Is.EqualTo(20));
     }
 
     [Test]
@@ -50,9 +59,10 @@ public class Rfc3339SecondsDateTimeConverterTest
         ).DateTime;
         local = DateTime.SpecifyKind(local, DateTimeKind.Local);
         var model = new TestModel { Date = local };
-        var json = JsonUtils.Serialize(model);
-        Assert.That(json, Does.Contain("Z\""));
-        Assert.That(json, Does.Not.Contain("."));
+        var value = SerializedDate(model);
+        Assert.That(value, Does.EndWith("Z"));
+        Assert.That(value, Does.Not.Contain("."));
+        Assert.That(value.Length, Is.EqualTo(20));
     }
 
     [Test]

--- a/tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
@@ -1,0 +1,69 @@
+using System.Text.Json.Serialization;
+using Auth0.ManagementApi.Core;
+using NUnit.Framework;
+
+namespace Auth0.ManagementApi.Test.Unit;
+
+[TestFixture]
+public class Rfc3339SecondsDateTimeConverterTest
+{
+    private class TestModel
+    {
+        [JsonPropertyName("date")]
+        [JsonConverter(typeof(Rfc3339SecondsDateTimeConverter))]
+        public DateTime? Date { get; set; }
+    }
+
+    [Test]
+    public void Serialize_WholeSecondUtc_EmitsTwentyCharValue()
+    {
+        var model = new TestModel
+        {
+            Date = new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+        var json = JsonUtils.Serialize(model);
+        Assert.That(json, Does.Contain("\"date\":\"2026-07-01T00:00:00Z\""));
+    }
+
+    [Test]
+    public void Serialize_WithSubSecondPrecision_TruncatesToSeconds()
+    {
+        var model = new TestModel
+        {
+            Date = new DateTime(2026, 7, 1, 0, 0, 0, 123, DateTimeKind.Utc),
+        };
+        var json = JsonUtils.Serialize(model);
+        Assert.That(json, Does.Contain("\"date\":\"2026-07-01T00:00:00Z\""));
+    }
+
+    [Test]
+    public void Serialize_LocalTime_ConvertsToUtcZ()
+    {
+        var local = new DateTimeOffset(
+            2026,
+            7,
+            1,
+            2,
+            0,
+            0,
+            TimeSpan.FromHours(2)
+        ).DateTime;
+        local = DateTime.SpecifyKind(local, DateTimeKind.Local);
+        var model = new TestModel { Date = local };
+        var json = JsonUtils.Serialize(model);
+        Assert.That(json, Does.Contain("Z\""));
+        Assert.That(json, Does.Not.Contain("."));
+    }
+
+    [Test]
+    public void Roundtrip_Deserialize_ParsesBackToUtc()
+    {
+        var json = "{\"date\":\"2026-07-01T00:00:00Z\"}";
+        var model = JsonUtils.Deserialize<TestModel>(json);
+        Assert.That(model.Date, Is.Not.Null);
+        Assert.That(
+            model.Date!.Value.ToUniversalTime(),
+            Is.EqualTo(new DateTime(2026, 7, 1, 0, 0, 0, DateTimeKind.Utc))
+        );
+    }
+}

--- a/tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
+++ b/tests/Auth0.ManagementApi.Test/Unit/Rfc3339SecondsDateTimeConverterTest.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Auth0.ManagementApi.Core;
@@ -46,23 +47,37 @@ public class Rfc3339SecondsDateTimeConverterTest
     }
 
     [Test]
-    public void Serialize_LocalTime_ConvertsToUtcZ()
+    public void Serialize_UnspecifiedKind_LabeledUtcWithoutShifting()
     {
-        var local = new DateTimeOffset(
-            2026,
-            7,
-            1,
-            2,
-            0,
-            0,
-            TimeSpan.FromHours(2)
-        ).DateTime;
-        local = DateTime.SpecifyKind(local, DateTimeKind.Local);
+        // Kind == Unspecified is the default for `new DateTime(...)`. The wall
+        // clock must be preserved and simply labeled "Z" — never shifted by the
+        // host machine's UTC offset. This assertion is timezone-independent.
+        var model = new TestModel { Date = new DateTime(2026, 7, 1, 15, 30, 45) };
+        var value = SerializedDate(model);
+        Assert.That(value, Is.EqualTo("2026-07-01T15:30:45Z"));
+        Assert.That(value.Length, Is.EqualTo(20));
+    }
+
+    [Test]
+    public void Serialize_LocalTime_ConvertsToEquivalentUtcInstant()
+    {
+        // A Local-kind value must be shifted to its UTC equivalent before the
+        // "Z" is appended. Rather than hardcode an offset (which varies by host
+        // timezone), confirm the emitted value denotes the same instant.
+        var local = new DateTime(2026, 7, 1, 12, 30, 45, DateTimeKind.Local);
         var model = new TestModel { Date = local };
         var value = SerializedDate(model);
+
         Assert.That(value, Does.EndWith("Z"));
         Assert.That(value, Does.Not.Contain("."));
         Assert.That(value.Length, Is.EqualTo(20));
+
+        var parsed = DateTime.Parse(
+            value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.RoundtripKind
+        );
+        Assert.That(parsed.ToUniversalTime(), Is.EqualTo(local.ToUniversalTime()));
     }
 
     [Test]


### PR DESCRIPTION
### Changes

Fixes the `date_from` / `date_to` sub-second-precision bug on event-stream redelivery ([auth0/auth0.net#1067](https://github.com/auth0/auth0.net/issues/1067)).

Auth0's redelivery schema declares these fields as `{ "type": "string", "format": "date-time", "maxLength": 20 }`. `DateTimeSerializer` emits millisecond precision (`...00.000Z`, 24 chars), so `POST /event-streams/{id}/redeliver` returns **HTTP 400** and `Redeliveries.CreateAsync` is unusable.

**Fix:** a per-property `Rfc3339SecondsDateTimeConverter` applied to `CreateEventStreamRedeliveryRequestContent.DateFrom` / `.DateTo` only. It emits seconds-only RFC 3339 (20 chars) and preserves the caller's wall-clock value — `Utc` as-is, `Local` converted, `Unspecified` labeled `Z` without shifting (no shift matches current for `Unspecified`). The global `Constants.DateTimeFormat` is untouched, so no other endpoint changes. The converter, its tests, and the request-content file are in `.fernignore` to survive regeneration.

### Behavior

`DateFrom = <value>` → serialized `date_from` (host at UTC−4):

| Input | Old → result | New |
|---|---|---|
| `new DateTime(2026, 7, 1)` (Unspecified) | `2026-07-01T00:00:00.000` → **400** | `2026-07-01T00:00:00Z` |
| `…, DateTimeKind.Utc` | `2026-07-01T00:00:00.000Z` → **400** | `2026-07-01T00:00:00Z` |
| `…, DateTimeKind.Local` | `2026-07-01T00:00:00.000-04:00` → **400** | `2026-07-01T04:00:00Z` |

### Testing

- `Rfc3339SecondsDateTimeConverterTest` (unit) — serialization per `DateTimeKind`, sub-second truncation, round-trip.
- `RedeliveryDateSerializationTest` (WireMock) — asserts `date_from`/`date_to` on the wire through the real serializer + HTTP pipeline.

> Local: full `Auth0.ManagementApi.Test` suite → **Failed: 0, Passed: 748**. No GitHub Actions CI configured; no tenant creds for the live integration tier.

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage (WireMock, no live tenant)
- [ ] This change has been tested on the latest version of the platform/language — **no tenant creds**

### References

- GitHub issue: https://github.com/auth0/auth0.net/issues/1067

### Checklist

- [x] All existing and new tests complete without errors
