### PR TITLE
chore: Remove fern-replay files from .fernignore

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -24,7 +24,6 @@ V9_MIGRATION_GUIDE.md
 V10_MIGRATION_GUIDE.md
 CLAUDE.md
 AGENTS.md
-.fern/
 
 Auth0.ManagementApi.slnx
 Auth0.Net.slnx
@@ -69,6 +68,3 @@ src/Auth0.ManagementApi/Core/Public/RateLimit.cs
 src/Auth0.ManagementApi/Core/Public/QuotaLimit.cs
 src/Auth0.ManagementApi/Exceptions/TooManyRequestsError.cs
 tests/Auth0.ManagementApi.Test/Unit/ExceptionEnrichmentTest.cs
-
-.fern/replay.lock
-.fern/replay.yml


### PR DESCRIPTION
### Changes

- Removes fern replay related files from `.fernignore`

### References


### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors