### PR TITLE
mgmt: SDK generation after upgrading Fern C# version

### DIFF
--- a/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
+++ b/src/Auth0.ManagementApi/Auth0.ManagementApi.csproj
@@ -8,7 +8,7 @@
     <Version>7.48.0</Version>
     <AssemblyVersion>$(Version)</AssemblyVersion>
     <FileVersion>$(Version)</FileVersion>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageReadmeFile Condition="Exists('..\..\README.md')">README.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/auth0/auth0.net</PackageProjectUrl>
     <PolySharpIncludeRuntimeSupportedAttributes>true</PolySharpIncludeRuntimeSupportedAttributes>
   </PropertyGroup>
@@ -46,7 +46,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="" />
+    <None
+      Include="..\..\README.md"
+      Pack="true"
+      PackagePath=""
+      Condition="Exists('..\..\README.md')"
+    />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Auth0.ManagementApi/Core/QueryStringBuilder.cs
+++ b/src/Auth0.ManagementApi/Core/QueryStringBuilder.cs
@@ -18,26 +18,30 @@ namespace Auth0.ManagementApi.Core;
 ///
 /// Three encoding contexts are distinguished:
 ///   Path segment (pchar): unreserved + sub-delims + ":" + "@"
-///   Query key:   query chars minus "&amp;", "=", "+", "#"
-///   Query value: query chars minus "&amp;", "+", "#"
+///   Query key:   query chars minus "&amp;", "=", "+", ";", "#"
+///   Query value: query chars minus "&amp;", "+", ";", "#"
+///
+/// ";" is percent-encoded in queries even though RFC 3986 permits it: it is a
+/// legacy parameter separator that many servers and frameworks still split on,
+/// so leaving it raw truncates the value.
 /// </summary>
 internal static class QueryStringBuilder
 {
     // ──────────────────────────────────────────────────────────────────────
     // RFC 3986 character sets
     //
-    // Query key safe:    unreserved + (sub-delims \ {& = +}) + : @ / ?
-    // Query value safe:  unreserved + (sub-delims \ {& +})   + : @ / ?
+    // Query key safe:    unreserved + (sub-delims \ {& = + ;}) + : @ / ?
+    // Query value safe:  unreserved + (sub-delims \ {& + ;})   + : @ / ?
     // Path segment safe: unreserved + sub-delims + : @
     // ──────────────────────────────────────────────────────────────────────
 
 #if NET8_0_OR_GREATER
     private static readonly SearchValues<char> SafeQueryKeyChars = SearchValues.Create(
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,;:@/?"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,:@/?"
     );
 
     private static readonly SearchValues<char> SafeQueryValueChars = SearchValues.Create(
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,;=:@/?"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,=:@/?"
     );
 
     private static readonly SearchValues<char> SafePathChars = SearchValues.Create(
@@ -45,10 +49,10 @@ internal static class QueryStringBuilder
     );
 #else
     private const string SafeQueryKeyChars =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,;:@/?";
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,:@/?";
 
     private const string SafeQueryValueChars =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,;=:@/?";
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$'()*,=:@/?";
 
     private const string SafePathChars =
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.~!$&'()*+,;=:@";
@@ -415,7 +419,7 @@ internal static class QueryStringBuilder
 #if NET8_0_OR_GREATER
         return SafeQueryKeyChars.Contains(c);
 #else
-        // query = *( pchar / "/" / "?" )  minus "&", "=", "+", "#"
+        // query = *( pchar / "/" / "?" )  minus "&", "=", "+", ";", "#"
         return (c >= 'A' && c <= 'Z')
             || (c >= 'a' && c <= 'z')
             || (c >= '0' && c <= '9')
@@ -430,7 +434,6 @@ internal static class QueryStringBuilder
             || c == ')'
             || c == '*'
             || c == ','
-            || c == ';'
             || c == ':'
             || c == '@'
             || c == '/'
@@ -444,7 +447,7 @@ internal static class QueryStringBuilder
 #if NET8_0_OR_GREATER
         return SafeQueryValueChars.Contains(c);
 #else
-        // query = *( pchar / "/" / "?" )  minus "&", "+", "#"
+        // query = *( pchar / "/" / "?" )  minus "&", "+", ";", "#"
         return (c >= 'A' && c <= 'Z')
             || (c >= 'a' && c <= 'z')
             || (c >= '0' && c <= '9')
@@ -459,7 +462,6 @@ internal static class QueryStringBuilder
             || c == ')'
             || c == '*'
             || c == ','
-            || c == ';'
             || c == '='
             || c == ':'
             || c == '@'

--- a/src/Auth0.ManagementApi/ManagementApiClient.cs
+++ b/src/Auth0.ManagementApi/ManagementApiClient.cs
@@ -15,10 +15,17 @@ public partial class ManagementApiClient : IManagementApiClient
     public ManagementApiClient(string? token = null, ClientOptions? clientOptions = null)
     {
         clientOptions ??= new ClientOptions();
-        if ((clientOptions.TenantDomain != null) && !clientOptions.IsBaseUrlExplicitlySet)
+        if (clientOptions.TenantDomain != null)
         {
             var _tenantDomain = clientOptions.TenantDomain ?? "{TENANT}.auth0.com";
-            clientOptions.BaseUrl = $"https://{_tenantDomain}/api/v2";
+            if (!clientOptions.IsBaseUrlExplicitlySet)
+            {
+                clientOptions.BaseUrl = $"https://{_tenantDomain}/api/v2";
+            }
+            else if (clientOptions.BaseUrl == ManagementApiClientEnvironment.Default)
+            {
+                clientOptions.BaseUrl = $"https://{_tenantDomain}/api/v2";
+            }
         }
         var platformHeaders = new Headers(new Dictionary<string, string>() { });
         foreach (var header in platformHeaders)

--- a/tests/Auth0.ManagementApi.Test/Core/QueryStringBuilderTests.cs
+++ b/tests/Auth0.ManagementApi.Test/Core/QueryStringBuilderTests.cs
@@ -641,6 +641,20 @@ public class QueryStringBuilderTests
     }
 
     [Test]
+    public void Build_Semicolon_Encoded()
+    {
+        // ";" is a legacy parameter separator, so it must be encoded in keys and values
+        var parameters = new List<KeyValuePair<string, string>>
+        {
+            new("a;b", "jo@example.com; ceo@example.com"),
+        };
+
+        var result = QueryStringBuilder.Build(parameters);
+
+        Assert.That(result, Is.EqualTo("?a%3Bb=jo@example.com%3B%20ceo@example.com"));
+    }
+
+    [Test]
     public void Build_ODataFilter_DollarPreserved()
     {
         // "$" is safe in query keys (sub-delimiter), verifies OData-style parameters work


### PR DESCRIPTION
### Changes

This PR upgrades the underlying Fern C# generator version and regenerates the Management API SDK. Alongside the regeneration, it includes a few behavioral and packaging fixes:

- **Query string encoding** — Semicolons are now percent-encoded in both query keys and values. Although semicolons are technically permitted in query strings, many servers and frameworks still treat them as a legacy parameter separator, which could silently truncate a value (for example, when passing a comma/semicolon-delimited list of email addresses). Encoding them ensures the full value reaches the API intact.
- **Tenant domain resolution** — When a tenant domain is provided, the base URL is now correctly derived from it even if the base URL was left at its default value. Previously, the default could take precedence and requests would not be routed to the intended tenant.
- **Package README packaging** — README inclusion during packaging is now conditional on the file being present, making the build more robust when the README is not available.

No public API surface changes; these are internal behavior and build corrections.

### References


### Testing

Existing unit and mock tests continue to pass without errors. A new unit test was added to verify that semicolons are correctly encoded in query keys and values.

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
