### PR TITLE
feat: Adds On-Behalf of Token Exchange support

### DIFF
--- a/Examples.md
+++ b/Examples.md
@@ -20,6 +20,7 @@
 - [5. Multi-Resource Refresh Token (MRRT)](#5-multi-resource-refresh-token-mrrt)
 - [6. Custom Token Exchange (CTE)](#6-custom-token-exchange-cte)
 - [7. Token Vault (Federated Connection Access Token)](#7-token-vault-federated-connection-access-token)
+- [8. On-Behalf-Of Token Exchange (OBO)](#8-on-behalf-of-token-exchange-obo)
 
 ## 1. Client Initialization
 
@@ -292,7 +293,7 @@ Console.WriteLine($"Access Token : {tokenResponse.AccessToken}");
 Console.WriteLine($"Granted Scope: {tokenResponse.Scope}");
 
 // The server may grant fewer scopes than requested, and returns them in no guaranteed
-// order — compare as sets rather than comparing the raw strings.
+// order - compare as sets rather than comparing the raw strings.
 var requested = requestedScope.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 var granted = (tokenResponse.Scope ?? string.Empty).Split(' ', StringSplitOptions.RemoveEmptyEntries);
 var missingScopes = requested.Except(granted).ToList();
@@ -310,7 +311,7 @@ Custom Token Exchange uses the OAuth 2.0 Token Exchange grant (RFC 8693) to exch
 existing token for a new Auth0-issued token. The same call supports two use cases,
 selected by the parameters you pass.
 
-### Phase 1 — exchange a subject token for an access token
+### Phase 1 - exchange a subject token for an access token
 
 ```csharp
 using Auth0.AuthenticationApi;
@@ -332,7 +333,7 @@ Console.WriteLine($"Access Token     : {tokenResponse.AccessToken}");
 Console.WriteLine($"Issued Token Type: {tokenResponse.IssuedTokenType}");
 ```
 
-### Phase 2 — request a Session Transfer Token
+### Phase 2 - request a Session Transfer Token
 
 Set `Audience` to your tenant's session-transfer audience and supply an actor token. The
 response's `IssuedTokenType` will be `TokenType.SessionTransferToken`.
@@ -355,7 +356,7 @@ if (sttResponse.IssuedTokenType == TokenType.SessionTransferToken)
 }
 ```
 
-> `ActorToken` and `ActorTokenType` are both-or-neither — supplying only one throws
+> `ActorToken` and `ActorTokenType` are both-or-neither - supplying only one throws
 > `ArgumentException` before any network call.
 
 [Go to Top](#)
@@ -385,8 +386,46 @@ var tokenResponse = await auth.GetTokenAsync(new FederatedConnectionAccessTokenR
 Console.WriteLine($"Federated Access Token: {tokenResponse.AccessToken}");
 ```
 
-> `Connection` is required — omitting it throws `ArgumentException` before any network
+> `Connection` is required - omitting it throws `ArgumentException` before any network
 > call. `requested_token_type` is fixed to the federated-connection URN and set for you.
+
+[Go to Top](#)
+
+## 8. On-Behalf-Of Token Exchange (OBO)
+
+Exchange an incoming user access token for a short-lived token scoped to a downstream API,
+then inspect the actor for audit logging. The current actor (`GetCurrentActor()`) is the
+only value to use for authorization decisions; the delegation chain is
+for audit/logging only. The exchanged token is **not** validated by this SDK - the
+downstream resource server must validate it.
+
+```csharp
+using Auth0.AuthenticationApi;
+using Auth0.AuthenticationApi.Models;
+
+var auth = new AuthenticationApiClient(new Uri("https://YOUR_DOMAIN"));
+
+var response = await auth.GetTokenOnBehalfOfAsync(new OnBehalfOfTokenRequest
+{
+    ClientId = "YOUR_CLIENT_ID",
+    ClientSecret = "YOUR_CLIENT_SECRET",
+    SubjectToken = incomingUserAccessToken,
+    Audience = "https://calendar-api.acme.com",
+    Scope = "calendar:read calendar:write"
+});
+
+string downstreamToken = response.AccessToken;   // short-lived, non-refreshable
+
+// Authorization: use ONLY the current actor.
+string? currentActor = response.GetCurrentActor(); // e.g. "mcp_server_client_id"
+if (currentActor is null)
+{
+    throw new UnauthorizedAccessException("Exchanged token has no actor claim.");
+}
+
+// Audit/logging only - do NOT use nested prior actors for access control.
+Actor? chain = response.GetDelegationChain();
+```
 
 [Go to Top](#)
 
@@ -413,7 +452,7 @@ Console.WriteLine($"Federated Access Token: {tokenResponse.AccessToken}");
 
 The recommended way to initialize the Management API client is using the `ManagementClient` wrapper, which abstracts token management via an `ITokenProvider`.
 
-**Client credentials** (recommended — tokens are acquired and refreshed automatically):
+**Client credentials** (recommended - tokens are acquired and refreshed automatically):
 
 ```csharp
 using Auth0.ManagementApi;
@@ -909,7 +948,7 @@ public async Task UseCustomDomainWithManagementApiClient()
 ```
 
 > **Note:** If you supply your own `HttpClient` alongside `CustomDomain`, the
-> `CustomDomainInterceptor` is **not** injected automatically — you must add it yourself
+> `CustomDomainInterceptor` is **not** injected automatically - you must add it yourself
 > as shown above. Without it the header is still sent, but it will be present on every
 > request rather than only whitelisted ones.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The recommended way to use the Management API is with the `ManagementClient` wra
 
 The `ManagementClient` wrapper abstracts token management through an `ITokenProvider`. Choose the built-in provider that fits your scenario, or implement the interface for full control.
 
-**Client credentials** (recommended for server-to-server — tokens are acquired and refreshed automatically):
+**Client credentials** (recommended for server-to-server - tokens are acquired and refreshed automatically):
 
 ```csharp
 var client = new ManagementClient(new ManagementClientOptions
@@ -54,7 +54,7 @@ var client = new ManagementClient(new ManagementClientOptions
 var users = await client.Users.GetAllAsync();
 ```
 
-> **Note:** The domain is specified twice — once in `ManagementClientOptions` (to build the base API URL `https://{domain}/api/v2`) and once in `ClientCredentialsTokenProvider` (to build the token endpoint URL `https://{domain}/oauth/token`). Both must match your Auth0 tenant domain.
+> **Note:** The domain is specified twice - once in `ManagementClientOptions` (to build the base API URL `https://{domain}/api/v2`) and once in `ClientCredentialsTokenProvider` (to build the token endpoint URL `https://{domain}/oauth/token`). Both must match your Auth0 tenant domain.
 
 > **Already have a token?** Use `ManagementApiClient` directly:
 > ```csharp
@@ -137,6 +137,8 @@ var client = new AuthenticationApiClient(new Uri("https://YOUR_AUTH0_DOMAIN"));
 This library contains [URL Builders](https://auth0.github.io/auth0.net/#using-url-builders) which will assist you with constructing an authentication URL, but does not actually handle the authentication/authorization flow for you. It is suggested that you refer to the [Quickstart tutorials](https://auth0.com/docs/quickstarts) for guidance on how to implement authentication for your specific platform.
 
 **Important note on state validation**: If you choose to use the [AuthorizationUrlBuilder](https://auth0.github.io/auth0.net/api/Auth0.AuthenticationApi.Builders.AuthorizationUrlBuilder.html) to construct the authorization URL and implement a login flow callback yourself, it is important to generate and store a state value (using [WithState](https://auth0.github.io/auth0.net/api/Auth0.AuthenticationApi.Builders.AuthorizationUrlBuilder.html#Auth0_AuthenticationApi_Builders_AuthorizationUrlBuilder_WithState_System_String_)) and validate it in your callback URL before exchanging the authorization code for the tokens.
+
+**On-Behalf-Of Token Exchange (RFC 8693)**: Use `AuthenticationApiClient.GetTokenOnBehalfOfAsync` to exchange an incoming user access token for a short-lived token scoped to a downstream API. See [On-Behalf-Of Token Exchange](Examples.md#8-on-behalf-of-token-exchange-obo).
 
 See [more examples](Examples.md#authentication-api).
 

--- a/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/AuthenticationApiClient.cs
@@ -271,6 +271,44 @@ public class AuthenticationApiClient : IAuthenticationApiClient
     }
 
     /// <inheritdoc/>
+    public async Task<OnBehalfOfTokenResponse> GetTokenOnBehalfOfAsync(OnBehalfOfTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        request.ThrowIfNull();
+
+        if (string.IsNullOrEmpty(request.SubjectToken))
+            throw new ArgumentException(
+                "SubjectToken is required.", nameof(request.SubjectToken));
+
+        if (string.IsNullOrEmpty(request.Audience))
+            throw new ArgumentException(
+                "Audience is required.", nameof(request.Audience));
+
+        var tokenExchangeRequest = new TokenExchangeTokenRequest
+        {
+            SubjectToken = request.SubjectToken,
+            SubjectTokenType = TokenType.AccessToken,
+            Audience = request.Audience,
+            Scope = request.Scope,
+            Organization = request.Organization,
+            ClientId = request.ClientId,
+            ClientSecret = request.ClientSecret,
+            ClientAssertionSecurityKey = request.ClientAssertionSecurityKey,
+            ClientAssertionSecurityKeyAlgorithm = request.ClientAssertionSecurityKeyAlgorithm
+        };
+
+        var response = await GetTokenAsync(tokenExchangeRequest, cancellationToken).ConfigureAwait(false);
+
+        return new OnBehalfOfTokenResponse
+        {
+            AccessToken = response.AccessToken,
+            TokenType = response.TokenType,
+            ExpiresIn = response.ExpiresIn,
+            Scope = response.Scope,
+            IssuedTokenType = response.IssuedTokenType
+        };
+    }
+
+    /// <inheritdoc/>
     public async Task<AccessTokenResponse> GetTokenAsync(FederatedConnectionAccessTokenRequest request, CancellationToken cancellationToken = default)
     {
         request.ThrowIfNull();

--- a/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
+++ b/src/Auth0.AuthenticationApi/IAuthenticationApiClient.cs
@@ -99,6 +99,24 @@ public interface IAuthenticationApiClient : IDisposable
     Task<AccessTokenResponse> GetTokenAsync(TokenExchangeTokenRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Performs an On-Behalf-Of (OBO) token exchange: exchanges an incoming
+    /// user access token for a short-lived, audience-scoped access token that preserves
+    /// user identity and actor attribution. The subject-token type is set to an access
+    /// token internally.
+    /// </summary>
+    /// <param name="request"><see cref="OnBehalfOfTokenRequest"/> containing the subject token, audience, and associated parameters.</param>
+    /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
+    /// <returns><see cref="Task"/> representing the async operation containing an
+    /// <see cref="OnBehalfOfTokenResponse" />. Use
+    /// <see cref="OnBehalfOfTokenResponse.GetCurrentActor"/> for authorization and
+    /// <see cref="OnBehalfOfTokenResponse.GetDelegationChain"/> for audit logging.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="request"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown when <see cref="OnBehalfOfTokenRequest.SubjectToken"/> or <see cref="OnBehalfOfTokenRequest.Audience"/> is missing.</exception>
+    /// <exception cref="Auth0.Core.Exceptions.ApiException">Thrown when the token endpoint returns an unsuccessful response - for example
+    /// <see cref="Auth0.Core.Exceptions.ErrorApiException"/> for an OAuth error, or <see cref="Auth0.Core.Exceptions.RateLimitApiException"/> when rate limited.</exception>
+    Task<OnBehalfOfTokenResponse> GetTokenOnBehalfOfAsync(OnBehalfOfTokenRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Exchanges an Auth0 token for an access token issued by a federated connection
     /// (Token Vault), using the Auth0 federated-connection-access-token grant.
     /// </summary>

--- a/src/Auth0.AuthenticationApi/Models/Actor.cs
+++ b/src/Auth0.AuthenticationApi/Models/Actor.cs
@@ -14,15 +14,26 @@ namespace Auth0.AuthenticationApi.Models;
 public class Actor
 {
     /// <summary>
+    /// Initializes a new <see cref="Actor"/>. Used by the deserializer to populate the
+    /// read-only properties; the type is otherwise only produced by decoding an access token.
+    /// </summary>
+    [JsonConstructor]
+    public Actor(string? subject, Actor? act)
+    {
+        Subject = subject;
+        Act = act;
+    }
+
+    /// <summary>
     /// The <c>sub</c> of this actor. May be <c>null</c> if the decoded <c>act</c> claim did
     /// not contain a <c>sub</c>.
     /// </summary>
     [JsonPropertyName("sub")]
-    public string? Subject { get; set; }
+    public string? Subject { get; }
 
     /// <summary>
     /// The nested prior actor, or <c>null</c> if this is the end of the delegation chain.
     /// </summary>
     [JsonPropertyName("act")]
-    public Actor? Act { get; set; }
+    public Actor? Act { get; }
 }

--- a/src/Auth0.AuthenticationApi/Models/Actor.cs
+++ b/src/Auth0.AuthenticationApi/Models/Actor.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Auth0.AuthenticationApi.Models;
+
+/// <summary>
+/// Represents the <c>act</c> (actor) claim from an exchanged access token.
+/// </summary>
+/// <remarks>
+/// The outermost <see cref="Actor"/> identifies the <b>current actor</b> — the client that
+/// performed the token exchange. Only the current actor may be used for access-control
+/// decisions. Prior actors reachable through <see cref="Act"/> are informational only
+/// (audit/logging).
+/// </remarks>
+public class Actor
+{
+    /// <summary>
+    /// The <c>sub</c> of this actor. May be <c>null</c> if the decoded <c>act</c> claim did
+    /// not contain a <c>sub</c>.
+    /// </summary>
+    [JsonPropertyName("sub")]
+    public string? Subject { get; set; }
+
+    /// <summary>
+    /// The nested prior actor, or <c>null</c> if this is the end of the delegation chain.
+    /// </summary>
+    [JsonPropertyName("act")]
+    public Actor? Act { get; set; }
+}

--- a/src/Auth0.AuthenticationApi/Models/OnBehalfOfTokenRequest.cs
+++ b/src/Auth0.AuthenticationApi/Models/OnBehalfOfTokenRequest.cs
@@ -1,0 +1,54 @@
+using Microsoft.IdentityModel.Tokens;
+
+namespace Auth0.AuthenticationApi.Models;
+
+/// <summary>
+/// Represents an On-Behalf-Of (OBO) token-exchange request.
+/// </summary>
+/// <remarks>
+/// Exchanges an incoming user access token (<see cref="SubjectToken"/>) for a short-lived,
+/// audience-scoped access token that preserves user identity and actor attribution. The
+/// SDK sets the grant type and subject-token type internally.
+/// </remarks>
+public class OnBehalfOfTokenRequest : IClientAuthentication
+{
+    /// <summary>
+    /// The incoming user access token to exchange. Required.
+    /// </summary>
+    public string SubjectToken { get; set; }
+
+    /// <summary>
+    /// The target audience (API identifier) the exchanged token is scoped to. Required.
+    /// </summary>
+    public string Audience { get; set; }
+
+    /// <summary>
+    /// Optional space-delimited scopes for the requested token.
+    /// </summary>
+    public string Scope { get; set; }
+
+    /// <summary>
+    /// Optional organization. Can be an Organization Name or ID.
+    /// </summary>
+    public string Organization { get; set; }
+
+    /// <summary>
+    /// Client ID of the application.
+    /// </summary>
+    public string ClientId { get; set; }
+
+    /// <summary>
+    /// Client Secret of the application.
+    /// </summary>
+    public string ClientSecret { get; set; }
+
+    /// <summary>
+    /// Security Key to use with Client Assertion.
+    /// </summary>
+    public SecurityKey ClientAssertionSecurityKey { get; set; }
+
+    /// <summary>
+    /// Algorithm for the Security Key to use with Client Assertion.
+    /// </summary>
+    public string ClientAssertionSecurityKeyAlgorithm { get; set; }
+}

--- a/src/Auth0.AuthenticationApi/Models/OnBehalfOfTokenResponse.cs
+++ b/src/Auth0.AuthenticationApi/Models/OnBehalfOfTokenResponse.cs
@@ -1,0 +1,115 @@
+using System.Text.Json.Serialization;
+using System.Threading;
+
+using Auth0.AuthenticationApi.Tokens;
+
+namespace Auth0.AuthenticationApi.Models;
+
+/// <summary>
+/// Represents the response of an On-Behalf-Of token exchange.
+/// </summary>
+/// <remarks>
+/// On-Behalf-Of exchange issues an access token only - no refresh or ID token.
+/// </remarks>
+public class OnBehalfOfTokenResponse : TokenBase
+{
+    /// <summary>
+    /// Expiration time in seconds.
+    /// </summary>
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    /// <summary>
+    /// The scopes that were actually granted for this token, which may be narrower than
+    /// the scope that was requested.
+    /// </summary>
+    [JsonPropertyName("scope")]
+    public string Scope { get; set; }
+
+    /// <summary>
+    /// The type of the token issued, as a URN.
+    /// </summary>
+    [JsonPropertyName("issued_token_type")]
+    public string IssuedTokenType { get; set; }
+
+    private ActorCache? actorCache;
+
+    /// <summary>
+    /// Returns the current actor - the outermost <c>act.sub</c>, identifying the client
+    /// that performed the exchange. This is the <b>only</b> value to use for authorization
+    /// decisions. Returns <c>null</c> when the token has no <c>act</c>
+    /// claim or cannot be decoded.
+    /// </summary>
+    /// <remarks>
+    /// The access token is decoded <b>without signature verification</b>. Validate the
+    /// token separately before trusting this value.
+    /// </remarks>
+    public string? GetCurrentActor()
+    {
+        return GetActor()?.Subject;
+    }
+
+    /// <summary>
+    /// Returns the full delegation chain (the current actor plus any nested prior actors).
+    /// <b>For audit/logging only</b> - nested prior actors must not be used for access
+    /// control. Returns <c>null</c> when the token has no <c>act</c> claim
+    /// or cannot be decoded.
+    /// </summary>
+    /// <remarks>
+    /// The access token is decoded <b>without signature verification</b>. Validate the
+    /// token separately before trusting these values.
+    /// </remarks>
+    public Actor? GetDelegationChain()
+    {
+        return GetActor();
+    }
+
+    /// <summary>
+    /// Decodes the <c>act</c> claim from <see cref="TokenBase.AccessToken"/>, caching the
+    /// result so repeated calls to <see cref="GetCurrentActor"/> and
+    /// <see cref="GetDelegationChain"/> do not re-parse the token. The cache is refreshed if
+    /// <see cref="TokenBase.AccessToken"/> is reassigned.
+    /// </summary>
+    /// <remarks>
+    /// The token and its decoded actor are held together in a single immutable
+    /// <see cref="ActorCache"/> that is published with a volatile (release) write and read
+    /// with a volatile (acquire) read. A caller reading concurrently always observes a
+    /// consistent, fully-constructed (token, actor) pair - never a mismatched one - so the
+    /// cache cannot return an actor decoded from a stale token.
+    /// </remarks>
+    private Actor? GetActor()
+    {
+        // Snapshot both the token and the cache once so this method is internally
+        // consistent even if AccessToken is reassigned by another thread while it runs.
+        // Volatile.Read/Write publish the immutable holder with acquire/release semantics so
+        // a concurrent reader that sees the reference also sees its fully-constructed fields
+        // (a plain write gives no such guarantee on weak memory models such as ARM64).
+        var token = AccessToken;
+        var cache = Volatile.Read(ref actorCache);
+
+        if (cache is null || !ReferenceEquals(cache.Token, token))
+        {
+            cache = new ActorCache(token, ActClaimReader.ReadActor(token));
+            Volatile.Write(ref actorCache, cache);
+        }
+
+        return cache.Actor;
+    }
+
+    /// <summary>
+    /// Immutable pairing of an access token with the <see cref="Actor"/> decoded from it,
+    /// so both are published together as a single reference (see <see cref="GetActor"/>).
+    /// </summary>
+    private sealed class ActorCache
+    {
+        public ActorCache(string? token, Actor? actor)
+        {
+            Token = token;
+            Actor = actor;
+        }
+
+        public string? Token { get; }
+
+        public Actor? Actor { get; }
+    }
+}

--- a/src/Auth0.AuthenticationApi/Tokens/ActClaimReader.cs
+++ b/src/Auth0.AuthenticationApi/Tokens/ActClaimReader.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Text.Json;
+
+using Auth0.AuthenticationApi.Models;
+
+namespace Auth0.AuthenticationApi.Tokens;
+
+/// <summary>
+/// Reads the <c>act</c> (actor) claim from a JWT access-token payload
+/// <b>without verifying the token signature</b>. Verifying the token is the responsibility
+/// of the downstream resource server and is out of scope for this client.
+/// </summary>
+internal static class ActClaimReader
+{
+    /// <summary>
+    /// Decodes the payload of <paramref name="accessToken"/> and returns its <c>act</c>
+    /// claim as an <see cref="Actor"/>, or <c>null</c> when the token is not a well-formed
+    /// JWT or has no <c>act</c> claim.
+    /// </summary>
+    public static Actor? ReadActor(string? accessToken)
+    {
+        if (string.IsNullOrEmpty(accessToken))
+            return null;
+
+        var parts = accessToken.Split('.');
+        if (parts.Length != 3)
+            return null;
+
+        try
+        {
+            var payload = Base64UrlDecode(parts[1]);
+            using var document = JsonDocument.Parse(payload);
+            if (!document.RootElement.TryGetProperty("act", out var act))
+                return null;
+
+            return act.Deserialize<Actor>();
+        }
+        catch (FormatException)
+        {
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private static byte[] Base64UrlDecode(string input)
+    {
+        var output = input.Replace('-', '+').Replace('_', '/');
+        switch (output.Length % 4)
+        {
+            case 2: output += "=="; break;
+            case 3: output += "="; break;
+        }
+
+        return Convert.FromBase64String(output);
+    }
+}

--- a/tests/Auth0.AuthenticationApi.IntegrationTests/OnBehalfOfTokenExchangeTests.cs
+++ b/tests/Auth0.AuthenticationApi.IntegrationTests/OnBehalfOfTokenExchangeTests.cs
@@ -1,0 +1,363 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web;
+using Auth0.AuthenticationApi.Models;
+using Auth0.Tests.Shared;
+using FluentAssertions;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Auth0.AuthenticationApi.IntegrationTests;
+
+public class OnBehalfOfTokenExchangeTests
+{
+    private static string Base64UrlEncode(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    // Builds an UNSIGNED JWT-shaped string (header.payload.sig) for decode tests.
+    private static string CreateJwt(string payloadJson)
+    {
+        return $"{Base64UrlEncode("{\"alg\":\"none\"}")}.{Base64UrlEncode(payloadJson)}.sig";
+    }
+
+    [Fact]
+    public void Actor_deserializes_nested_act_structure()
+    {
+        var json = "{\"sub\":\"mcp_server\",\"act\":{\"sub\":\"spa_client\"}}";
+
+        var actor = JsonSerializer.Deserialize<Actor>(json);
+
+        actor.Should().NotBeNull();
+        actor!.Subject.Should().Be("mcp_server");
+        actor.Act.Should().NotBeNull();
+        actor.Act!.Subject.Should().Be("spa_client");
+        actor.Act.Act.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCurrentActor_returns_outermost_act_sub_for_single_exchange()
+    {
+        var token = CreateJwt("{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"mcp_server\"}}");
+        var response = new OnBehalfOfTokenResponse { AccessToken = token };
+
+        response.GetCurrentActor().Should().Be("mcp_server");
+    }
+
+    [Fact]
+    public void GetCurrentActor_returns_outermost_act_sub_for_chained_exchange()
+    {
+        var token = CreateJwt(
+            "{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"mcp_server_2\",\"act\":{\"sub\":\"mcp_server_1\",\"act\":{\"sub\":\"spa_client\"}}}}");
+        var response = new OnBehalfOfTokenResponse { AccessToken = token };
+
+        response.GetCurrentActor().Should().Be("mcp_server_2");
+    }
+
+    [Fact]
+    public void GetDelegationChain_returns_full_nested_chain()
+    {
+        var token = CreateJwt(
+            "{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"mcp_server_2\",\"act\":{\"sub\":\"mcp_server_1\",\"act\":{\"sub\":\"spa_client\"}}}}");
+        var response = new OnBehalfOfTokenResponse { AccessToken = token };
+
+        var chain = response.GetDelegationChain();
+
+        chain.Should().NotBeNull();
+        chain!.Subject.Should().Be("mcp_server_2");
+        chain.Act!.Subject.Should().Be("mcp_server_1");
+        chain.Act.Act!.Subject.Should().Be("spa_client");
+        chain.Act.Act.Act.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCurrentActor_reflects_reassigned_access_token()
+    {
+        var response = new OnBehalfOfTokenResponse
+        {
+            AccessToken = CreateJwt("{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"first\"}}")
+        };
+
+        response.GetCurrentActor().Should().Be("first");
+
+        // Reassigning the token must invalidate the cached actor.
+        response.AccessToken = CreateJwt("{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"second\"}}");
+
+        response.GetCurrentActor().Should().Be("second");
+    }
+
+    [Fact]
+    public void Reassigning_from_act_to_no_act_token_invalidates_cache_to_null()
+    {
+        var response = new OnBehalfOfTokenResponse
+        {
+            AccessToken = CreateJwt("{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"first\"}}")
+        };
+
+        response.GetCurrentActor().Should().Be("first");
+        response.GetDelegationChain().Should().NotBeNull();
+
+        response.AccessToken = CreateJwt("{\"sub\":\"auth0|user123\"}");
+
+        response.GetCurrentActor().Should().BeNull();
+        response.GetDelegationChain().Should().BeNull();
+    }
+
+    [Fact]
+    public void Reassigning_from_no_act_to_act_token_populates_cache()
+    {
+        var response = new OnBehalfOfTokenResponse
+        {
+            AccessToken = CreateJwt("{\"sub\":\"auth0|user123\"}")
+        };
+
+        response.GetCurrentActor().Should().BeNull();
+
+        response.AccessToken = CreateJwt("{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"later\"}}");
+
+        response.GetCurrentActor().Should().Be("later");
+    }
+
+    [Fact]
+    public void Reassigning_to_equal_content_but_different_instance_returns_correct_value()
+    {
+        var payload = "{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"actor\"}}";
+        var response = new OnBehalfOfTokenResponse { AccessToken = CreateJwt(payload) };
+
+        response.GetCurrentActor().Should().Be("actor");
+
+        // A distinct string instance with identical content (a redundant re-parse, but the
+        // result must still be correct — never a mismatched/stale actor).
+        response.AccessToken = CreateJwt(payload);
+
+        response.GetCurrentActor().Should().Be("actor");
+    }
+
+    [Fact]
+    public void GetCurrentActor_and_GetDelegationChain_are_consistent_across_repeated_calls()
+    {
+        var response = new OnBehalfOfTokenResponse
+        {
+            AccessToken = CreateJwt(
+                "{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"outer\",\"act\":{\"sub\":\"inner\"}}}")
+        };
+
+        // Repeated calls (served from the cache after the first parse) stay consistent.
+        for (var i = 0; i < 3; i++)
+        {
+            response.GetCurrentActor().Should().Be("outer");
+            response.GetDelegationChain()!.Subject.Should().Be("outer");
+            response.GetDelegationChain()!.Act!.Subject.Should().Be("inner");
+        }
+    }
+
+    [Fact]
+    public void Concurrent_readers_on_a_stable_token_all_observe_the_correct_actor()
+    {
+        var response = new OnBehalfOfTokenResponse
+        {
+            AccessToken = CreateJwt("{\"sub\":\"auth0|user123\",\"act\":{\"sub\":\"concurrent_actor\"}}")
+        };
+
+        // Exercise the first-parse race: many threads read simultaneously. The atomically
+        // published cache must yield a consistent (token, actor) pair with no exceptions.
+        var results = new System.Collections.Concurrent.ConcurrentBag<string?>();
+
+        Parallel.For(0, 200, _ =>
+        {
+            results.Add(response.GetCurrentActor());
+            response.GetDelegationChain()!.Subject.Should().Be("concurrent_actor");
+        });
+
+        results.Should().HaveCount(200);
+        results.Should().OnlyContain(actor => actor == "concurrent_actor");
+    }
+
+    [Fact]
+    public void GetCurrentActor_and_GetDelegationChain_return_null_when_no_act_claim()
+    {
+        var token = CreateJwt("{\"sub\":\"auth0|user123\",\"aud\":\"https://api.acme.com\"}");
+        var response = new OnBehalfOfTokenResponse { AccessToken = token };
+
+        response.GetCurrentActor().Should().BeNull();
+        response.GetDelegationChain().Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("not-a-jwt")]
+    [InlineData("only.two")]
+    [InlineData("bad!!!.payload!!!.sig")]
+    public void GetCurrentActor_and_GetDelegationChain_return_null_for_malformed_token(string token)
+    {
+        var response = new OnBehalfOfTokenResponse { AccessToken = token };
+
+        response.GetCurrentActor().Should().BeNull();
+        response.GetDelegationChain().Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCurrentActor_and_GetDelegationChain_return_null_when_payload_is_invalid_json()
+    {
+        // Valid base64url payload segment, but the decoded bytes are not valid JSON.
+        var token = $"{Base64UrlEncode("{\"alg\":\"none\"}")}.{Base64UrlEncode("not json at all")}.sig";
+        var response = new OnBehalfOfTokenResponse { AccessToken = token };
+
+        response.GetCurrentActor().Should().BeNull();
+        response.GetDelegationChain().Should().BeNull();
+    }
+
+    [Fact]
+    public void GetCurrentActor_and_GetDelegationChain_return_null_when_act_claim_is_not_an_object()
+    {
+        // act is a string, not a nested actor object -> Deserialize<Actor> throws JsonException.
+        var token = CreateJwt("{\"sub\":\"auth0|user123\",\"act\":\"not-an-object\"}");
+        var response = new OnBehalfOfTokenResponse { AccessToken = token };
+
+        response.GetCurrentActor().Should().BeNull();
+        response.GetDelegationChain().Should().BeNull();
+    }
+
+    [Fact]
+    public void OnBehalfOfTokenRequest_implements_IClientAuthentication()
+    {
+        var request = new OnBehalfOfTokenRequest
+        {
+            SubjectToken = "user-access-token",
+            Audience = "https://calendar-api.acme.com",
+            Scope = "calendar:read",
+            Organization = "org_123",
+            ClientId = "mcp_server_client_id"
+        };
+
+        request.Should().BeAssignableTo<IClientAuthentication>();
+        request.SubjectToken.Should().Be("user-access-token");
+        request.Audience.Should().Be("https://calendar-api.acme.com");
+    }
+
+    private const string Domain = "test-tenant.auth0.com";
+    private const string ClientId = "mcp_server_client_id";
+    private const string ClientSecret = "test-client-secret";
+    private const string SubjectToken = "incoming-user-access-token";
+    private const string Audience = "https://calendar-api.acme.com";
+
+    private static AuthenticationApiClient CreateClient(
+        AccessTokenResponse response,
+        Dictionary<string, string> expectedParams)
+    {
+        var mockHandler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+
+        mockHandler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.Is<HttpRequestMessage>(req =>
+                    req.RequestUri.ToString() == $"https://{Domain}/oauth/token"
+                    && ValidateRequestContent(req, expectedParams)),
+                ItExpr.IsAny<CancellationToken>()
+            )
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.OK,
+                Content = new StringContent(
+                    JsonSerializer.Serialize(response, response.GetType()),
+                    Encoding.UTF8,
+                    "application/json"),
+            });
+
+        var httpClient = new HttpClient(mockHandler.Object);
+        return new TestAuthenticationApiClient(Domain, new TestHttpClientAuthenticationConnection(httpClient));
+    }
+
+    private static bool ValidateRequestContent(HttpRequestMessage content, Dictionary<string, string> contentParams)
+    {
+        string body = content.Content.ReadAsStringAsync().Result;
+        var result = body.Split("&")
+            .ToDictionary(kv => kv.Split("=")[0], kv => HttpUtility.UrlDecode(kv.Split("=")[1]));
+        return contentParams.Aggregate(true, (acc, kv) => acc && result.GetValueOrDefault(kv.Key) == kv.Value);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_sends_obo_exchange_request()
+    {
+        var response = new AccessTokenResponse
+        {
+            AccessToken = "exchanged-access-token",
+            TokenType = "Bearer",
+            ExpiresIn = 3600,
+            Scope = "calendar:read",
+            IssuedTokenType = TokenType.AccessToken
+        };
+        var expectedParams = new Dictionary<string, string>
+        {
+            { "grant_type", "urn:ietf:params:oauth:grant-type:token-exchange" },
+            { "subject_token", SubjectToken },
+            { "subject_token_type", TokenType.AccessToken },
+            { "audience", Audience },
+            { "scope", "calendar:read" },
+            { "organization", "org_123" }
+        };
+
+        var client = CreateClient(response, expectedParams);
+
+        var result = await client.GetTokenOnBehalfOfAsync(new OnBehalfOfTokenRequest
+        {
+            ClientId = ClientId,
+            ClientSecret = ClientSecret,
+            SubjectToken = SubjectToken,
+            Audience = Audience,
+            Scope = "calendar:read",
+            Organization = "org_123"
+        });
+
+        result.Should().NotBeNull();
+        result.Should().BeOfType<OnBehalfOfTokenResponse>();
+        result.AccessToken.Should().Be("exchanged-access-token");
+        result.TokenType.Should().Be("Bearer");
+        result.ExpiresIn.Should().Be(3600);
+        result.Scope.Should().Be("calendar:read");
+        result.IssuedTokenType.Should().Be(TokenType.AccessToken);
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_throws_when_subject_token_missing()
+    {
+        var client = new TestAuthenticationApiClient(
+            Domain, new TestHttpClientAuthenticationConnection(new HttpClient()));
+
+        Func<Task> act = () => client.GetTokenOnBehalfOfAsync(new OnBehalfOfTokenRequest
+        {
+            ClientId = ClientId,
+            Audience = Audience
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*SubjectToken*");
+    }
+
+    [Fact]
+    public async Task GetTokenOnBehalfOfAsync_throws_when_audience_missing()
+    {
+        var client = new TestAuthenticationApiClient(
+            Domain, new TestHttpClientAuthenticationConnection(new HttpClient()));
+
+        Func<Task> act = () => client.GetTokenOnBehalfOfAsync(new OnBehalfOfTokenRequest
+        {
+            ClientId = ClientId,
+            SubjectToken = SubjectToken
+        });
+
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Audience*");
+    }
+}


### PR DESCRIPTION
### Changes

This PR adds **On-Behalf-Of (OBO) Token Exchange** support to the Authentication API client, letting a service (for example, an MCP server) exchange an incoming user access token for a short-lived, audience-scoped access token that preserves the user's identity and actor attribution.

- Adds a new `GetTokenOnBehalfOfAsync` method to the Authentication API client that performs the exchange. The caller supplies the incoming user token, the target audience, and optional scope/organization; the grant type and subject-token type are set internally.
- The response exposes helpers to read the actor information from the exchanged token: one for the **current actor** (the value to use for authorization decisions) and one for the **full delegation chain** (for audit/logging only).
- Token validation is out of scope 
- Documentation and a usage example have been added to `README.md` and `Examples.md`.

### References

### Testing
- Unit tests cover the exchange request (correct parameters sent), input validation, response mapping, and the actor helpers. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors